### PR TITLE
feat: 회원가입 시 휴대전화 인증 기능 구현 (알림톡)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,6 @@ build
 
 # Application config (contains secrets)
 **/src/main/resources/application.yml
+**/src/main/resources/application.yaml
 **/src/main/resources/application-*.yml
+**/src/main/resources/application-*.yaml

--- a/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/controller/PhoneVerificationController.kt
+++ b/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/controller/PhoneVerificationController.kt
@@ -1,0 +1,29 @@
+package com.sclass.lms.auth.controller
+
+import com.sclass.common.dto.ApiResponse
+import com.sclass.lms.auth.dto.SendPhoneCodeRequest
+import com.sclass.lms.auth.dto.SendPhoneCodeResponse
+import com.sclass.lms.auth.dto.VerifyPhoneCodeRequest
+import com.sclass.lms.auth.dto.VerifyPhoneCodeResponse
+import com.sclass.lms.auth.usecase.PhoneVerificationUseCase
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth/phone")
+class PhoneVerificationController(
+    private val phoneVerificationUseCase: PhoneVerificationUseCase,
+) {
+    @PostMapping("/send-code")
+    fun sendCode(
+        @Valid @RequestBody request: SendPhoneCodeRequest,
+    ): ApiResponse<SendPhoneCodeResponse> = ApiResponse.success(phoneVerificationUseCase.sendCode(request))
+
+    @PostMapping("/verify-code")
+    fun verifyCode(
+        @Valid @RequestBody request: VerifyPhoneCodeRequest,
+    ): ApiResponse<VerifyPhoneCodeResponse> = ApiResponse.success(phoneVerificationUseCase.verifyCode(request))
+}

--- a/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/dto/OAuthCompleteSignupRequest.kt
+++ b/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/dto/OAuthCompleteSignupRequest.kt
@@ -8,7 +8,7 @@ data class OAuthCompleteSignupRequest(
     val signupToken: String,
 
     @field:NotBlank
-    val phoneNumber: String,
+    val phoneVerificationToken: String,
 
     @field:Nullable
     val profileImageUrl: String? = null,

--- a/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/dto/SendPhoneCodeRequest.kt
+++ b/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/dto/SendPhoneCodeRequest.kt
@@ -1,0 +1,8 @@
+package com.sclass.lms.auth.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class SendPhoneCodeRequest(
+    @field:NotBlank
+    val phoneNumber: String,
+)

--- a/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/dto/SendPhoneCodeResponse.kt
+++ b/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/dto/SendPhoneCodeResponse.kt
@@ -1,0 +1,5 @@
+package com.sclass.lms.auth.dto
+
+data class SendPhoneCodeResponse(
+    val expiresInSeconds: Long = 300,
+)

--- a/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/dto/VerifyPhoneCodeRequest.kt
+++ b/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/dto/VerifyPhoneCodeRequest.kt
@@ -1,0 +1,13 @@
+package com.sclass.lms.auth.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class VerifyPhoneCodeRequest(
+    @field:NotBlank
+    val phoneNumber: String,
+
+    @field:NotBlank
+    @field:Size(min = 6, max = 6)
+    val code: String,
+)

--- a/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/dto/VerifyPhoneCodeResponse.kt
+++ b/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/dto/VerifyPhoneCodeResponse.kt
@@ -1,0 +1,5 @@
+package com.sclass.lms.auth.dto
+
+data class VerifyPhoneCodeResponse(
+    val phoneVerificationToken: String,
+)

--- a/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/usecase/OAuthLoginUseCase.kt
+++ b/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/usecase/OAuthLoginUseCase.kt
@@ -65,13 +65,15 @@ class OAuthLoginUseCase(
         val platform = Platform.valueOf(signupInfo.platform)
         val role = Role.valueOf(signupInfo.role)
 
+        val phoneInfo = tokenService.resolveVerificationToken(request.phoneVerificationToken)
+
         val user =
             userService.registerWithOAuth(
                 oauthId = signupInfo.oauthId,
                 authProvider = authProvider,
                 email = signupInfo.email,
                 name = signupInfo.name,
-                phoneNumber = request.phoneNumber,
+                phoneNumber = phoneInfo.target,
                 profileImageUrl = request.profileImageUrl,
                 platform = platform,
                 role = role,

--- a/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/usecase/PhoneVerificationUseCase.kt
+++ b/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/usecase/PhoneVerificationUseCase.kt
@@ -1,0 +1,49 @@
+package com.sclass.lms.auth.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.token.service.TokenDomainService
+import com.sclass.domain.domains.user.domain.User
+import com.sclass.domain.domains.verification.domain.VerificationChannel
+import com.sclass.domain.domains.verification.service.VerificationDomainService
+import com.sclass.infrastructure.message.MessageSender
+import com.sclass.lms.auth.dto.SendPhoneCodeRequest
+import com.sclass.lms.auth.dto.SendPhoneCodeResponse
+import com.sclass.lms.auth.dto.VerifyPhoneCodeRequest
+import com.sclass.lms.auth.dto.VerifyPhoneCodeResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class PhoneVerificationUseCase(
+    private val verificationService: VerificationDomainService,
+    private val tokenService: TokenDomainService,
+    private val messageSender: MessageSender,
+    sender: MessageSender,
+) {
+    @Transactional
+    fun sendCode(request: SendPhoneCodeRequest): SendPhoneCodeResponse {
+        val phoneNumber = User.formatPhoneNumber(request.phoneNumber)
+        val verification =
+            verificationService.createVerification(
+                channel = VerificationChannel.PHONE,
+                target = phoneNumber,
+            )
+        messageSender.sendVerificationCode(phoneNumber, verification.code)
+        return SendPhoneCodeResponse()
+    }
+
+    @Transactional
+    fun verifyCode(request: VerifyPhoneCodeRequest): VerifyPhoneCodeResponse {
+        val phoneNumber = User.formatPhoneNumber(request.phoneNumber)
+        verificationService.verifyCode(
+            channel = VerificationChannel.PHONE,
+            target = phoneNumber,
+            code = request.code,
+        )
+        val token =
+            tokenService.issueVerificationToken(
+                channel = VerificationChannel.PHONE,
+                target = phoneNumber,
+            )
+        return VerifyPhoneCodeResponse(phoneVerificationToken = token)
+    }
+}

--- a/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/config/WebConfig.kt
+++ b/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/config/WebConfig.kt
@@ -1,0 +1,31 @@
+package com.sclass.lms.config
+
+import com.sclass.common.jwt.CurrentUserIdArgumentResolver
+import com.sclass.common.jwt.JwtAuthInterceptor
+import com.sclass.common.jwt.PlatformAuthInterceptor
+import com.sclass.domain.domains.user.domain.Platform
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig(
+    private val jwtAuthInterceptor: JwtAuthInterceptor,
+    private val currentUserIdArgumentResolver: CurrentUserIdArgumentResolver,
+) : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry
+            .addInterceptor(jwtAuthInterceptor)
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/api/v1/auth/**", "/api/v1/auth/phone/**")
+        registry
+            .addInterceptor(PlatformAuthInterceptor(Platform.LMS.name))
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/api/v1/auth/**", "/api/v1/auth/phone/**")
+    }
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(currentUserIdArgumentResolver)
+    }
+}

--- a/SClass-Api-Lms/src/test/kotlin/com/sclass/lms/auth/controller/OAuthControllerIntegrationTest.kt
+++ b/SClass-Api-Lms/src/test/kotlin/com/sclass/lms/auth/controller/OAuthControllerIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.sclass.domain.domains.user.domain.AuthProvider
 import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.domain.domains.user.service.UserDomainService
+import com.sclass.domain.domains.verification.domain.VerificationChannel
 import com.sclass.infrastructure.oauth.OAuthClientFactory
 import com.sclass.infrastructure.oauth.client.OAuthClient
 import com.sclass.infrastructure.oauth.dto.OAuthUserInfo
@@ -117,10 +118,16 @@ class OAuthControllerIntegrationTest {
                 platform = Platform.LMS,
             )
 
+        val phoneVerificationToken =
+            tokenDomainService.issueVerificationToken(
+                channel = VerificationChannel.PHONE,
+                target = "010-9999-8888",
+            )
+
         val request =
             OAuthCompleteSignupRequest(
                 signupToken = signupToken,
-                phoneNumber = "01099998888",
+                phoneVerificationToken = phoneVerificationToken,
                 profileImageUrl = "https://example.com/profile.jpg",
             )
 

--- a/SClass-Api-Lms/src/test/kotlin/com/sclass/lms/auth/controller/PhoneVerificationControllerIntegrationTest.kt
+++ b/SClass-Api-Lms/src/test/kotlin/com/sclass/lms/auth/controller/PhoneVerificationControllerIntegrationTest.kt
@@ -1,0 +1,105 @@
+package com.sclass.lms.auth.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.sclass.domain.domains.verification.domain.VerificationChannel
+import com.sclass.domain.domains.verification.service.VerificationDomainService
+import com.sclass.lms.auth.dto.SendPhoneCodeRequest
+import com.sclass.lms.auth.dto.VerifyPhoneCodeRequest
+import com.sclass.lms.config.ApiIntegrationTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@ApiIntegrationTest
+class PhoneVerificationControllerIntegrationTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var verificationDomainService: VerificationDomainService
+
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+
+    @Test
+    fun `인증코드 발송 요청 시 200을 반환한다`() {
+        val request = SendPhoneCodeRequest(phoneNumber = "01012345678")
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/phone/send-code")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.expiresInSeconds").value(300))
+    }
+
+    @Test
+    fun `phoneNumber가 비어있으면 400을 반환한다`() {
+        val invalidBody = """{"phoneNumber": ""}"""
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/phone/send-code")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(invalidBody),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `올바른 인증코드로 인증하면 phoneVerificationToken을 반환한다`() {
+        val verification =
+            verificationDomainService.createVerification(
+                channel = VerificationChannel.PHONE,
+                target = "010-5555-6666",
+            )
+
+        val request = VerifyPhoneCodeRequest(phoneNumber = "01055556666", code = verification.code)
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/phone/verify-code")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.phoneVerificationToken").isNotEmpty)
+    }
+
+    @Test
+    fun `잘못된 인증코드로 인증하면 에러를 반환한다`() {
+        verificationDomainService.createVerification(
+            channel = VerificationChannel.PHONE,
+            target = "010-7777-8888",
+        )
+
+        val request = VerifyPhoneCodeRequest(phoneNumber = "01077778888", code = "000000")
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/phone/verify-code")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `code가 6자리가 아니면 400을 반환한다`() {
+        val invalidBody = """{"phoneNumber": "01012345678", "code": "123"}"""
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/phone/verify-code")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(invalidBody),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+}

--- a/SClass-Api-Lms/src/test/kotlin/com/sclass/lms/auth/usecase/OAuthLoginUseCaseTest.kt
+++ b/SClass-Api-Lms/src/test/kotlin/com/sclass/lms/auth/usecase/OAuthLoginUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.sclass.lms.auth.usecase
 
 import com.sclass.common.jwt.SignupTokenInfo
+import com.sclass.common.jwt.VerificationTokenInfo
 import com.sclass.domain.domains.token.dto.TokenResult
 import com.sclass.domain.domains.token.service.TokenDomainService
 import com.sclass.domain.domains.user.domain.AuthProvider
@@ -115,7 +116,7 @@ class OAuthLoginUseCaseTest {
         val request =
             OAuthCompleteSignupRequest(
                 signupToken = "encrypted-signup-token",
-                phoneNumber = "010-1234-5678",
+                phoneVerificationToken = "encrypted-phone-token",
                 profileImageUrl = "https://example.com/profile.jpg",
             )
         val signupInfo =
@@ -127,10 +128,12 @@ class OAuthLoginUseCaseTest {
                 role = "ADMIN",
                 platform = "LMS",
             )
+        val phoneInfo = VerificationTokenInfo(channel = "PHONE", target = "010-1234-5678")
         val user = mockk<User> { every { id } returns "user-id" }
         val tokenResult = TokenResult(accessToken = "at", refreshToken = "rt")
 
         every { tokenService.resolveSignupToken("encrypted-signup-token") } returns signupInfo
+        every { tokenService.resolveVerificationToken("encrypted-phone-token") } returns phoneInfo
         every {
             userService.registerWithOAuth(
                 oauthId = "oauth-id",
@@ -166,7 +169,7 @@ class OAuthLoginUseCaseTest {
         val request =
             OAuthCompleteSignupRequest(
                 signupToken = "encrypted-signup-token",
-                phoneNumber = "010-5555-6666",
+                phoneVerificationToken = "encrypted-phone-token",
             )
         val signupInfo =
             SignupTokenInfo(
@@ -177,10 +180,12 @@ class OAuthLoginUseCaseTest {
                 role = "TEACHER",
                 platform = "LMS",
             )
+        val phoneInfo = VerificationTokenInfo(channel = "PHONE", target = "010-5555-6666")
         val user = mockk<User> { every { id } returns "new-user-id" }
         val tokenResult = TokenResult(accessToken = "access-token", refreshToken = "refresh-token")
 
         every { tokenService.resolveSignupToken("encrypted-signup-token") } returns signupInfo
+        every { tokenService.resolveVerificationToken("encrypted-phone-token") } returns phoneInfo
         every {
             userService.registerWithOAuth(
                 oauthId = "oauth-id",
@@ -206,7 +211,7 @@ class OAuthLoginUseCaseTest {
         val request =
             OAuthCompleteSignupRequest(
                 signupToken = "encrypted-signup-token",
-                phoneNumber = "010-1234-5678",
+                phoneVerificationToken = "encrypted-phone-token",
             )
         val signupInfo =
             SignupTokenInfo(
@@ -217,8 +222,10 @@ class OAuthLoginUseCaseTest {
                 role = "ADMIN",
                 platform = "LMS",
             )
+        val phoneInfo = VerificationTokenInfo(channel = "PHONE", target = "010-1234-5678")
 
         every { tokenService.resolveSignupToken("encrypted-signup-token") } returns signupInfo
+        every { tokenService.resolveVerificationToken("encrypted-phone-token") } returns phoneInfo
         every {
             userService.registerWithOAuth(
                 oauthId = "oauth-id",

--- a/SClass-Api-Lms/src/test/kotlin/com/sclass/lms/auth/usecase/PhoneVerificationUseCaseTest.kt
+++ b/SClass-Api-Lms/src/test/kotlin/com/sclass/lms/auth/usecase/PhoneVerificationUseCaseTest.kt
@@ -1,0 +1,126 @@
+package com.sclass.lms.auth.usecase
+
+import com.sclass.domain.domains.token.service.TokenDomainService
+import com.sclass.domain.domains.verification.domain.Verification
+import com.sclass.domain.domains.verification.domain.VerificationChannel
+import com.sclass.domain.domains.verification.exception.VerificationCodeMismatchException
+import com.sclass.domain.domains.verification.exception.VerificationSendRateLimitException
+import com.sclass.domain.domains.verification.service.VerificationDomainService
+import com.sclass.infrastructure.message.MessageSender
+import com.sclass.lms.auth.dto.SendPhoneCodeRequest
+import com.sclass.lms.auth.dto.VerifyPhoneCodeRequest
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class PhoneVerificationUseCaseTest {
+    private lateinit var verificationService: VerificationDomainService
+    private lateinit var tokenService: TokenDomainService
+    private lateinit var messageSender: MessageSender
+    private lateinit var useCase: PhoneVerificationUseCase
+
+    @BeforeEach
+    fun setUp() {
+        verificationService = mockk()
+        tokenService = mockk()
+        messageSender = mockk()
+        useCase = PhoneVerificationUseCase(verificationService, tokenService, messageSender, messageSender)
+    }
+
+    @Test
+    fun `인증코드 발송 요청 시 인증을 생성하고 메시지를 발송한다`() {
+        val request = SendPhoneCodeRequest(phoneNumber = "010-1234-5678")
+        val verification =
+            Verification(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+                code = "123456",
+                expiresAt = LocalDateTime.now().plusMinutes(5),
+            )
+
+        every {
+            verificationService.createVerification(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+            )
+        } returns verification
+        every { messageSender.sendVerificationCode("010-1234-5678", "123456") } just runs
+
+        val result = useCase.sendCode(request)
+
+        assertNotNull(result)
+        assertEquals(300L, result.expiresInSeconds)
+        verify { messageSender.sendVerificationCode("010-1234-5678", "123456") }
+    }
+
+    @Test
+    fun `발송 횟수 초과 시 VerificationSendRateLimitException이 발생한다`() {
+        val request = SendPhoneCodeRequest(phoneNumber = "010-1234-5678")
+
+        every {
+            verificationService.createVerification(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+            )
+        } throws VerificationSendRateLimitException()
+
+        assertThrows<VerificationSendRateLimitException> {
+            useCase.sendCode(request)
+        }
+    }
+
+    @Test
+    fun `올바른 인증코드로 인증하면 phoneVerificationToken을 반환한다`() {
+        val request = VerifyPhoneCodeRequest(phoneNumber = "010-1234-5678", code = "123456")
+        val verification =
+            Verification(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+                code = "123456",
+                expiresAt = LocalDateTime.now().plusMinutes(5),
+            )
+
+        every {
+            verificationService.verifyCode(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+                code = "123456",
+            )
+        } returns verification
+        every {
+            tokenService.issueVerificationToken(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+            )
+        } returns "encrypted-verification-token"
+
+        val result = useCase.verifyCode(request)
+
+        assertEquals("encrypted-verification-token", result.phoneVerificationToken)
+    }
+
+    @Test
+    fun `잘못된 인증코드로 인증하면 VerificationCodeMismatchException이 발생한다`() {
+        val request = VerifyPhoneCodeRequest(phoneNumber = "010-1234-5678", code = "999999")
+
+        every {
+            verificationService.verifyCode(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+                code = "999999",
+            )
+        } throws VerificationCodeMismatchException()
+
+        assertThrows<VerificationCodeMismatchException> {
+            useCase.verifyCode(request)
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/controller/PhoneVerificationController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/controller/PhoneVerificationController.kt
@@ -1,0 +1,29 @@
+package com.sclass.supporters.auth.controller
+
+import com.sclass.common.dto.ApiResponse
+import com.sclass.supporters.auth.dto.SendPhoneCodeRequest
+import com.sclass.supporters.auth.dto.SendPhoneCodeResponse
+import com.sclass.supporters.auth.dto.VerifyPhoneCodeRequest
+import com.sclass.supporters.auth.dto.VerifyPhoneCodeResponse
+import com.sclass.supporters.auth.usecase.PhoneVerificationUseCase
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth/phone")
+class PhoneVerificationController(
+    private val phoneVerificationUseCase: PhoneVerificationUseCase,
+) {
+    @PostMapping("/send-code")
+    fun sendCode(
+        @Valid @RequestBody request: SendPhoneCodeRequest,
+    ): ApiResponse<SendPhoneCodeResponse> = ApiResponse.success(phoneVerificationUseCase.sendCode(request))
+
+    @PostMapping("/verify-code")
+    fun verifyCode(
+        @Valid @RequestBody request: VerifyPhoneCodeRequest,
+    ): ApiResponse<VerifyPhoneCodeResponse> = ApiResponse.success(phoneVerificationUseCase.verifyCode(request))
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/dto/OAuthCompleteSignupRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/dto/OAuthCompleteSignupRequest.kt
@@ -8,7 +8,7 @@ data class OAuthCompleteSignupRequest(
     val signupToken: String,
 
     @field:NotBlank
-    val phoneNumber: String,
+    val phoneVerificationToken: String,
 
     @field:Nullable
     val profileImageUrl: String? = null,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/dto/SendPhoneCodeRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/dto/SendPhoneCodeRequest.kt
@@ -1,0 +1,8 @@
+package com.sclass.supporters.auth.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class SendPhoneCodeRequest(
+    @field:NotBlank
+    val phoneNumber: String,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/dto/SendPhoneCodeResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/dto/SendPhoneCodeResponse.kt
@@ -1,0 +1,5 @@
+package com.sclass.supporters.auth.dto
+
+data class SendPhoneCodeResponse(
+    val expiresInSeconds: Long = 300,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/dto/VerifyPhoneCodeRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/dto/VerifyPhoneCodeRequest.kt
@@ -1,0 +1,13 @@
+package com.sclass.supporters.auth.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class VerifyPhoneCodeRequest(
+    @field:NotBlank
+    val phoneNumber: String,
+
+    @field:NotBlank
+    @field:Size(min = 6, max = 6)
+    val code: String,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/dto/VerifyPhoneCodeResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/dto/VerifyPhoneCodeResponse.kt
@@ -1,0 +1,5 @@
+package com.sclass.supporters.auth.dto
+
+data class VerifyPhoneCodeResponse(
+    val phoneVerificationToken: String,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/OAuthLoginUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/OAuthLoginUseCase.kt
@@ -67,13 +67,15 @@ class OAuthLoginUseCase(
         val platform = Platform.valueOf(signupInfo.platform)
         val role = Role.valueOf(signupInfo.role)
 
+        val phoneInfo = tokenService.resolveVerificationToken(request.phoneVerificationToken)
+
         val user =
             userService.registerWithOAuth(
                 oauthId = signupInfo.oauthId,
                 authProvider = authProvider,
                 email = signupInfo.email,
                 name = signupInfo.name,
-                phoneNumber = request.phoneNumber,
+                phoneNumber = phoneInfo.target,
                 profileImageUrl = request.profileImageUrl,
                 platform = platform,
                 role = role,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/PhoneVerificationUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/PhoneVerificationUseCase.kt
@@ -1,0 +1,49 @@
+package com.sclass.supporters.auth.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.token.service.TokenDomainService
+import com.sclass.domain.domains.user.domain.User
+import com.sclass.domain.domains.verification.domain.VerificationChannel
+import com.sclass.domain.domains.verification.service.VerificationDomainService
+import com.sclass.infrastructure.message.MessageSender
+import com.sclass.supporters.auth.dto.SendPhoneCodeRequest
+import com.sclass.supporters.auth.dto.SendPhoneCodeResponse
+import com.sclass.supporters.auth.dto.VerifyPhoneCodeRequest
+import com.sclass.supporters.auth.dto.VerifyPhoneCodeResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class PhoneVerificationUseCase(
+    private val verificationService: VerificationDomainService,
+    private val tokenService: TokenDomainService,
+    private val messageSender: MessageSender,
+    sender: MessageSender,
+) {
+    @Transactional
+    fun sendCode(request: SendPhoneCodeRequest): SendPhoneCodeResponse {
+        val phoneNumber = User.formatPhoneNumber(request.phoneNumber)
+        val verification =
+            verificationService.createVerification(
+                channel = VerificationChannel.PHONE,
+                target = phoneNumber,
+            )
+        messageSender.sendVerificationCode(phoneNumber, verification.code)
+        return SendPhoneCodeResponse()
+    }
+
+    @Transactional
+    fun verifyCode(request: VerifyPhoneCodeRequest): VerifyPhoneCodeResponse {
+        val phoneNumber = User.formatPhoneNumber(request.phoneNumber)
+        verificationService.verifyCode(
+            channel = VerificationChannel.PHONE,
+            target = phoneNumber,
+            code = request.code,
+        )
+        val token =
+            tokenService.issueVerificationToken(
+                channel = VerificationChannel.PHONE,
+                target = phoneNumber,
+            )
+        return VerifyPhoneCodeResponse(phoneVerificationToken = token)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/config/WebConfig.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/config/WebConfig.kt
@@ -1,0 +1,31 @@
+package com.sclass.supporters.config
+
+import com.sclass.common.jwt.CurrentUserIdArgumentResolver
+import com.sclass.common.jwt.JwtAuthInterceptor
+import com.sclass.common.jwt.PlatformAuthInterceptor
+import com.sclass.domain.domains.user.domain.Platform
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig(
+    private val jwtAuthInterceptor: JwtAuthInterceptor,
+    private val currentUserIdArgumentResolver: CurrentUserIdArgumentResolver,
+) : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry
+            .addInterceptor(jwtAuthInterceptor)
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/api/v1/auth/**", "/api/v1/auth/phone/**")
+        registry
+            .addInterceptor(PlatformAuthInterceptor(Platform.SUPPORTERS.name))
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/api/v1/auth/**", "/api/v1/auth/phone/**")
+    }
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(currentUserIdArgumentResolver)
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/controller/OAuthControllerIntegrationTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/controller/OAuthControllerIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.sclass.domain.domains.user.domain.AuthProvider
 import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.domain.domains.user.service.UserDomainService
+import com.sclass.domain.domains.verification.domain.VerificationChannel
 import com.sclass.infrastructure.oauth.OAuthClientFactory
 import com.sclass.infrastructure.oauth.client.OAuthClient
 import com.sclass.infrastructure.oauth.dto.OAuthUserInfo
@@ -122,10 +123,16 @@ class OAuthControllerIntegrationTest {
                 platform = Platform.SUPPORTERS,
             )
 
+        val phoneVerificationToken =
+            tokenDomainService.issueVerificationToken(
+                channel = VerificationChannel.PHONE,
+                target = "010-9999-8888",
+            )
+
         val request =
             OAuthCompleteSignupRequest(
                 signupToken = signupToken,
-                phoneNumber = "01099998888",
+                phoneVerificationToken = phoneVerificationToken,
                 profileImageUrl = "https://example.com/profile.jpg",
             )
 

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/controller/PhoneVerificationControllerIntegrationTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/controller/PhoneVerificationControllerIntegrationTest.kt
@@ -1,0 +1,105 @@
+package com.sclass.supporters.auth.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.sclass.domain.domains.verification.domain.VerificationChannel
+import com.sclass.domain.domains.verification.service.VerificationDomainService
+import com.sclass.supporters.auth.dto.SendPhoneCodeRequest
+import com.sclass.supporters.auth.dto.VerifyPhoneCodeRequest
+import com.sclass.supporters.config.ApiIntegrationTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@ApiIntegrationTest
+class PhoneVerificationControllerIntegrationTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var verificationDomainService: VerificationDomainService
+
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+
+    @Test
+    fun `인증코드 발송 요청 시 200을 반환한다`() {
+        val request = SendPhoneCodeRequest(phoneNumber = "01012345678")
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/phone/send-code")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.expiresInSeconds").value(300))
+    }
+
+    @Test
+    fun `phoneNumber가 비어있으면 400을 반환한다`() {
+        val invalidBody = """{"phoneNumber": ""}"""
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/phone/send-code")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(invalidBody),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `올바른 인증코드로 인증하면 phoneVerificationToken을 반환한다`() {
+        val verification =
+            verificationDomainService.createVerification(
+                channel = VerificationChannel.PHONE,
+                target = "010-5555-6666",
+            )
+
+        val request = VerifyPhoneCodeRequest(phoneNumber = "01055556666", code = verification.code)
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/phone/verify-code")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.phoneVerificationToken").isNotEmpty)
+    }
+
+    @Test
+    fun `잘못된 인증코드로 인증하면 에러를 반환한다`() {
+        verificationDomainService.createVerification(
+            channel = VerificationChannel.PHONE,
+            target = "010-7777-8888",
+        )
+
+        val request = VerifyPhoneCodeRequest(phoneNumber = "01077778888", code = "000000")
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/phone/verify-code")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    fun `code가 6자리가 아니면 400을 반환한다`() {
+        val invalidBody = """{"phoneNumber": "01012345678", "code": "123"}"""
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/phone/verify-code")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(invalidBody),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/OAuthLoginUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/OAuthLoginUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.sclass.supporters.auth.usecase
 
 import com.sclass.common.jwt.SignupTokenInfo
+import com.sclass.common.jwt.VerificationTokenInfo
 import com.sclass.domain.domains.token.dto.TokenResult
 import com.sclass.domain.domains.token.service.TokenDomainService
 import com.sclass.domain.domains.user.domain.AuthProvider
@@ -190,7 +191,7 @@ class OAuthLoginUseCaseTest {
         val request =
             OAuthCompleteSignupRequest(
                 signupToken = "encrypted-signup-token",
-                phoneNumber = "010-1234-5678",
+                phoneVerificationToken = "encrypted-phone-token",
                 profileImageUrl = "https://example.com/profile.jpg",
             )
         val signupInfo =
@@ -202,10 +203,12 @@ class OAuthLoginUseCaseTest {
                 role = "STUDENT",
                 platform = "SUPPORTERS",
             )
+        val phoneInfo = VerificationTokenInfo(channel = "PHONE", target = "010-1234-5678")
         val user = mockk<User> { every { id } returns "new-user-id" }
         val tokenResult = TokenResult(accessToken = "at", refreshToken = "rt")
 
         every { tokenService.resolveSignupToken("encrypted-signup-token") } returns signupInfo
+        every { tokenService.resolveVerificationToken("encrypted-phone-token") } returns phoneInfo
         every {
             userService.registerWithOAuth(
                 oauthId = "oauth-id",
@@ -231,7 +234,7 @@ class OAuthLoginUseCaseTest {
         val request =
             OAuthCompleteSignupRequest(
                 signupToken = "encrypted-signup-token",
-                phoneNumber = "010-9999-8888",
+                phoneVerificationToken = "encrypted-phone-token",
                 profileImageUrl = "https://example.com/img.png",
             )
         val signupInfo =
@@ -243,10 +246,12 @@ class OAuthLoginUseCaseTest {
                 role = "TEACHER",
                 platform = "SUPPORTERS",
             )
+        val phoneInfo = VerificationTokenInfo(channel = "PHONE", target = "010-9999-8888")
         val user = mockk<User> { every { id } returns "user-id" }
         val tokenResult = TokenResult(accessToken = "at", refreshToken = "rt")
 
         every { tokenService.resolveSignupToken("encrypted-signup-token") } returns signupInfo
+        every { tokenService.resolveVerificationToken("encrypted-phone-token") } returns phoneInfo
         every {
             userService.registerWithOAuth(
                 oauthId = "oauth-id-2",
@@ -282,7 +287,7 @@ class OAuthLoginUseCaseTest {
         val request =
             OAuthCompleteSignupRequest(
                 signupToken = "encrypted-signup-token",
-                phoneNumber = "010-1111-2222",
+                phoneVerificationToken = "encrypted-phone-token",
             )
         val signupInfo =
             SignupTokenInfo(
@@ -293,10 +298,12 @@ class OAuthLoginUseCaseTest {
                 role = "STUDENT",
                 platform = "SUPPORTERS",
             )
+        val phoneInfo = VerificationTokenInfo(channel = "PHONE", target = "010-1111-2222")
         val user = mockk<User> { every { id } returns "user-id" }
         val tokenResult = TokenResult(accessToken = "at", refreshToken = "rt")
 
         every { tokenService.resolveSignupToken("encrypted-signup-token") } returns signupInfo
+        every { tokenService.resolveVerificationToken("encrypted-phone-token") } returns phoneInfo
         every {
             userService.registerWithOAuth(
                 oauthId = any(),
@@ -333,7 +340,7 @@ class OAuthLoginUseCaseTest {
         val request =
             OAuthCompleteSignupRequest(
                 signupToken = "encrypted-signup-token",
-                phoneNumber = "010-1111-2222",
+                phoneVerificationToken = "encrypted-phone-token",
             )
         val signupInfo =
             SignupTokenInfo(
@@ -344,8 +351,10 @@ class OAuthLoginUseCaseTest {
                 role = "STUDENT",
                 platform = "SUPPORTERS",
             )
+        val phoneInfo = VerificationTokenInfo(channel = "PHONE", target = "010-1111-2222")
 
         every { tokenService.resolveSignupToken("encrypted-signup-token") } returns signupInfo
+        every { tokenService.resolveVerificationToken("encrypted-phone-token") } returns phoneInfo
         every {
             userService.registerWithOAuth(
                 oauthId = "oauth-id",

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/PhoneVerificationUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/PhoneVerificationUseCaseTest.kt
@@ -1,0 +1,126 @@
+package com.sclass.supporters.auth.usecase
+
+import com.sclass.domain.domains.token.service.TokenDomainService
+import com.sclass.domain.domains.verification.domain.Verification
+import com.sclass.domain.domains.verification.domain.VerificationChannel
+import com.sclass.domain.domains.verification.exception.VerificationCodeMismatchException
+import com.sclass.domain.domains.verification.exception.VerificationSendRateLimitException
+import com.sclass.domain.domains.verification.service.VerificationDomainService
+import com.sclass.infrastructure.message.MessageSender
+import com.sclass.supporters.auth.dto.SendPhoneCodeRequest
+import com.sclass.supporters.auth.dto.VerifyPhoneCodeRequest
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class PhoneVerificationUseCaseTest {
+    private lateinit var verificationService: VerificationDomainService
+    private lateinit var tokenService: TokenDomainService
+    private lateinit var messageSender: MessageSender
+    private lateinit var useCase: PhoneVerificationUseCase
+
+    @BeforeEach
+    fun setUp() {
+        verificationService = mockk()
+        tokenService = mockk()
+        messageSender = mockk()
+        useCase = PhoneVerificationUseCase(verificationService, tokenService, messageSender, messageSender)
+    }
+
+    @Test
+    fun `인증코드 발송 요청 시 인증을 생성하고 메시지를 발송한다`() {
+        val request = SendPhoneCodeRequest(phoneNumber = "010-1234-5678")
+        val verification =
+            Verification(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+                code = "123456",
+                expiresAt = LocalDateTime.now().plusMinutes(5),
+            )
+
+        every {
+            verificationService.createVerification(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+            )
+        } returns verification
+        every { messageSender.sendVerificationCode("010-1234-5678", "123456") } just runs
+
+        val result = useCase.sendCode(request)
+
+        assertNotNull(result)
+        assertEquals(300L, result.expiresInSeconds)
+        verify { messageSender.sendVerificationCode("010-1234-5678", "123456") }
+    }
+
+    @Test
+    fun `발송 횟수 초과 시 VerificationSendRateLimitException이 발생한다`() {
+        val request = SendPhoneCodeRequest(phoneNumber = "010-1234-5678")
+
+        every {
+            verificationService.createVerification(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+            )
+        } throws VerificationSendRateLimitException()
+
+        assertThrows<VerificationSendRateLimitException> {
+            useCase.sendCode(request)
+        }
+    }
+
+    @Test
+    fun `올바른 인증코드로 인증하면 phoneVerificationToken을 반환한다`() {
+        val request = VerifyPhoneCodeRequest(phoneNumber = "010-1234-5678", code = "123456")
+        val verification =
+            Verification(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+                code = "123456",
+                expiresAt = LocalDateTime.now().plusMinutes(5),
+            )
+
+        every {
+            verificationService.verifyCode(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+                code = "123456",
+            )
+        } returns verification
+        every {
+            tokenService.issueVerificationToken(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+            )
+        } returns "encrypted-verification-token"
+
+        val result = useCase.verifyCode(request)
+
+        assertEquals("encrypted-verification-token", result.phoneVerificationToken)
+    }
+
+    @Test
+    fun `잘못된 인증코드로 인증하면 VerificationCodeMismatchException이 발생한다`() {
+        val request = VerifyPhoneCodeRequest(phoneNumber = "010-1234-5678", code = "999999")
+
+        every {
+            verificationService.verifyCode(
+                channel = VerificationChannel.PHONE,
+                target = "010-1234-5678",
+                code = "999999",
+            )
+        } throws VerificationCodeMismatchException()
+
+        assertThrows<VerificationCodeMismatchException> {
+            useCase.verifyCode(request)
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/config/IntegrationTestConfig.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/config/IntegrationTestConfig.kt
@@ -1,6 +1,7 @@
 package com.sclass.supporters.config
 
 import com.google.cloud.storage.Storage
+import com.sclass.infrastructure.message.MessageSender
 import com.sclass.infrastructure.oauth.OAuthClientFactory
 import com.sclass.infrastructure.oauth.client.OAuthClient
 import io.mockk.mockk
@@ -31,4 +32,8 @@ class IntegrationTestConfig {
     @Bean
     @Primary
     fun mockGcsStorage(): Storage = mockk<Storage>(relaxed = true)
+
+    @Bean
+    @Primary
+    fun mockMessageSender(): MessageSender = mockk<MessageSender>(relaxed = true)
 }

--- a/SClass-Common/src/main/kotlin/com/sclass/common/jwt/JwtTokenProvider.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/jwt/JwtTokenProvider.kt
@@ -31,7 +31,12 @@ class JwtTokenProvider(
         private const val EMAIL = "email"
         private const val NAME = "name"
         private const val PLATFORM = "platform"
-        private const val SIGNUP_TOKEN_TTL_SECONDS = 300L
+        private const val SIGNUP_TOKEN_TTL_SECONDS = 300L // 5분
+
+        private const val VERIFICATION_TOKEN = "VERIFICATION"
+        private const val CHANNEL = "channel"
+        private const val TARGET = "target"
+        private const val VERIFICATION_TOKEN_TTL_SECONDS = 600L
     }
 
     private val secretKey: SecretKey by lazy {
@@ -160,6 +165,35 @@ class JwtTokenProvider(
             name = claims.get(NAME, String::class.java),
             role = claims.get(ROLE, String::class.java),
             platform = claims.get(PLATFORM, String::class.java),
+        )
+    }
+
+    fun generateVerificationToken(
+        channel: String,
+        target: String,
+    ): String {
+        val issuedAt = Date()
+        val expiration = Date(issuedAt.time + VERIFICATION_TOKEN_TTL_SECONDS * MILLI_TO_SECOND)
+        return Jwts
+            .builder()
+            .issuer(TOKEN_ISSUER)
+            .issuedAt(issuedAt)
+            .claim(TOKEN_TYPE, VERIFICATION_TOKEN)
+            .claim(CHANNEL, channel)
+            .claim(TARGET, target)
+            .expiration(expiration)
+            .signWith(secretKey)
+            .compact()
+    }
+
+    fun parseVerificationToken(token: String): VerificationTokenInfo {
+        val claims = getJws(token).payload
+        if (claims.get(TOKEN_TYPE) != VERIFICATION_TOKEN) {
+            throw InvalidTokenException()
+        }
+        return VerificationTokenInfo(
+            channel = claims.get(CHANNEL, String::class.java),
+            target = claims.get(TARGET, String::class.java),
         )
     }
 }

--- a/SClass-Common/src/main/kotlin/com/sclass/common/jwt/VerificationTokenInfo.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/jwt/VerificationTokenInfo.kt
@@ -1,0 +1,6 @@
+package com.sclass.common.jwt
+
+data class VerificationTokenInfo(
+    val channel: String,
+    val target: String,
+)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/service/TokenDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/service/TokenDomainService.kt
@@ -4,12 +4,14 @@ import com.sclass.common.annotation.DomainService
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.common.jwt.JwtTokenProvider
 import com.sclass.common.jwt.SignupTokenInfo
+import com.sclass.common.jwt.VerificationTokenInfo
 import com.sclass.domain.domains.token.adaptor.RefreshTokenAdaptor
 import com.sclass.domain.domains.token.domain.RefreshToken
 import com.sclass.domain.domains.token.dto.TokenResult
 import com.sclass.domain.domains.user.domain.AuthProvider
 import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.Role
+import com.sclass.domain.domains.verification.domain.VerificationChannel
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
@@ -66,5 +68,18 @@ class TokenDomainService(
     fun resolveSignupToken(encryptedSignupToken: String): SignupTokenInfo {
         val signupJwt = aesTokenEncryptor.decrypt(encryptedSignupToken)
         return jwtTokenProvider.parseSignupToken(signupJwt)
+    }
+
+    fun issueVerificationToken(
+        channel: VerificationChannel,
+        target: String,
+    ): String {
+        val jwt = jwtTokenProvider.generateVerificationToken(channel.name, target)
+        return aesTokenEncryptor.encrypt(jwt)
+    }
+
+    fun resolveVerificationToken(encryptedToken: String): VerificationTokenInfo {
+        val jwt = aesTokenEncryptor.decrypt(encryptedToken)
+        return jwtTokenProvider.parseVerificationToken(jwt)
     }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/domain/User.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/domain/User.kt
@@ -36,6 +36,9 @@ class User(
 
     @Column(nullable = false)
     var activated: Boolean = true,
+
+    @Column(nullable = false)
+    var emailVerified: Boolean = false,
 ) : BaseTimeEntity() {
     fun changePassword(newHashedPassword: String) {
         this.hashedPassword = newHashedPassword

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/service/UserDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/service/UserDomainService.kt
@@ -5,7 +5,6 @@ import com.sclass.domain.domains.user.adaptor.UserAdaptor
 import com.sclass.domain.domains.user.adaptor.UserRoleAdaptor
 import com.sclass.domain.domains.user.domain.AuthProvider
 import com.sclass.domain.domains.user.domain.Platform
-import com.sclass.domain.domains.user.domain.QUser.user
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.domain.domains.user.domain.User
 import com.sclass.domain.domains.user.domain.UserRole
@@ -109,6 +108,7 @@ class UserDomainService(
                 oauthId = oauthId,
                 phoneNumber = User.formatPhoneNumber(phoneNumber),
                 profileImageUrl = profileImageUrl,
+                emailVerified = true,
             )
         val savedUser = userAdaptor.save(user)
 

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/adaptor/VerificationAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/adaptor/VerificationAdaptor.kt
@@ -1,0 +1,25 @@
+package com.sclass.domain.domains.verification.adaptor
+
+import com.sclass.common.annotation.Adaptor
+import com.sclass.domain.domains.verification.domain.Verification
+import com.sclass.domain.domains.verification.domain.VerificationChannel
+import com.sclass.domain.domains.verification.repository.VerificationRepository
+import java.time.LocalDateTime
+
+@Adaptor
+class VerificationAdaptor(
+    private val verificationRepository: VerificationRepository,
+) {
+    fun save(verification: Verification): Verification = verificationRepository.save(verification)
+
+    fun findLatestOrNull(
+        channel: VerificationChannel,
+        target: String,
+    ): Verification? = verificationRepository.findFirstByChannelAndTargetOrderByCreatedAtDesc(channel, target)
+
+    fun countRecent(
+        channel: VerificationChannel,
+        target: String,
+        after: LocalDateTime,
+    ): Long = verificationRepository.countByChannelAndTargetAndCreatedAtAfter(channel, target, after)
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/domain/Verification.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/domain/Verification.kt
@@ -1,0 +1,72 @@
+package com.sclass.domain.domains.verification.domain
+
+import com.sclass.domain.common.model.BaseTimeEntity
+import com.sclass.domain.common.vo.Ulid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "verifications",
+    indexes = [
+        Index(name = "idx_verifications_channel_target_created_at", columnList = "channel, target, createdAt"),
+    ],
+)
+class Verification(
+    @Id
+    @Column(length = 26)
+    val id: String = Ulid.generate(),
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    val channel: VerificationChannel,
+
+    @Column(nullable = false)
+    val target: String,
+
+    @Column(nullable = false, length = 6)
+    val code: String,
+
+    @Column(nullable = false)
+    val expiresAt: LocalDateTime,
+
+    @Column(nullable = false)
+    var attemptCount: Int = 0,
+
+    @Column(nullable = false)
+    var verified: Boolean = false,
+) : BaseTimeEntity() {
+    fun isExpired(): Boolean = LocalDateTime.now().isAfter(expiresAt)
+
+    fun incrementAttemptCount() {
+        attemptCount++
+    }
+
+    fun verify() {
+        verified = true
+    }
+
+    companion object {
+        private const val CODE_LENGTH = 6
+        private const val EXPIRATION_MINUTES = 5L
+
+        fun create(
+            channel: VerificationChannel,
+            target: String,
+        ): Verification {
+            val code = (0 until CODE_LENGTH).map { (0..9).random() }.joinToString("")
+            return Verification(
+                channel = channel,
+                target = target,
+                code = code,
+                expiresAt = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES),
+            )
+        }
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/domain/VerificationChannel.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/domain/VerificationChannel.kt
@@ -1,0 +1,6 @@
+package com.sclass.domain.domains.verification.domain
+
+enum class VerificationChannel {
+    PHONE,
+    EMAIL,
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/exception/VerificationErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/exception/VerificationErrorCode.kt
@@ -1,0 +1,15 @@
+package com.sclass.domain.domains.verification.exception
+
+import com.sclass.common.exception.ErrorCode
+
+enum class VerificationErrorCode(
+    override val code: String,
+    override val message: String,
+    override val httpStatus: Int,
+) : ErrorCode {
+    VERIFICATION_NOT_FOUND("VERIFICATION_001", "인증 요청을 찾을 수 없습니다", 404),
+    VERIFICATION_EXPIRED("VERIFICATION_002", "인증번호가 만료되었습니다", 400),
+    VERIFICATION_CODE_MISMATCH("VERIFICATION_003", "인증번호가 일치하지 않습니다", 400),
+    VERIFICATION_MAX_ATTEMPTS("VERIFICATION_004", "인증 시도 횟수를 초과했습니다", 429),
+    VERIFICATION_SEND_RATE_LIMIT("VERIFICATION_005", "인증번호 발송 횟수를 초과했습니다", 429),
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/exception/VerificationExceptions.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/exception/VerificationExceptions.kt
@@ -1,0 +1,13 @@
+package com.sclass.domain.domains.verification.exception
+
+import com.sclass.common.exception.BusinessException
+
+class VerificationNotFoundException : BusinessException(VerificationErrorCode.VERIFICATION_NOT_FOUND)
+
+class VerificationExpiredException : BusinessException(VerificationErrorCode.VERIFICATION_EXPIRED)
+
+class VerificationCodeMismatchException : BusinessException(VerificationErrorCode.VERIFICATION_CODE_MISMATCH)
+
+class VerificationMaxAttemptsException : BusinessException(VerificationErrorCode.VERIFICATION_MAX_ATTEMPTS)
+
+class VerificationSendRateLimitException : BusinessException(VerificationErrorCode.VERIFICATION_SEND_RATE_LIMIT)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/repository/VerificationRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/repository/VerificationRepository.kt
@@ -1,0 +1,19 @@
+package com.sclass.domain.domains.verification.repository
+
+import com.sclass.domain.domains.verification.domain.Verification
+import com.sclass.domain.domains.verification.domain.VerificationChannel
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+
+interface VerificationRepository : JpaRepository<Verification, String> {
+    fun findFirstByChannelAndTargetOrderByCreatedAtDesc(
+        channel: VerificationChannel,
+        target: String,
+    ): Verification?
+
+    fun countByChannelAndTargetAndCreatedAtAfter(
+        channel: VerificationChannel,
+        target: String,
+        createdAt: LocalDateTime,
+    ): Long
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/service/VerificationDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/verification/service/VerificationDomainService.kt
@@ -1,0 +1,66 @@
+package com.sclass.domain.domains.verification.service
+
+import com.sclass.common.annotation.DomainService
+import com.sclass.domain.domains.verification.adaptor.VerificationAdaptor
+import com.sclass.domain.domains.verification.domain.Verification
+import com.sclass.domain.domains.verification.domain.VerificationChannel
+import com.sclass.domain.domains.verification.exception.VerificationCodeMismatchException
+import com.sclass.domain.domains.verification.exception.VerificationExpiredException
+import com.sclass.domain.domains.verification.exception.VerificationMaxAttemptsException
+import com.sclass.domain.domains.verification.exception.VerificationNotFoundException
+import com.sclass.domain.domains.verification.exception.VerificationSendRateLimitException
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@DomainService
+class VerificationDomainService(
+    private val verificationAdaptor: VerificationAdaptor,
+) {
+    companion object {
+        private const val MAX_SEND_PER_HOURS = 5
+        private const val MAX_ATTEMPTS_PER_CODE = 5
+    }
+
+    @Transactional
+    fun createVerification(
+        channel: VerificationChannel,
+        target: String,
+    ): Verification {
+        val recentCount = verificationAdaptor.countRecent(channel, target, after = LocalDateTime.now().minusHours(1))
+
+        if (recentCount >= MAX_SEND_PER_HOURS) {
+            throw VerificationSendRateLimitException()
+        }
+
+        val verification = Verification.create(channel, target)
+        return verificationAdaptor.save(verification)
+    }
+
+    @Transactional
+    fun verifyCode(
+        channel: VerificationChannel,
+        target: String,
+        code: String,
+    ): Verification {
+        val verification =
+            verificationAdaptor.findLatestOrNull(channel, target)
+                ?: throw VerificationNotFoundException()
+
+        if (verification.isExpired()) {
+            throw VerificationExpiredException()
+        }
+
+        if (verification.attemptCount >= MAX_ATTEMPTS_PER_CODE) {
+            throw VerificationMaxAttemptsException()
+        }
+
+        verification.incrementAttemptCount()
+
+        if (verification.code != code) {
+            throw VerificationCodeMismatchException()
+        }
+
+        verification.verify()
+        return verification
+    }
+}

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceTest.kt
@@ -2,11 +2,13 @@ package com.sclass.domain.domains.token.service
 
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.common.jwt.JwtTokenProvider
+import com.sclass.common.jwt.VerificationTokenInfo
 import com.sclass.domain.domains.token.adaptor.RefreshTokenAdaptor
 import com.sclass.domain.domains.token.domain.RefreshToken
 import com.sclass.domain.domains.user.domain.AuthProvider
 import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.Role
+import com.sclass.domain.domains.verification.domain.VerificationChannel
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -109,6 +111,40 @@ class TokenDomainServiceTest {
                 )
 
             assertEquals("encrypted-signup", result)
+        }
+    }
+
+    @Nested
+    inner class IssueVerificationToken {
+        @Test
+        fun `verification JWT를 생성하고 암호화하여 반환한다`() {
+            every {
+                jwtTokenProvider.generateVerificationToken("PHONE", "010-1234-5678")
+            } returns "raw-verification-jwt"
+            every { aesTokenEncryptor.encrypt("raw-verification-jwt") } returns "encrypted-verification"
+
+            val result =
+                tokenDomainService.issueVerificationToken(
+                    channel = VerificationChannel.PHONE,
+                    target = "010-1234-5678",
+                )
+
+            assertEquals("encrypted-verification", result)
+        }
+    }
+
+    @Nested
+    inner class ResolveVerificationToken {
+        @Test
+        fun `암호화된 verification token에서 channel과 target을 추출한다`() {
+            every { aesTokenEncryptor.decrypt("encrypted-verification") } returns "raw-verification-jwt"
+            every { jwtTokenProvider.parseVerificationToken("raw-verification-jwt") } returns
+                VerificationTokenInfo(channel = "PHONE", target = "010-1234-5678")
+
+            val result = tokenDomainService.resolveVerificationToken("encrypted-verification")
+
+            assertEquals("PHONE", result.channel)
+            assertEquals("010-1234-5678", result.target)
         }
     }
 }

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/verification/domain/VerificationTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/verification/domain/VerificationTest.kt
@@ -1,0 +1,138 @@
+package com.sclass.domain.domains.verification.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class VerificationTest {
+    @Nested
+    inner class Create {
+        @Test
+        fun `6자리 숫자 코드를 생성한다`() {
+            val verification = Verification.create(VerificationChannel.PHONE, "010-1234-5678")
+
+            assertEquals(6, verification.code.length)
+            assertTrue(verification.code.all { it.isDigit() })
+        }
+
+        @Test
+        fun `초기 상태는 미인증이고 시도횟수 0이다`() {
+            val verification = Verification.create(VerificationChannel.PHONE, "010-1234-5678")
+
+            assertFalse(verification.verified)
+            assertEquals(0, verification.attemptCount)
+        }
+
+        @Test
+        fun `만료시간이 현재로부터 5분 후이다`() {
+            val before = LocalDateTime.now().plusMinutes(4)
+            val verification = Verification.create(VerificationChannel.PHONE, "010-1234-5678")
+            val after = LocalDateTime.now().plusMinutes(6)
+
+            assertTrue(verification.expiresAt.isAfter(before))
+            assertTrue(verification.expiresAt.isBefore(after))
+        }
+
+        @Test
+        fun `채널과 대상이 올바르게 설정된다`() {
+            val verification = Verification.create(VerificationChannel.PHONE, "010-1234-5678")
+
+            assertEquals(VerificationChannel.PHONE, verification.channel)
+            assertEquals("010-1234-5678", verification.target)
+        }
+
+        @Test
+        fun `ULID 형식의 id가 생성된다`() {
+            val verification = Verification.create(VerificationChannel.PHONE, "010-1234-5678")
+
+            assertNotNull(verification.id)
+            assertEquals(26, verification.id.length)
+        }
+    }
+
+    @Nested
+    inner class IsExpired {
+        @Test
+        fun `만료시간 이전이면 false를 반환한다`() {
+            val verification =
+                Verification(
+                    channel = VerificationChannel.PHONE,
+                    target = "010-1234-5678",
+                    code = "123456",
+                    expiresAt = LocalDateTime.now().plusMinutes(5),
+                )
+
+            assertFalse(verification.isExpired())
+        }
+
+        @Test
+        fun `만료시간 이후이면 true를 반환한다`() {
+            val verification =
+                Verification(
+                    channel = VerificationChannel.PHONE,
+                    target = "010-1234-5678",
+                    code = "123456",
+                    expiresAt = LocalDateTime.now().minusMinutes(1),
+                )
+
+            assertTrue(verification.isExpired())
+        }
+    }
+
+    @Nested
+    inner class IncrementAttemptCount {
+        @Test
+        fun `시도 횟수가 1 증가한다`() {
+            val verification =
+                Verification(
+                    channel = VerificationChannel.PHONE,
+                    target = "010-1234-5678",
+                    code = "123456",
+                    expiresAt = LocalDateTime.now().plusMinutes(5),
+                )
+
+            verification.incrementAttemptCount()
+
+            assertEquals(1, verification.attemptCount)
+        }
+
+        @Test
+        fun `여러 번 호출하면 누적된다`() {
+            val verification =
+                Verification(
+                    channel = VerificationChannel.PHONE,
+                    target = "010-1234-5678",
+                    code = "123456",
+                    expiresAt = LocalDateTime.now().plusMinutes(5),
+                )
+
+            repeat(3) { verification.incrementAttemptCount() }
+
+            assertEquals(3, verification.attemptCount)
+        }
+    }
+
+    @Nested
+    inner class Verify {
+        @Test
+        fun `verified가 true로 변경된다`() {
+            val verification =
+                Verification(
+                    channel = VerificationChannel.PHONE,
+                    target = "010-1234-5678",
+                    code = "123456",
+                    expiresAt = LocalDateTime.now().plusMinutes(5),
+                )
+
+            assertFalse(verification.verified)
+
+            verification.verify()
+
+            assertTrue(verification.verified)
+        }
+    }
+}

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/verification/service/VerificationDomainServiceTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/verification/service/VerificationDomainServiceTest.kt
@@ -1,0 +1,153 @@
+package com.sclass.domain.domains.verification.service
+
+import com.sclass.domain.domains.verification.adaptor.VerificationAdaptor
+import com.sclass.domain.domains.verification.domain.Verification
+import com.sclass.domain.domains.verification.domain.VerificationChannel
+import com.sclass.domain.domains.verification.exception.VerificationCodeMismatchException
+import com.sclass.domain.domains.verification.exception.VerificationExpiredException
+import com.sclass.domain.domains.verification.exception.VerificationMaxAttemptsException
+import com.sclass.domain.domains.verification.exception.VerificationNotFoundException
+import com.sclass.domain.domains.verification.exception.VerificationSendRateLimitException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class VerificationDomainServiceTest {
+    private lateinit var verificationAdaptor: VerificationAdaptor
+    private lateinit var verificationDomainService: VerificationDomainService
+
+    @BeforeEach
+    fun setUp() {
+        verificationAdaptor = mockk()
+        verificationDomainService = VerificationDomainService(verificationAdaptor)
+    }
+
+    @Nested
+    inner class CreateVerification {
+        @Test
+        fun `인증을 생성하고 저장한다`() {
+            val slot = slot<Verification>()
+            every { verificationAdaptor.countRecent(VerificationChannel.PHONE, "010-1234-5678", any()) } returns 0L
+            every { verificationAdaptor.save(capture(slot)) } answers { slot.captured }
+
+            val result = verificationDomainService.createVerification(VerificationChannel.PHONE, "010-1234-5678")
+
+            assertEquals(VerificationChannel.PHONE, result.channel)
+            assertEquals("010-1234-5678", result.target)
+            assertEquals(6, result.code.length)
+            assertNotNull(result.expiresAt)
+            verify { verificationAdaptor.save(any()) }
+        }
+
+        @Test
+        fun `1시간 내 발송 횟수가 4회면 정상 발송된다`() {
+            val slot = slot<Verification>()
+            every { verificationAdaptor.countRecent(VerificationChannel.PHONE, "010-1234-5678", any()) } returns 4L
+            every { verificationAdaptor.save(capture(slot)) } answers { slot.captured }
+
+            val result = verificationDomainService.createVerification(VerificationChannel.PHONE, "010-1234-5678")
+
+            assertNotNull(result)
+        }
+
+        @Test
+        fun `1시간 내 발송 횟수가 5회 이상이면 VerificationSendRateLimitException이 발생한다`() {
+            every { verificationAdaptor.countRecent(VerificationChannel.PHONE, "010-1234-5678", any()) } returns 5L
+
+            assertThrows<VerificationSendRateLimitException> {
+                verificationDomainService.createVerification(VerificationChannel.PHONE, "010-1234-5678")
+            }
+        }
+    }
+
+    @Nested
+    inner class VerifyCode {
+        @Test
+        fun `올바른 코드로 인증하면 verified 상태가 된다`() {
+            val verification =
+                Verification(
+                    channel = VerificationChannel.PHONE,
+                    target = "010-1234-5678",
+                    code = "123456",
+                    expiresAt = LocalDateTime.now().plusMinutes(5),
+                )
+
+            every { verificationAdaptor.findLatestOrNull(VerificationChannel.PHONE, "010-1234-5678") } returns verification
+
+            val result = verificationDomainService.verifyCode(VerificationChannel.PHONE, "010-1234-5678", "123456")
+
+            assertEquals(true, result.verified)
+            assertEquals(1, result.attemptCount)
+        }
+
+        @Test
+        fun `인증 요청이 없으면 VerificationNotFoundException이 발생한다`() {
+            every { verificationAdaptor.findLatestOrNull(VerificationChannel.PHONE, "010-0000-0000") } returns null
+
+            assertThrows<VerificationNotFoundException> {
+                verificationDomainService.verifyCode(VerificationChannel.PHONE, "010-0000-0000", "123456")
+            }
+        }
+
+        @Test
+        fun `만료된 인증코드로 인증하면 VerificationExpiredException이 발생한다`() {
+            val verification =
+                Verification(
+                    channel = VerificationChannel.PHONE,
+                    target = "010-1234-5678",
+                    code = "123456",
+                    expiresAt = LocalDateTime.now().minusMinutes(1),
+                )
+
+            every { verificationAdaptor.findLatestOrNull(VerificationChannel.PHONE, "010-1234-5678") } returns verification
+
+            assertThrows<VerificationExpiredException> {
+                verificationDomainService.verifyCode(VerificationChannel.PHONE, "010-1234-5678", "123456")
+            }
+        }
+
+        @Test
+        fun `시도 횟수가 5회 이상이면 VerificationMaxAttemptsException이 발생한다`() {
+            val verification =
+                Verification(
+                    channel = VerificationChannel.PHONE,
+                    target = "010-1234-5678",
+                    code = "123456",
+                    expiresAt = LocalDateTime.now().plusMinutes(5),
+                    attemptCount = 5,
+                )
+
+            every { verificationAdaptor.findLatestOrNull(VerificationChannel.PHONE, "010-1234-5678") } returns verification
+
+            assertThrows<VerificationMaxAttemptsException> {
+                verificationDomainService.verifyCode(VerificationChannel.PHONE, "010-1234-5678", "123456")
+            }
+        }
+
+        @Test
+        fun `잘못된 코드로 인증하면 VerificationCodeMismatchException이 발생하고 시도 횟수가 증가한다`() {
+            val verification =
+                Verification(
+                    channel = VerificationChannel.PHONE,
+                    target = "010-1234-5678",
+                    code = "123456",
+                    expiresAt = LocalDateTime.now().plusMinutes(5),
+                )
+
+            every { verificationAdaptor.findLatestOrNull(VerificationChannel.PHONE, "010-1234-5678") } returns verification
+
+            assertThrows<VerificationCodeMismatchException> {
+                verificationDomainService.verifyCode(VerificationChannel.PHONE, "010-1234-5678", "999999")
+            }
+            assertEquals(1, verification.attemptCount)
+        }
+    }
+}

--- a/SClass-Infrastructure/build.gradle.kts
+++ b/SClass-Infrastructure/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation("com.google.cloud:google-cloud-storage")
 
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.springframework.boot:spring-boot-starter-mail")
 
     testImplementation("io.mockk:mockk:1.13.16")
 }

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/AlimtalkConfig.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/AlimtalkConfig.kt
@@ -1,0 +1,21 @@
+package com.sclass.infrastructure.message
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+@ConditionalOnProperty(name = ["alimtalk.enabled"], havingValue = "true")
+@EnableConfigurationProperties(AlimtalkProperties::class)
+class AlimtalkConfig {
+    @Bean
+    @Qualifier("alimtalkWebClient")
+    fun alimtalkWebClient(): WebClient =
+        WebClient
+            .builder()
+            .baseUrl("https://sens.apigw.ntruss.com")
+            .build()
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/AlimtalkMessageSender.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/AlimtalkMessageSender.kt
@@ -1,0 +1,84 @@
+package com.sclass.infrastructure.message
+
+import com.sclass.infrastructure.message.dto.AlimtalkRequest
+import com.sclass.infrastructure.message.dto.AlimtalkResponse
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.HttpMethod
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+import java.util.Base64
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+@Component
+@ConditionalOnProperty(name = ["alimtalk.enabled"], havingValue = "true")
+class AlimtalkMessageSender(
+    @param:Qualifier("alimtalkWebClient") private val alimtalkWebClient: WebClient,
+    private val alimtalkProperties: AlimtalkProperties,
+) : MessageSender {
+    companion object {
+        private const val PHONE_VERIFY_TEMPLATE_CODE = "sclassPhoneVerify"
+    }
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun sendVerificationCode(
+        phoneNumber: String,
+        code: String,
+    ) {
+        val timestamp = System.currentTimeMillis().toString()
+        val url = "/alimtalk/v2/services/${alimtalkProperties.serviceId}/messages"
+        val signature = makeSignature(url, timestamp)
+
+        val requestBody =
+            AlimtalkRequest(
+                plusFriendId = alimtalkProperties.plusFriendId,
+                templateCode = PHONE_VERIFY_TEMPLATE_CODE,
+                messages =
+                    listOf(
+                        AlimtalkRequest.Message(
+                            to = phoneNumber.replace("-", ""),
+                            content = "[S-Class] 휴대전화 인증번호 안내\n\n인증번호는 $code 입니다. 5분 이내에 입력해주세요.\n\n본인이 요청하지 않았다면 이 메시지를 무시해주세요.",
+                        ),
+                    ),
+            )
+        val response =
+            alimtalkWebClient
+                .post()
+                .uri(url)
+                .header("Content-Type", "application/json; charset=utf-8")
+                .header("x-ncp-apigw-timestamp", timestamp)
+                .header("x-ncp-iam-access-key", alimtalkProperties.accessKey)
+                .header("x-ncp-apigw-signature-v2", signature)
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono<AlimtalkResponse>()
+                .block()
+
+        if (response?.statusCode != "202") {
+            log.error("[알림톡] 발송 실패: {}", response)
+            throw RuntimeException("알림톡 발송에 실패했습니다")
+        }
+    }
+
+    private fun makeSignature(
+        url: String,
+        timestamp: String,
+    ): String {
+        val message = "${HttpMethod.POST.name()} $url\n$timestamp\n${alimtalkProperties.accessKey}"
+
+        val signingKey =
+            SecretKeySpec(
+                alimtalkProperties.secretKey.toByteArray(Charsets.UTF_8),
+                "HmacSHA256",
+            )
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(signingKey)
+
+        val rawHmac = mac.doFinal(message.toByteArray(Charsets.UTF_8))
+        return Base64.getEncoder().encodeToString(rawHmac)
+    }
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/AlimtalkProperties.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/AlimtalkProperties.kt
@@ -1,0 +1,12 @@
+package com.sclass.infrastructure.message
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "alimtalk")
+data class AlimtalkProperties(
+    val enabled: Boolean = false,
+    val serviceId: String = "",
+    val accessKey: String = "",
+    val secretKey: String = "",
+    val plusFriendId: String = "",
+)

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/LoggingMessageSender.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/LoggingMessageSender.kt
@@ -1,0 +1,18 @@
+package com.sclass.infrastructure.message
+
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+@Component
+@Profile("local", "test")
+class LoggingMessageSender : MessageSender {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun sendVerificationCode(
+        phoneNumber: String,
+        code: String,
+    ) {
+        log.info("[SMS 인증] phoneNumber = $phoneNumber, code = $code")
+    }
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/MessageSender.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/MessageSender.kt
@@ -1,0 +1,8 @@
+package com.sclass.infrastructure.message
+
+interface MessageSender {
+    fun sendVerificationCode(
+        phoneNumber: String,
+        code: String,
+    )
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/dto/AlimtalkRequest.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/dto/AlimtalkRequest.kt
@@ -1,0 +1,12 @@
+package com.sclass.infrastructure.message.dto
+
+data class AlimtalkRequest(
+    val plusFriendId: String,
+    val templateCode: String,
+    val messages: List<Message>,
+) {
+    data class Message(
+        val to: String,
+        val content: String,
+    )
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/dto/AlimtalkResponse.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/dto/AlimtalkResponse.kt
@@ -1,0 +1,12 @@
+package com.sclass.infrastructure.message.dto
+
+data class AlimtalkResponse(
+    val statusCode: String?,
+    val statusName: String?,
+    val messages: List<MessageResult>?,
+) {
+    data class MessageResult(
+        val messageId: String?,
+        val requestId: String?,
+    )
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/GoogleOAuthClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/GoogleOAuthClient.kt
@@ -2,12 +2,13 @@ package com.sclass.infrastructure.oauth.client
 
 import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
 import com.sclass.infrastructure.oauth.dto.OAuthUserInfo
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 
 @Component
 class GoogleOAuthClient(
-    webClient: WebClient,
+    @Qualifier("oAuthWebClient") webClient: WebClient,
 ) : AbstractOAuthClient(webClient) {
     override val provider = "GOOGLE"
     override val userInfoUrl = "https://www.googleapis.com/oauth2/v2/userinfo"

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/KakaoOAuthClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/KakaoOAuthClient.kt
@@ -2,12 +2,13 @@ package com.sclass.infrastructure.oauth.client
 
 import com.sclass.infrastructure.oauth.dto.KakaoUserInfoResponse
 import com.sclass.infrastructure.oauth.dto.OAuthUserInfo
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 
 @Component
 class KakaoOAuthClient(
-    webClient: WebClient,
+    @Qualifier("oAuthWebClient") webClient: WebClient,
 ) : AbstractOAuthClient(webClient) {
     override val provider = "KAKAO"
     override val userInfoUrl = "https://kapi.kakao.com/v2/user/me"

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/config/OAuthConfig.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/config/OAuthConfig.kt
@@ -1,5 +1,6 @@
 package com.sclass.infrastructure.oauth.config
 
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -12,6 +13,7 @@ import java.time.Duration
 @EnableConfigurationProperties(OAuthProperties::class)
 class OAuthConfig {
     @Bean
+    @Qualifier("oAuthWebClient")
     fun oAuthWebClient(): WebClient {
         val httpClient =
             HttpClient


### PR DESCRIPTION
## Summary
- 휴대전화 인증코드 발송(알림톡) 및 검증 API 구현 (Supporters, LMS)
- NCP SENS 알림톡 연동 (`AlimtalkMessageSender`) + 로컬용 `LoggingMessageSender` 분리
- Verification 도메인 (엔티티, 리포지토리, 어댑터, 도메인서비스)
- 인증 완료 시 verification token 발급, 회원가입 시 검증
- 단위 테스트 및 통합 테스트 추가

## Test plan
- [ ] 알림톡 인증코드 발송 API 호출 시 정상 발송 확인
- [ ] 인증코드 검증 성공/실패 케이스 확인
- [ ] 만료된 인증코드 검증 시 에러 응답 확인
- [ ] verification token으로 회원가입 정상 동작 확인
- [ ] 로컬 환경에서 LoggingMessageSender로 동작 확인

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)