### PR TITLE
feat: 수동 빌드/배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,112 @@
+name: Deploy (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 배포 환경
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
+      service:
+        description: 배포 대상 서비스
+        required: true
+        type: choice
+        options:
+          - supporters-api
+          - lms-api
+          - backoffice-api
+          - all
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Build deploy matrix
+        id: set-matrix
+        run: |
+          SERVICE="${{ inputs.service }}"
+
+          if [[ "$SERVICE" == "all" ]]; then
+            matrix='[{"service":"supporters-api","module":"SClass-Api-Supporters"},{"service":"lms-api","module":"SClass-Api-Lms"},{"service":"backoffice-api","module":"SClass-Api-Backoffice"}]'
+          elif [[ "$SERVICE" == "supporters-api" ]]; then
+            matrix='[{"service":"supporters-api","module":"SClass-Api-Supporters"}]'
+          elif [[ "$SERVICE" == "lms-api" ]]; then
+            matrix='[{"service":"lms-api","module":"SClass-Api-Lms"}]'
+          elif [[ "$SERVICE" == "backoffice-api" ]]; then
+            matrix='[{"service":"backoffice-api","module":"SClass-Api-Backoffice"}]'
+          fi
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Deploy targets: $matrix"
+
+  deploy:
+    name: Deploy ${{ matrix.target.service }} (${{ inputs.environment }})
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.setup.outputs.matrix) }}
+    environment:
+      name: ${{ inputs.environment }} / ${{ matrix.target.service }}
+      url: ${{ steps.deploy.outputs.service_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          ECR_REPOSITORY: sclass-${{ inputs.environment }}-${{ matrix.target.service }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build \
+            --build-arg MODULE=${{ matrix.target.module }} \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            .
+
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: Deploy to App Runner
+        id: deploy
+        env:
+          SERVICE_NAME: sclass-${{ inputs.environment }}-${{ matrix.target.service }}
+        run: |
+          SERVICE_ARN=$(aws apprunner list-services \
+            --query "ServiceSummaryList[?ServiceName=='${SERVICE_NAME}'].ServiceArn" \
+            --output text)
+
+          if [ -z "$SERVICE_ARN" ]; then
+            echo "::error::App Runner service '${SERVICE_NAME}' not found"
+            exit 1
+          fi
+
+          SERVICE_URL=$(aws apprunner list-services \
+            --query "ServiceSummaryList[?ServiceName=='${SERVICE_NAME}'].ServiceUrl" \
+            --output text)
+
+          aws apprunner start-deployment --service-arn "$SERVICE_ARN"
+          echo "Deployment triggered for ${SERVICE_NAME} (${SERVICE_ARN})"
+          echo "service_url=https://${SERVICE_URL}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- GitHub Actions UI에서 수동으로 빌드/배포할 수 있는 `deploy.yml` 워크플로우 추가
- 환경(dev/prod)과 서비스(supporters-api/lms-api/backoffice-api/all) 선택 가능
- 배포 스텝은 기존 cd.yml과 동일한 패턴 (Docker build → ECR push → App Runner start-deployment)

## Test plan
- [ ] GitHub Actions UI에서 workflow_dispatch 트리거 확인
- [ ] dev 환경 단일 서비스 배포 테스트
- [ ] all 선택 시 3개 서비스 동시 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)