### PR TITLE
feat: Api-Management OAuth 로그인/회원가입 엔드포인트 구현

### DIFF
--- a/SClass-Api-Management/build.gradle.kts
+++ b/SClass-Api-Management/build.gradle.kts
@@ -4,4 +4,5 @@ dependencies {
     implementation(project(":SClass-Infrastructure"))
 
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 }

--- a/SClass-Api-Management/src/main/kotlin/com/sclass/management/auth/controller/OAuthController.kt
+++ b/SClass-Api-Management/src/main/kotlin/com/sclass/management/auth/controller/OAuthController.kt
@@ -1,0 +1,29 @@
+package com.sclass.management.auth.controller
+
+import com.sclass.common.dto.ApiResponse
+import com.sclass.management.auth.dto.OAuthCompleteSignupRequest
+import com.sclass.management.auth.dto.OAuthLoginRequest
+import com.sclass.management.auth.dto.OAuthLoginResponse
+import com.sclass.management.auth.dto.TokenResponse
+import com.sclass.management.auth.usecase.OAuthLoginUseCase
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth/oauth")
+class OAuthController(
+    private val oAuthLoginUseCase: OAuthLoginUseCase,
+) {
+    @PostMapping("/login")
+    fun oauthLogin(
+        @Valid @RequestBody request: OAuthLoginRequest,
+    ): ApiResponse<OAuthLoginResponse> = ApiResponse.success(oAuthLoginUseCase.login(request))
+
+    @PostMapping("/complete-signup")
+    fun completeSignup(
+        @Valid @RequestBody request: OAuthCompleteSignupRequest,
+    ): ApiResponse<TokenResponse> = ApiResponse.success(oAuthLoginUseCase.completeSignup(request))
+}

--- a/SClass-Api-Management/src/main/kotlin/com/sclass/management/auth/dto/OAuthCompleteSignupRequest.kt
+++ b/SClass-Api-Management/src/main/kotlin/com/sclass/management/auth/dto/OAuthCompleteSignupRequest.kt
@@ -1,0 +1,11 @@
+package com.sclass.management.auth.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class OAuthCompleteSignupRequest(
+    @field:NotBlank
+    val signupToken: String,
+
+    @field:NotBlank
+    val phoneNumber: String,
+)

--- a/SClass-Api-Management/src/main/kotlin/com/sclass/management/auth/dto/OAuthLoginRequest.kt
+++ b/SClass-Api-Management/src/main/kotlin/com/sclass/management/auth/dto/OAuthLoginRequest.kt
@@ -1,0 +1,20 @@
+package com.sclass.management.auth.dto
+
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.Role
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+data class OAuthLoginRequest(
+    @field:NotBlank
+    val provider: String,
+
+    @field:NotBlank
+    val accessToken: String,
+
+    @field:NotNull
+    val role: Role,
+
+    @field:NotNull
+    val platform: Platform,
+)

--- a/SClass-Api-Management/src/main/kotlin/com/sclass/management/auth/dto/OAuthLoginResponse.kt
+++ b/SClass-Api-Management/src/main/kotlin/com/sclass/management/auth/dto/OAuthLoginResponse.kt
@@ -1,0 +1,8 @@
+package com.sclass.management.auth.dto
+
+data class OAuthLoginResponse(
+    val isNewUser: Boolean,
+    val accessToken: String? = null,
+    val refreshToken: String? = null,
+    val signupToken: String? = null,
+)

--- a/SClass-Api-Management/src/main/kotlin/com/sclass/management/auth/dto/TokenResponse.kt
+++ b/SClass-Api-Management/src/main/kotlin/com/sclass/management/auth/dto/TokenResponse.kt
@@ -1,0 +1,6 @@
+package com.sclass.management.auth.dto
+
+data class TokenResponse(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/SClass-Api-Management/src/main/kotlin/com/sclass/management/auth/usecase/OAuthLoginUseCase.kt
+++ b/SClass-Api-Management/src/main/kotlin/com/sclass/management/auth/usecase/OAuthLoginUseCase.kt
@@ -1,0 +1,88 @@
+package com.sclass.management.auth.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.token.service.TokenDomainService
+import com.sclass.domain.domains.user.domain.AuthProvider
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.domain.domains.user.service.UserDomainService
+import com.sclass.infrastructure.oauth.OAuthClientFactory
+import com.sclass.management.auth.dto.OAuthCompleteSignupRequest
+import com.sclass.management.auth.dto.OAuthLoginRequest
+import com.sclass.management.auth.dto.OAuthLoginResponse
+import com.sclass.management.auth.dto.TokenResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class OAuthLoginUseCase(
+    private val oAuthClientFactory: OAuthClientFactory,
+    private val userService: UserDomainService,
+    private val tokenService: TokenDomainService,
+) {
+    @Transactional
+    fun login(request: OAuthLoginRequest): OAuthLoginResponse {
+        val client = oAuthClientFactory.getClient(request.provider)
+        val userInfo = client.fetchUserInfo(request.accessToken)
+
+        val authProvider = AuthProvider.valueOf(request.provider.uppercase())
+
+        val user =
+            userService.findByOAuthOrNull(userInfo.id, authProvider)?.also {
+                userService.ensureUserRole(it.id, request.platform, request.role)
+            } ?: userService.linkOAuthAndEnsureRole(
+                email = userInfo.email,
+                oauthId = userInfo.id,
+                platform = request.platform,
+                role = request.role,
+            )
+
+        if (user != null) {
+            val tokens = tokenService.issueTokens(user.id, request.role)
+            return OAuthLoginResponse(
+                isNewUser = false,
+                accessToken = tokens.accessToken,
+                refreshToken = tokens.refreshToken,
+            )
+        }
+
+        val signupToken =
+            tokenService.issueSignupToken(
+                oauthId = userInfo.id,
+                provider = request.provider.uppercase(),
+                email = userInfo.email,
+                name = userInfo.name,
+                role = request.role,
+                platform = request.platform,
+            )
+        return OAuthLoginResponse(
+            isNewUser = true,
+            signupToken = signupToken,
+        )
+    }
+
+    @Transactional
+    fun completeSignup(request: OAuthCompleteSignupRequest): TokenResponse {
+        val signupInfo = tokenService.resolveSignupToken(request.signupToken)
+        val authProvider = AuthProvider.valueOf(signupInfo.provider)
+        val platform = Platform.valueOf(signupInfo.platform)
+        val role = Role.valueOf(signupInfo.role)
+
+        val user =
+            userService.registerWithOAuth(
+                oauthId = signupInfo.oauthId,
+                authProvider = authProvider,
+                email = signupInfo.email,
+                name = signupInfo.name,
+                phoneNumber = request.phoneNumber,
+                profileImageUrl = null,
+                platform = platform,
+                role = role,
+            )
+
+        val tokens = tokenService.issueTokens(user.id, role)
+        return TokenResponse(
+            accessToken = tokens.accessToken,
+            refreshToken = tokens.refreshToken,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Management 모듈에 OAuth 로그인/회원가입 API 엔드포인트 추가
- Supporters와 동일한 플로우 (platform을 프론트에서 전달)

## Changes
- `OAuthController`: `POST /api/v1/auth/oauth/login`, `POST /api/v1/auth/oauth/complete-signup`
- `OAuthLoginUseCase`: oauthId 조회 → 이메일 연결 → signupToken 발급
- OAuth 관련 DTO 4개 (`OAuthLoginRequest`, `OAuthLoginResponse`, `OAuthCompleteSignupRequest`, `TokenResponse`)
- `build.gradle.kts`: `spring-boot-starter-validation` 의존성 추가

## Affected Modules
- [x] SClass-Api-Management

## Test Plan
- [x] 빌드 성공 확인
- [x] ktlint 통과

## Checklist
- [x] 컨벤션 준수
- [x] 불필요한 파일 미포함

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)