### PR TITLE
refactor: CORS 설정을 Common 모듈로 이동

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/config/WebConfig.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/config/WebConfig.kt
@@ -4,10 +4,8 @@ import com.sclass.common.jwt.CurrentUserIdArgumentResolver
 import com.sclass.common.jwt.JwtAuthInterceptor
 import com.sclass.common.jwt.PlatformAuthInterceptor
 import com.sclass.domain.domains.user.domain.Platform
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
-import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
@@ -15,22 +13,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 class WebConfig(
     private val jwtAuthInterceptor: JwtAuthInterceptor,
     private val currentUserIdArgumentResolver: CurrentUserIdArgumentResolver,
-    @param:Value("\${cors.allow.origins}") private val allowedOrigins: String,
 ) : WebMvcConfigurer {
-    override fun addCorsMappings(registry: CorsRegistry) {
-        registry
-            .addMapping("/**")
-            .allowedOrigins(
-                *allowedOrigins
-                    .split(",")
-                    .map(String::trim)
-                    .filter(String::isNotEmpty)
-                    .toTypedArray(),
-            ).allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-            .allowedHeaders("*")
-            .allowCredentials(true)
-    }
-
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry
             .addInterceptor(jwtAuthInterceptor)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/config/CorsConfig.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/config/CorsConfig.kt
@@ -1,0 +1,27 @@
+package com.sclass.common.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class CorsConfig(
+    @param:Value("\${cors.allow.origins:}") private val allowedOrigins: String,
+) : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        val origins =
+            allowedOrigins
+                .split(",")
+                .map(String::trim)
+                .filter(String::isNotEmpty)
+        if (origins.isEmpty()) return
+
+        registry
+            .addMapping("/**")
+            .allowedOrigins(*origins.toTypedArray())
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+    }
+}


### PR DESCRIPTION
## Summary
- `CorsConfig`를 Common 모듈에 생성하여 모든 API 모듈에서 공유
- Backoffice WebConfig에서 CORS 관련 코드 제거
- `cors.allow.origins` 미설정 시 CORS 등록 건너뜀 (기본값 빈 문자열)

## Test plan
- [ ] 빌드 및 전체 테스트 통과 확인
- [ ] `cors.allow.origins` 설정된 모듈에서 CORS 정상 동작 확인
- [ ] `cors.allow.origins` 미설정 모듈에서 에러 없이 기동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)