### PR TITLE
feat: Teacher-User @ManyToOne 관계 설정

### DIFF
--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/domain/Teacher.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/domain/Teacher.kt
@@ -2,25 +2,30 @@ package com.sclass.domain.domains.teacher.domain
 
 import com.sclass.domain.common.model.BaseTimeEntity
 import com.sclass.domain.common.vo.Ulid
+import com.sclass.domain.domains.user.domain.User
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 
 @Entity
 @Table(
     name = "teachers",
-    uniqueConstraints = [UniqueConstraint(columnNames = ["userId", "organizationId"])],
+    uniqueConstraints = [UniqueConstraint(columnNames = ["user_id", "organizationId"])],
 )
 class Teacher(
     @Id
     @Column(length = 26)
     val id: String = Ulid.generate(),
 
-    @Column(nullable = false, length = 26)
-    val userId: String,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
 
     @Column(nullable = true)
     val organizationId: Long? = null,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/service/TeacherDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/service/TeacherDomainService.kt
@@ -4,6 +4,7 @@ import com.sclass.common.annotation.DomainService
 import com.sclass.domain.domains.teacher.adaptor.TeacherAdaptor
 import com.sclass.domain.domains.teacher.domain.Teacher
 import com.sclass.domain.domains.teacher.exception.TeacherAlreadyExistsException
+import com.sclass.domain.domains.user.domain.User
 import org.springframework.transaction.annotation.Transactional
 
 @DomainService
@@ -12,21 +13,21 @@ class TeacherDomainService(
 ) {
     @Transactional
     fun register(
-        userId: String,
+        user: User,
         organizationId: Long?,
     ): Teacher {
         val alreadyExists =
             if (organizationId != null) {
-                teacherAdaptor.existsByUserIdAndOrganizationId(userId, organizationId)
+                teacherAdaptor.existsByUserIdAndOrganizationId(user.id, organizationId)
             } else {
-                teacherAdaptor.existsByUserIdAndOrganizationIdIsNull(userId)
+                teacherAdaptor.existsByUserIdAndOrganizationIdIsNull(user.id)
             }
         if (alreadyExists) {
             throw TeacherAlreadyExistsException()
         }
         return teacherAdaptor.save(
             Teacher(
-                userId = userId,
+                user = user,
                 organizationId = organizationId,
             ),
         )

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/teacher/service/TeacherDomainServiceTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/teacher/service/TeacherDomainServiceTest.kt
@@ -3,6 +3,7 @@ package com.sclass.domain.domains.teacher.service
 import com.sclass.domain.domains.teacher.adaptor.TeacherAdaptor
 import com.sclass.domain.domains.teacher.domain.Teacher
 import com.sclass.domain.domains.teacher.exception.TeacherAlreadyExistsException
+import com.sclass.domain.domains.user.domain.User
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -17,10 +18,14 @@ class TeacherDomainServiceTest {
     private lateinit var teacherAdaptor: TeacherAdaptor
     private lateinit var teacherDomainService: TeacherDomainService
 
+    private lateinit var user: User
+
     @BeforeEach
     fun setUp() {
         teacherAdaptor = mockk()
         teacherDomainService = TeacherDomainService(teacherAdaptor)
+        user = mockk<User>()
+        every { user.id } returns "user-id"
     }
 
     @Nested
@@ -31,9 +36,9 @@ class TeacherDomainServiceTest {
             every { teacherAdaptor.existsByUserIdAndOrganizationId("user-id", 1L) } returns false
             every { teacherAdaptor.save(capture(slot)) } answers { slot.captured }
 
-            val result = teacherDomainService.register(userId = "user-id", organizationId = 1L)
+            val result = teacherDomainService.register(user = user, organizationId = 1L)
 
-            assertEquals("user-id", result.userId)
+            assertEquals(user, result.user)
             assertEquals(1L, result.organizationId)
         }
 
@@ -43,9 +48,9 @@ class TeacherDomainServiceTest {
             every { teacherAdaptor.existsByUserIdAndOrganizationIdIsNull("user-id") } returns false
             every { teacherAdaptor.save(capture(slot)) } answers { slot.captured }
 
-            val result = teacherDomainService.register(userId = "user-id", organizationId = null)
+            val result = teacherDomainService.register(user = user, organizationId = null)
 
-            assertEquals("user-id", result.userId)
+            assertEquals(user, result.user)
             assertNull(result.organizationId)
         }
 
@@ -54,7 +59,7 @@ class TeacherDomainServiceTest {
             every { teacherAdaptor.existsByUserIdAndOrganizationId("user-id", 1L) } returns true
 
             assertThrows<TeacherAlreadyExistsException> {
-                teacherDomainService.register(userId = "user-id", organizationId = 1L)
+                teacherDomainService.register(user = user, organizationId = 1L)
             }
         }
 
@@ -63,7 +68,7 @@ class TeacherDomainServiceTest {
             every { teacherAdaptor.existsByUserIdAndOrganizationIdIsNull("user-id") } returns true
 
             assertThrows<TeacherAlreadyExistsException> {
-                teacherDomainService.register(userId = "user-id", organizationId = null)
+                teacherDomainService.register(user = user, organizationId = null)
             }
         }
     }


### PR DESCRIPTION
Closes #37

## Summary
- `Teacher.userId(String)` → `Teacher.user(User)` `@ManyToOne(fetch = LAZY)` + `@JoinColumn` 변경
- `TeacherDomainService.register()`가 `userId: String` 대신 `User` 객체를 받도록 수정
- 테스트 업데이트

## Test plan
- [x] `TeacherDomainServiceTest` 전체 통과
- [x] `TeacherAdaptorTest` 전체 통과
- [x] `./gradlew clean build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)