### PR TITLE
feat: UserRole state 필드 추가 및 선생님 인증 per-platform 리팩토링

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/teacher/controller/TeacherManagementController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/teacher/controller/TeacherManagementController.kt
@@ -3,16 +3,16 @@ package com.sclass.backoffice.teacher.controller
 import com.sclass.backoffice.teacher.dto.CreateTeacherRequest
 import com.sclass.backoffice.teacher.dto.CreateTeacherResponse
 import com.sclass.backoffice.teacher.dto.TeacherPageResponse
-import com.sclass.backoffice.teacher.dto.UpdateVerificationStatusRequest
+import com.sclass.backoffice.teacher.dto.UpdateTeacherStateRequest
 import com.sclass.backoffice.teacher.usecase.CreateTeacherUseCase
 import com.sclass.backoffice.teacher.usecase.GetTeachersUseCase
-import com.sclass.backoffice.teacher.usecase.UpdateTeacherVerificationUseCase
+import com.sclass.backoffice.teacher.usecase.UpdateTeacherStateUseCase
 import com.sclass.common.annotation.CurrentUserId
 import com.sclass.common.dto.ApiResponse
 import com.sclass.domain.domains.teacher.domain.MajorCategory
-import com.sclass.domain.domains.teacher.domain.TeacherVerificationStatus
 import com.sclass.domain.domains.teacher.dto.TeacherSearchCondition
 import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.UserRoleState
 import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
@@ -32,7 +32,7 @@ import java.time.LocalDateTime
 @RequestMapping("/api/v1/teachers")
 class TeacherManagementController(
     private val getTeachersUseCase: GetTeachersUseCase,
-    private val updateTeacherVerificationUseCase: UpdateTeacherVerificationUseCase,
+    private val updateTeacherStateUseCase: UpdateTeacherStateUseCase,
     private val createTeacherUseCase: CreateTeacherUseCase,
 ) {
     @PostMapping
@@ -47,7 +47,7 @@ class TeacherManagementController(
         @RequestParam(required = false) university: String?,
         @RequestParam(required = false) major: String?,
         @RequestParam(required = false) majorCategory: MajorCategory?,
-        @RequestParam(required = false) verificationStatus: TeacherVerificationStatus?,
+        @RequestParam(required = false) state: UserRoleState?,
         @RequestParam(required = false) platform: Platform?,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) submittedAtFrom: LocalDateTime?,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) submittedAtTo: LocalDateTime?,
@@ -63,7 +63,7 @@ class TeacherManagementController(
                     university = university,
                     major = major,
                     majorCategory = majorCategory,
-                    verificationStatus = verificationStatus,
+                    state = state,
                     platform = platform,
                     submittedAtFrom = submittedAtFrom,
                     submittedAtTo = submittedAtTo,
@@ -74,13 +74,13 @@ class TeacherManagementController(
             ),
         )
 
-    @PatchMapping("/{teacherId}/verification-status")
-    fun updateVerificationStatus(
+    @PatchMapping("/{teacherId}/state")
+    fun updateState(
         @PathVariable teacherId: String,
-        @RequestBody request: UpdateVerificationStatusRequest,
+        @RequestBody request: UpdateTeacherStateRequest,
         @CurrentUserId userId: String,
     ): ApiResponse<Nothing> {
-        updateTeacherVerificationUseCase.execute(teacherId, request, userId)
+        updateTeacherStateUseCase.execute(teacherId, request, userId)
         return ApiResponse.success()
     }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/teacher/dto/TeacherListResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/teacher/dto/TeacherListResponse.kt
@@ -2,8 +2,8 @@ package com.sclass.backoffice.teacher.dto
 
 import com.sclass.domain.domains.teacher.domain.MajorCategory
 import com.sclass.domain.domains.teacher.domain.Teacher
-import com.sclass.domain.domains.teacher.domain.TeacherVerificationStatus
 import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.UserRoleState
 import java.time.LocalDateTime
 
 data class TeacherListResponse(
@@ -14,7 +14,7 @@ data class TeacherListResponse(
     val university: String?,
     val major: String?,
     val majorCategory: MajorCategory?,
-    val verificationStatus: TeacherVerificationStatus,
+    val state: UserRoleState,
     val submittedAt: LocalDateTime?,
     val createdAt: LocalDateTime,
 ) {
@@ -22,6 +22,7 @@ data class TeacherListResponse(
         fun from(
             teacher: Teacher,
             platform: Platform,
+            state: UserRoleState,
         ): TeacherListResponse =
             TeacherListResponse(
                 id = teacher.id,
@@ -31,7 +32,7 @@ data class TeacherListResponse(
                 university = teacher.education?.university,
                 major = teacher.education?.major,
                 majorCategory = teacher.education?.majorCategory,
-                verificationStatus = teacher.verification?.verificationStatus ?: TeacherVerificationStatus.DRAFT,
+                state = state,
                 submittedAt = teacher.verification?.submittedAt,
                 createdAt = teacher.createdAt,
             )

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/teacher/dto/UpdateTeacherStateRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/teacher/dto/UpdateTeacherStateRequest.kt
@@ -1,25 +1,27 @@
 package com.sclass.backoffice.teacher.dto
 
-import com.sclass.domain.domains.teacher.domain.TeacherVerificationStatus
 import com.sclass.domain.domains.teacher.exception.TeacherInvalidVerificationStatusException
 import com.sclass.domain.domains.teacher.exception.TeacherRejectReasonRequiredException
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.UserRoleState
 
-data class UpdateVerificationStatusRequest(
-    val status: TeacherVerificationStatus,
+data class UpdateTeacherStateRequest(
+    val state: UserRoleState,
+    val platform: Platform,
     val reason: String? = null,
 ) {
     val isApproved: Boolean
-        get() = status == TeacherVerificationStatus.APPROVED
+        get() = state == UserRoleState.APPROVED
 
     val requireReason: String
         get() = checkNotNull(reason)
 
     init {
-        if (status != TeacherVerificationStatus.APPROVED && status != TeacherVerificationStatus.REJECTED) {
+        if (state != UserRoleState.APPROVED && state != UserRoleState.REJECTED) {
             throw TeacherInvalidVerificationStatusException()
         }
 
-        if (status == TeacherVerificationStatus.REJECTED && reason == null) {
+        if (state == UserRoleState.REJECTED && reason == null) {
             throw TeacherRejectReasonRequiredException()
         }
     }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/teacher/usecase/GetTeachersUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/teacher/usecase/GetTeachersUseCase.kt
@@ -19,7 +19,7 @@ class GetTeachersUseCase(
     ): TeacherPageResponse {
         val page = teacherAdaptor.searchTeachers(condition, pageable)
         return TeacherPageResponse(
-            content = page.content.map { TeacherListResponse.from(it.teacher, it.platform) },
+            content = page.content.map { TeacherListResponse.from(it.teacher, it.platform, it.state) },
             totalElements = page.totalElements,
             totalPages = page.totalPages,
             currentPage = page.number,

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/teacher/usecase/UpdateTeacherStateUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/teacher/usecase/UpdateTeacherStateUseCase.kt
@@ -1,27 +1,27 @@
 package com.sclass.backoffice.teacher.usecase
 
-import com.sclass.backoffice.teacher.dto.UpdateVerificationStatusRequest
+import com.sclass.backoffice.teacher.dto.UpdateTeacherStateRequest
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.teacher.adaptor.TeacherAdaptor
 import com.sclass.domain.domains.teacher.service.TeacherDomainService
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-class UpdateTeacherVerificationUseCase(
+class UpdateTeacherStateUseCase(
     private val teacherAdaptor: TeacherAdaptor,
     private val teacherDomainService: TeacherDomainService,
 ) {
     @Transactional
     fun execute(
         teacherId: String,
-        request: UpdateVerificationStatusRequest,
+        request: UpdateTeacherStateRequest,
         userId: String,
     ) {
         val teacher = teacherAdaptor.findById(teacherId)
         if (request.isApproved) {
-            teacherDomainService.approve(teacher, userId)
+            teacherDomainService.approve(teacher, request.platform, userId)
         } else {
-            teacherDomainService.reject(teacher, request.requireReason)
+            teacherDomainService.reject(teacher, request.platform, request.requireReason)
         }
     }
 }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/teacher/controller/TeacherManagementControllerIntegrationTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/teacher/controller/TeacherManagementControllerIntegrationTest.kt
@@ -6,11 +6,15 @@ import com.sclass.backoffice.config.ApiIntegrationTest
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.common.jwt.JwtTokenProvider
 import com.sclass.domain.domains.teacher.domain.Teacher
-import com.sclass.domain.domains.teacher.domain.TeacherVerificationStatus
 import com.sclass.domain.domains.teacher.repository.TeacherRepository
 import com.sclass.domain.domains.user.domain.AuthProvider
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.Role
 import com.sclass.domain.domains.user.domain.User
+import com.sclass.domain.domains.user.domain.UserRole
+import com.sclass.domain.domains.user.domain.UserRoleState
 import com.sclass.domain.domains.user.repository.UserRepository
+import com.sclass.domain.domains.user.repository.UserRoleRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -31,6 +35,9 @@ class TeacherManagementControllerIntegrationTest {
     private lateinit var userRepository: UserRepository
 
     @Autowired
+    private lateinit var userRoleRepository: UserRoleRepository
+
+    @Autowired
     private lateinit var teacherRepository: TeacherRepository
 
     @Autowired
@@ -43,10 +50,12 @@ class TeacherManagementControllerIntegrationTest {
 
     private lateinit var adminToken: String
     private lateinit var teacher: Teacher
+    private lateinit var teacherUser: User
 
     @BeforeEach
     fun setUp() {
         teacherRepository.deleteAll()
+        userRoleRepository.deleteAll()
         userRepository.deleteAll()
 
         val adminUser =
@@ -59,7 +68,7 @@ class TeacherManagementControllerIntegrationTest {
                 ),
             )
 
-        val teacherUser =
+        teacherUser =
             userRepository.save(
                 User(
                     email = "teacher@sclass.com",
@@ -80,14 +89,15 @@ class TeacherManagementControllerIntegrationTest {
         adminToken = "Bearer ${aesTokenEncryptor.encrypt(jwt)}"
     }
 
-    private fun submitTeacherForPending(): Teacher {
-        teacher.verification =
-            com.sclass.domain.domains.teacher.domain.TeacherVerification(
-                verificationStatus = TeacherVerificationStatus.PENDING,
-                submittedAt = java.time.LocalDateTime.now(),
-            )
-        return teacherRepository.save(teacher)
-    }
+    private fun createTeacherRole(state: UserRoleState): UserRole =
+        userRoleRepository.save(
+            UserRole(
+                userId = teacherUser.id,
+                platform = Platform.SUPPORTERS,
+                role = Role.TEACHER,
+                state = state,
+            ),
+        )
 
     @Nested
     inner class CreateTeacher {
@@ -172,16 +182,20 @@ class TeacherManagementControllerIntegrationTest {
     }
 
     @Nested
-    inner class UpdateVerificationStatus {
+    inner class UpdateState {
         @Test
         fun `APPROVED 요청 시 200을 반환한다`() {
-            submitTeacherForPending()
+            createTeacherRole(UserRoleState.PENDING)
 
-            val body = mapOf("status" to "APPROVED")
+            val body =
+                mapOf(
+                    "state" to "APPROVED",
+                    "platform" to "SUPPORTERS",
+                )
 
             mockMvc
                 .perform(
-                    patch("/api/v1/teachers/${teacher.id}/verification-status")
+                    patch("/api/v1/teachers/${teacher.id}/state")
                         .header("Authorization", adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)),
@@ -191,13 +205,18 @@ class TeacherManagementControllerIntegrationTest {
 
         @Test
         fun `REJECTED 요청 시 reason과 함께 200을 반환한다`() {
-            submitTeacherForPending()
+            createTeacherRole(UserRoleState.PENDING)
 
-            val body = mapOf("status" to "REJECTED", "reason" to "서류 미비")
+            val body =
+                mapOf(
+                    "state" to "REJECTED",
+                    "platform" to "SUPPORTERS",
+                    "reason" to "서류 미비",
+                )
 
             mockMvc
                 .perform(
-                    patch("/api/v1/teachers/${teacher.id}/verification-status")
+                    patch("/api/v1/teachers/${teacher.id}/state")
                         .header("Authorization", adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)),
@@ -207,13 +226,17 @@ class TeacherManagementControllerIntegrationTest {
 
         @Test
         fun `REJECTED 요청 시 reason이 없으면 400을 반환한다`() {
-            submitTeacherForPending()
+            createTeacherRole(UserRoleState.PENDING)
 
-            val body = mapOf("status" to "REJECTED")
+            val body =
+                mapOf(
+                    "state" to "REJECTED",
+                    "platform" to "SUPPORTERS",
+                )
 
             mockMvc
                 .perform(
-                    patch("/api/v1/teachers/${teacher.id}/verification-status")
+                    patch("/api/v1/teachers/${teacher.id}/state")
                         .header("Authorization", adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)),
@@ -224,13 +247,17 @@ class TeacherManagementControllerIntegrationTest {
 
         @Test
         fun `DRAFT 상태는 허용되지 않아 400을 반환한다`() {
-            submitTeacherForPending()
+            createTeacherRole(UserRoleState.PENDING)
 
-            val body = mapOf("status" to "DRAFT")
+            val body =
+                mapOf(
+                    "state" to "DRAFT",
+                    "platform" to "SUPPORTERS",
+                )
 
             mockMvc
                 .perform(
-                    patch("/api/v1/teachers/${teacher.id}/verification-status")
+                    patch("/api/v1/teachers/${teacher.id}/state")
                         .header("Authorization", adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)),
@@ -241,13 +268,17 @@ class TeacherManagementControllerIntegrationTest {
 
         @Test
         fun `PENDING 상태는 허용되지 않아 400을 반환한다`() {
-            submitTeacherForPending()
+            createTeacherRole(UserRoleState.PENDING)
 
-            val body = mapOf("status" to "PENDING")
+            val body =
+                mapOf(
+                    "state" to "PENDING",
+                    "platform" to "SUPPORTERS",
+                )
 
             mockMvc
                 .perform(
-                    patch("/api/v1/teachers/${teacher.id}/verification-status")
+                    patch("/api/v1/teachers/${teacher.id}/state")
                         .header("Authorization", adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)),
@@ -258,13 +289,17 @@ class TeacherManagementControllerIntegrationTest {
 
         @Test
         fun `인증 토큰이 없으면 401을 반환한다`() {
-            submitTeacherForPending()
+            createTeacherRole(UserRoleState.PENDING)
 
-            val body = mapOf("status" to "APPROVED")
+            val body =
+                mapOf(
+                    "state" to "APPROVED",
+                    "platform" to "SUPPORTERS",
+                )
 
             mockMvc
                 .perform(
-                    patch("/api/v1/teachers/${teacher.id}/verification-status")
+                    patch("/api/v1/teachers/${teacher.id}/state")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)),
                 ).andExpect(status().isUnauthorized)

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/teacher/dto/UpdateTeacherStateRequestTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/teacher/dto/UpdateTeacherStateRequestTest.kt
@@ -1,8 +1,9 @@
 package com.sclass.backoffice.teacher.dto
 
-import com.sclass.domain.domains.teacher.domain.TeacherVerificationStatus
 import com.sclass.domain.domains.teacher.exception.TeacherInvalidVerificationStatusException
 import com.sclass.domain.domains.teacher.exception.TeacherRejectReasonRequiredException
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.UserRoleState
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -10,14 +11,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-class UpdateVerificationStatusRequestTest {
+class UpdateTeacherStateRequestTest {
     @Nested
-    inner class StatusValidation {
+    inner class StateValidation {
         @Test
         fun `APPROVED 상태로 생성할 수 있다`() {
             val request =
-                UpdateVerificationStatusRequest(
-                    status = TeacherVerificationStatus.APPROVED,
+                UpdateTeacherStateRequest(
+                    state = UserRoleState.APPROVED,
+                    platform = Platform.SUPPORTERS,
                 )
 
             assertTrue(request.isApproved)
@@ -26,8 +28,9 @@ class UpdateVerificationStatusRequestTest {
         @Test
         fun `REJECTED 상태로 생성할 수 있다`() {
             val request =
-                UpdateVerificationStatusRequest(
-                    status = TeacherVerificationStatus.REJECTED,
+                UpdateTeacherStateRequest(
+                    state = UserRoleState.REJECTED,
+                    platform = Platform.SUPPORTERS,
                     reason = "서류 미비",
                 )
 
@@ -37,14 +40,20 @@ class UpdateVerificationStatusRequestTest {
         @Test
         fun `DRAFT 상태는 허용되지 않는다`() {
             assertThrows<TeacherInvalidVerificationStatusException> {
-                UpdateVerificationStatusRequest(status = TeacherVerificationStatus.DRAFT)
+                UpdateTeacherStateRequest(
+                    state = UserRoleState.DRAFT,
+                    platform = Platform.SUPPORTERS,
+                )
             }
         }
 
         @Test
         fun `PENDING 상태는 허용되지 않는다`() {
             assertThrows<TeacherInvalidVerificationStatusException> {
-                UpdateVerificationStatusRequest(status = TeacherVerificationStatus.PENDING)
+                UpdateTeacherStateRequest(
+                    state = UserRoleState.PENDING,
+                    platform = Platform.SUPPORTERS,
+                )
             }
         }
     }
@@ -54,8 +63,9 @@ class UpdateVerificationStatusRequestTest {
         @Test
         fun `REJECTED 상태에서 reason이 없으면 예외가 발생한다`() {
             assertThrows<TeacherRejectReasonRequiredException> {
-                UpdateVerificationStatusRequest(
-                    status = TeacherVerificationStatus.REJECTED,
+                UpdateTeacherStateRequest(
+                    state = UserRoleState.REJECTED,
+                    platform = Platform.SUPPORTERS,
                     reason = null,
                 )
             }
@@ -64,8 +74,9 @@ class UpdateVerificationStatusRequestTest {
         @Test
         fun `REJECTED 상태에서 reason이 있으면 requireReason으로 접근할 수 있다`() {
             val request =
-                UpdateVerificationStatusRequest(
-                    status = TeacherVerificationStatus.REJECTED,
+                UpdateTeacherStateRequest(
+                    state = UserRoleState.REJECTED,
+                    platform = Platform.SUPPORTERS,
                     reason = "서류 미비",
                 )
 

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/teacher/usecase/UpdateTeacherStateUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/teacher/usecase/UpdateTeacherStateUseCaseTest.kt
@@ -1,10 +1,11 @@
 package com.sclass.backoffice.teacher.usecase
 
-import com.sclass.backoffice.teacher.dto.UpdateVerificationStatusRequest
+import com.sclass.backoffice.teacher.dto.UpdateTeacherStateRequest
 import com.sclass.domain.domains.teacher.adaptor.TeacherAdaptor
 import com.sclass.domain.domains.teacher.domain.Teacher
-import com.sclass.domain.domains.teacher.domain.TeacherVerificationStatus
 import com.sclass.domain.domains.teacher.service.TeacherDomainService
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.UserRoleState
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -12,10 +13,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-class UpdateTeacherVerificationUseCaseTest {
+class UpdateTeacherStateUseCaseTest {
     private lateinit var teacherAdaptor: TeacherAdaptor
     private lateinit var teacherDomainService: TeacherDomainService
-    private lateinit var useCase: UpdateTeacherVerificationUseCase
+    private lateinit var useCase: UpdateTeacherStateUseCase
 
     private val teacherId = "teacher-id"
     private val userId = "admin-user-id"
@@ -24,7 +25,7 @@ class UpdateTeacherVerificationUseCaseTest {
     fun setUp() {
         teacherAdaptor = mockk()
         teacherDomainService = mockk(relaxed = true)
-        useCase = UpdateTeacherVerificationUseCase(teacherAdaptor, teacherDomainService)
+        useCase = UpdateTeacherStateUseCase(teacherAdaptor, teacherDomainService)
     }
 
     @Nested
@@ -35,13 +36,14 @@ class UpdateTeacherVerificationUseCaseTest {
             every { teacherAdaptor.findById(teacherId) } returns teacher
 
             val request =
-                UpdateVerificationStatusRequest(
-                    status = TeacherVerificationStatus.APPROVED,
+                UpdateTeacherStateRequest(
+                    state = UserRoleState.APPROVED,
+                    platform = Platform.SUPPORTERS,
                 )
 
             useCase.execute(teacherId, request, userId)
 
-            verify { teacherDomainService.approve(teacher, userId) }
+            verify { teacherDomainService.approve(teacher, Platform.SUPPORTERS, userId) }
         }
     }
 
@@ -53,14 +55,15 @@ class UpdateTeacherVerificationUseCaseTest {
             every { teacherAdaptor.findById(teacherId) } returns teacher
 
             val request =
-                UpdateVerificationStatusRequest(
-                    status = TeacherVerificationStatus.REJECTED,
+                UpdateTeacherStateRequest(
+                    state = UserRoleState.REJECTED,
+                    platform = Platform.SUPPORTERS,
                     reason = "서류 미비",
                 )
 
             useCase.execute(teacherId, request, userId)
 
-            verify { teacherDomainService.reject(teacher, "서류 미비") }
+            verify { teacherDomainService.reject(teacher, Platform.SUPPORTERS, "서류 미비") }
         }
     }
 }

--- a/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/usecase/OAuthLoginUseCase.kt
+++ b/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/usecase/OAuthLoginUseCase.kt
@@ -35,6 +35,7 @@ class OAuthLoginUseCase(
             )
 
         if (user != null) {
+            userService.activateIfApproved(user.id, request.platform, request.role)
             val tokens = tokenService.issueTokens(user.id, request.role, request.platform)
             return OAuthLoginResponse(
                 isNewUser = false,

--- a/SClass-Api-Lms/src/test/kotlin/com/sclass/lms/auth/usecase/OAuthLoginUseCaseTest.kt
+++ b/SClass-Api-Lms/src/test/kotlin/com/sclass/lms/auth/usecase/OAuthLoginUseCaseTest.kt
@@ -15,6 +15,7 @@ import com.sclass.infrastructure.oauth.client.OAuthClient
 import com.sclass.infrastructure.oauth.dto.OAuthUserInfo
 import com.sclass.lms.auth.dto.OAuthCompleteSignupRequest
 import com.sclass.lms.auth.dto.OAuthLoginRequest
+import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -61,6 +62,7 @@ class OAuthLoginUseCaseTest {
         every { oAuthClient.fetchUserInfo("oauth-access-token") } returns userInfo
         every { userService.findByOAuthOrNull("oauth-id", AuthProvider.GOOGLE) } returns user
         every { userService.ensureUserRole("user-id", Platform.LMS, Role.ADMIN) } just runs
+        every { userService.activateIfApproved("user-id", Platform.LMS, Role.ADMIN) } just Runs
         every { tokenService.issueTokens("user-id", Role.ADMIN, Platform.LMS) } returns tokenResult
 
         val result = useCase.login(request)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/LoginUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/LoginUseCase.kt
@@ -23,6 +23,8 @@ class LoginUseCase(
                 request.role,
             )
 
+        userService.activateIfApproved(user.id, Platform.SUPPORTERS, request.role)
+
         val tokens = tokenService.issueTokens(user.id, request.role, Platform.SUPPORTERS)
         return TokenResponse(
             accessToken = tokens.accessToken,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/OAuthLoginUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/OAuthLoginUseCase.kt
@@ -41,6 +41,7 @@ class OAuthLoginUseCase(
             )
 
         if (user != null) {
+            userService.activateIfApproved(user.id, request.platform, request.role)
             val tokens = tokenService.issueTokens(user.id, request.role, request.platform)
             return OAuthLoginResponse(
                 isNewUser = false,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/teacher/dto/TeacherProfileResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/teacher/dto/TeacherProfileResponse.kt
@@ -2,7 +2,7 @@ package com.sclass.supporters.teacher.dto
 
 import com.sclass.domain.domains.teacher.domain.MajorCategory
 import com.sclass.domain.domains.teacher.domain.Teacher
-import com.sclass.domain.domains.teacher.domain.TeacherVerificationStatus
+import com.sclass.domain.domains.user.domain.UserRoleState
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -18,7 +18,7 @@ data class TeacherProfileResponse(
     val highSchool: String?,
     val address: String?,
     val residentNumber: String?,
-    val verificationStatus: TeacherVerificationStatus,
+    val state: UserRoleState,
     val submittedAt: LocalDateTime?,
     val rejectionReason: String?,
     val documents: List<TeacherDocumentResponse>,
@@ -26,6 +26,7 @@ data class TeacherProfileResponse(
     companion object {
         fun from(
             teacher: Teacher,
+            state: UserRoleState,
             documents: List<TeacherDocumentResponse>,
         ): TeacherProfileResponse =
             TeacherProfileResponse(
@@ -40,9 +41,9 @@ data class TeacherProfileResponse(
                 highSchool = teacher.education.highSchool,
                 address = teacher.personalInfo.address,
                 residentNumber = teacher.personalInfo.residentNumber,
-                verificationStatus = teacher.verification.verificationStatus,
-                submittedAt = teacher.verification.submittedAt,
-                rejectionReason = teacher.verification.rejectionReason,
+                state = state,
+                submittedAt = teacher.verification?.submittedAt,
+                rejectionReason = teacher.verification?.rejectionReason,
                 documents = documents,
             )
     }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/teacher/usecase/GetMyTeacherProfileUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/teacher/usecase/GetMyTeacherProfileUseCase.kt
@@ -3,6 +3,10 @@ package com.sclass.supporters.teacher.usecase
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.teacher.adaptor.TeacherAdaptor
 import com.sclass.domain.domains.teacher.adaptor.TeacherDocumentAdaptor
+import com.sclass.domain.domains.user.adaptor.UserRoleAdaptor
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.domain.domains.user.exception.RoleNotFoundException
 import com.sclass.supporters.teacher.dto.TeacherDocumentResponse
 import com.sclass.supporters.teacher.dto.TeacherProfileResponse
 import org.springframework.transaction.annotation.Transactional
@@ -11,13 +15,18 @@ import org.springframework.transaction.annotation.Transactional
 class GetMyTeacherProfileUseCase(
     private val teacherAdaptor: TeacherAdaptor,
     private val teacherDocumentAdaptor: TeacherDocumentAdaptor,
+    private val userRoleAdaptor: UserRoleAdaptor,
 ) {
     @Transactional(readOnly = true)
     fun execute(userId: String): TeacherProfileResponse {
         val teacher = teacherAdaptor.findByUserId(userId)
         val documents = teacherDocumentAdaptor.findAllByTeacherId(teacher.id)
+        val userRole =
+            userRoleAdaptor.findByUserIdAndPlatformAndRole(userId, Platform.SUPPORTERS, Role.TEACHER)
+                ?: throw RoleNotFoundException()
         return TeacherProfileResponse.from(
             teacher = teacher,
+            state = userRole.state,
             documents = documents.map { TeacherDocumentResponse.from(it) },
         )
     }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/teacher/usecase/SubmitTeacherVerificationUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/teacher/usecase/SubmitTeacherVerificationUseCase.kt
@@ -4,6 +4,10 @@ import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.teacher.adaptor.TeacherAdaptor
 import com.sclass.domain.domains.teacher.adaptor.TeacherDocumentAdaptor
 import com.sclass.domain.domains.teacher.service.TeacherDomainService
+import com.sclass.domain.domains.user.adaptor.UserRoleAdaptor
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.domain.domains.user.exception.RoleNotFoundException
 import com.sclass.supporters.teacher.dto.TeacherDocumentResponse
 import com.sclass.supporters.teacher.dto.TeacherProfileResponse
 import org.springframework.transaction.annotation.Transactional
@@ -13,14 +17,19 @@ class SubmitTeacherVerificationUseCase(
     private val teacherAdaptor: TeacherAdaptor,
     private val teacherDomainService: TeacherDomainService,
     private val teacherDocumentAdaptor: TeacherDocumentAdaptor,
+    private val userRoleAdaptor: UserRoleAdaptor,
 ) {
     @Transactional
     fun execute(userId: String): TeacherProfileResponse {
         val teacher = teacherAdaptor.findByUserId(userId)
-        val submitted = teacherDomainService.submitForVerification(teacher)
+        val submitted = teacherDomainService.submitForVerification(teacher, Platform.SUPPORTERS)
         val documents = teacherDocumentAdaptor.findAllByTeacherId(submitted.id)
+        val userRole =
+            userRoleAdaptor.findByUserIdAndPlatformAndRole(userId, Platform.SUPPORTERS, Role.TEACHER)
+                ?: throw RoleNotFoundException()
         return TeacherProfileResponse.from(
             teacher = submitted,
+            state = userRole.state,
             documents = documents.map { TeacherDocumentResponse.from(it) },
         )
     }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/teacher/usecase/UpdateTeacherProfileUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/teacher/usecase/UpdateTeacherProfileUseCase.kt
@@ -4,6 +4,10 @@ import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.teacher.adaptor.TeacherAdaptor
 import com.sclass.domain.domains.teacher.adaptor.TeacherDocumentAdaptor
 import com.sclass.domain.domains.teacher.service.TeacherDomainService
+import com.sclass.domain.domains.user.adaptor.UserRoleAdaptor
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.domain.domains.user.exception.RoleNotFoundException
 import com.sclass.supporters.teacher.dto.TeacherDocumentResponse
 import com.sclass.supporters.teacher.dto.TeacherProfileResponse
 import com.sclass.supporters.teacher.dto.UpdateTeacherProfileRequest
@@ -14,6 +18,7 @@ class UpdateTeacherProfileUseCase(
     private val teacherAdaptor: TeacherAdaptor,
     private val teacherDomainService: TeacherDomainService,
     private val teacherDocumentAdaptor: TeacherDocumentAdaptor,
+    private val userRoleAdaptor: UserRoleAdaptor,
 ) {
     @Transactional
     fun execute(
@@ -24,6 +29,7 @@ class UpdateTeacherProfileUseCase(
         val updated =
             teacherDomainService.updateProfile(
                 teacher = teacher,
+                platform = Platform.SUPPORTERS,
                 birthDate = request.birthDate,
                 selfIntroduction = request.selfIntroduction,
                 majorCategory = request.majorCategory,
@@ -34,8 +40,12 @@ class UpdateTeacherProfileUseCase(
                 residentNumber = request.residentNumber,
             )
         val documents = teacherDocumentAdaptor.findAllByTeacherId(updated.id)
+        val userRole =
+            userRoleAdaptor.findByUserIdAndPlatformAndRole(userId, Platform.SUPPORTERS, Role.TEACHER)
+                ?: throw RoleNotFoundException()
         return TeacherProfileResponse.from(
             teacher = updated,
+            state = userRole.state,
             documents = documents.map { TeacherDocumentResponse.from(it) },
         )
     }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/OAuthLoginUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/OAuthLoginUseCaseTest.kt
@@ -17,6 +17,7 @@ import com.sclass.infrastructure.oauth.client.OAuthClient
 import com.sclass.infrastructure.oauth.dto.OAuthUserInfo
 import com.sclass.supporters.auth.dto.OAuthCompleteSignupRequest
 import com.sclass.supporters.auth.dto.OAuthLoginRequest
+import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -67,6 +68,7 @@ class OAuthLoginUseCaseTest {
         every { oAuthClient.fetchUserInfo("oauth-access-token") } returns userInfo
         every { userService.findByOAuthOrNull("oauth-id", AuthProvider.GOOGLE) } returns user
         every { userService.ensureUserRole("user-id", Platform.SUPPORTERS, Role.STUDENT) } just runs
+        every { userService.activateIfApproved("user-id", Platform.SUPPORTERS, Role.STUDENT) } just Runs
         every { tokenService.issueTokens("user-id", Role.STUDENT, Platform.SUPPORTERS) } returns tokenResult
 
         val result = useCase.login(request)
@@ -94,6 +96,7 @@ class OAuthLoginUseCaseTest {
         every { oAuthClient.fetchUserInfo("oauth-access-token") } returns userInfo
         every { userService.findByOAuthOrNull("oauth-id", AuthProvider.GOOGLE) } returns user
         every { userService.ensureUserRole("user-id", Platform.SUPPORTERS, Role.TEACHER) } just runs
+        every { userService.activateIfApproved("user-id", Platform.SUPPORTERS, Role.TEACHER) } just Runs
         every { tokenService.issueTokens("user-id", Role.TEACHER, Platform.SUPPORTERS) } returns tokenResult
 
         useCase.login(request)
@@ -125,6 +128,7 @@ class OAuthLoginUseCaseTest {
                 role = Role.STUDENT,
             )
         } returns user
+        every { userService.activateIfApproved("linked-user-id", Platform.SUPPORTERS, Role.STUDENT) } just Runs
         every { tokenService.issueTokens("linked-user-id", Role.STUDENT, Platform.SUPPORTERS) } returns tokenResult
 
         val result = useCase.login(request)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/adaptor/TeacherAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/adaptor/TeacherAdaptor.kt
@@ -2,7 +2,6 @@ package com.sclass.domain.domains.teacher.adaptor
 
 import com.sclass.common.annotation.Adaptor
 import com.sclass.domain.domains.teacher.domain.Teacher
-import com.sclass.domain.domains.teacher.domain.TeacherVerificationStatus
 import com.sclass.domain.domains.teacher.dto.TeacherSearchCondition
 import com.sclass.domain.domains.teacher.dto.TeacherWithPlatform
 import com.sclass.domain.domains.teacher.exception.TeacherNotFoundException
@@ -25,11 +24,6 @@ class TeacherAdaptor(
     fun existsByUserId(userId: String): Boolean = teacherRepository.existsByUserId(userId)
 
     fun save(teacher: Teacher): Teacher = teacherRepository.save(teacher)
-
-    fun findAllByVerificationStatus(
-        status: TeacherVerificationStatus,
-        pageable: Pageable,
-    ): Page<Teacher> = teacherRepository.findAllByStatus(status, pageable)
 
     fun searchTeachers(
         condition: TeacherSearchCondition,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/domain/Teacher.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/domain/Teacher.kt
@@ -3,11 +3,11 @@ package com.sclass.domain.domains.teacher.domain
 import com.sclass.domain.common.model.BaseTimeEntity
 import com.sclass.domain.common.vo.Ulid
 import com.sclass.domain.domains.teacher.exception.TeacherNotEditableException
-import com.sclass.domain.domains.teacher.exception.TeacherNotPendingException
 import com.sclass.domain.domains.teacher.exception.TeacherNotSubmittableException
 import com.sclass.domain.domains.teacher.exception.TeacherProfileIncompleteException
 import com.sclass.domain.domains.teacher.exception.TeacherRequiredDocumentsMissingException
 import com.sclass.domain.domains.user.domain.User
+import com.sclass.domain.domains.user.domain.UserRoleState
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
@@ -50,6 +50,7 @@ class Teacher(
     var verification: TeacherVerification = TeacherVerification(),
 ) : BaseTimeEntity() {
     fun updateProfile(
+        state: UserRoleState,
         birthDate: LocalDate,
         selfIntroduction: String?,
         majorCategory: MajorCategory,
@@ -59,8 +60,7 @@ class Teacher(
         address: String,
         residentNumber: String,
     ) {
-        val status = verification.verificationStatus
-        if (status != TeacherVerificationStatus.DRAFT && status != TeacherVerificationStatus.REJECTED) {
+        if (state != UserRoleState.DRAFT && state != UserRoleState.REJECTED) {
             throw TeacherNotEditableException()
         }
         profile = TeacherProfile(birthDate = birthDate, selfIntroduction = selfIntroduction)
@@ -79,47 +79,35 @@ class Teacher(
             )
     }
 
-    fun submitForVerification(
+    fun recordSubmission(
         documents: List<TeacherDocument>,
+        state: UserRoleState,
         now: LocalDateTime = LocalDateTime.now(),
     ) {
-        val status = verification.verificationStatus
-        if (status != TeacherVerificationStatus.DRAFT && status != TeacherVerificationStatus.REJECTED) {
+        if (state != UserRoleState.DRAFT && state != UserRoleState.REJECTED) {
             throw TeacherNotSubmittableException()
         }
         validateProfileComplete()
         validateRequiredDocuments(documents)
-        verification =
-            TeacherVerification(
-                verificationStatus = TeacherVerificationStatus.PENDING,
-                submittedAt = now,
-            )
+        verification = TeacherVerification(submittedAt = now)
     }
 
-    fun approve(
+    fun recordApproval(
         approvedBy: String,
         now: LocalDateTime = LocalDateTime.now(),
     ) {
-        if (verification.verificationStatus != TeacherVerificationStatus.PENDING) {
-            throw TeacherNotPendingException()
-        }
         verification =
             TeacherVerification(
-                verificationStatus = TeacherVerificationStatus.APPROVED,
-                submittedAt = verification.submittedAt,
+                submittedAt = verification?.submittedAt,
                 approvedAt = now,
                 approvedBy = approvedBy,
             )
     }
 
-    fun reject(reason: String) {
-        if (verification.verificationStatus != TeacherVerificationStatus.PENDING) {
-            throw TeacherNotPendingException()
-        }
+    fun recordRejection(reason: String) {
         verification =
             TeacherVerification(
-                verificationStatus = TeacherVerificationStatus.REJECTED,
-                submittedAt = verification.submittedAt,
+                submittedAt = verification?.submittedAt,
                 rejectionReason = reason,
             )
     }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/domain/TeacherVerification.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/domain/TeacherVerification.kt
@@ -2,16 +2,10 @@ package com.sclass.domain.domains.teacher.domain
 
 import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
 import java.time.LocalDateTime
 
 @Embeddable
 data class TeacherVerification(
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    val verificationStatus: TeacherVerificationStatus = TeacherVerificationStatus.DRAFT,
-
     @Column
     val submittedAt: LocalDateTime? = null,
 

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/domain/TeacherVerificationStatus.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/domain/TeacherVerificationStatus.kt
@@ -1,8 +1,0 @@
-package com.sclass.domain.domains.teacher.domain
-
-enum class TeacherVerificationStatus {
-    DRAFT,
-    PENDING,
-    APPROVED,
-    REJECTED,
-}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/dto/TeacherSearchCondition.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/dto/TeacherSearchCondition.kt
@@ -1,8 +1,8 @@
 package com.sclass.domain.domains.teacher.dto
 
 import com.sclass.domain.domains.teacher.domain.MajorCategory
-import com.sclass.domain.domains.teacher.domain.TeacherVerificationStatus
 import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.UserRoleState
 import java.time.LocalDateTime
 
 data class TeacherSearchCondition(
@@ -11,7 +11,7 @@ data class TeacherSearchCondition(
     val university: String? = null,
     val major: String? = null,
     val majorCategory: MajorCategory? = null,
-    val verificationStatus: TeacherVerificationStatus? = null,
+    val state: UserRoleState? = null,
     val platform: Platform? = null,
     val submittedAtFrom: LocalDateTime? = null,
     val submittedAtTo: LocalDateTime? = null,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/dto/TeacherWithPlatform.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/dto/TeacherWithPlatform.kt
@@ -2,8 +2,10 @@ package com.sclass.domain.domains.teacher.dto
 
 import com.sclass.domain.domains.teacher.domain.Teacher
 import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.UserRoleState
 
 data class TeacherWithPlatform(
     val teacher: Teacher,
     val platform: Platform,
+    val state: UserRoleState,
 )

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/repository/TeacherCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/repository/TeacherCustomRepositoryImpl.kt
@@ -4,12 +4,12 @@ import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.sclass.domain.domains.teacher.domain.MajorCategory
 import com.sclass.domain.domains.teacher.domain.QTeacher.teacher
-import com.sclass.domain.domains.teacher.domain.TeacherVerificationStatus
 import com.sclass.domain.domains.teacher.dto.TeacherSearchCondition
 import com.sclass.domain.domains.teacher.dto.TeacherWithPlatform
 import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.QUser.user
 import com.sclass.domain.domains.user.domain.QUserRole.userRole
+import com.sclass.domain.domains.user.domain.UserRoleState
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -24,7 +24,7 @@ class TeacherCustomRepositoryImpl(
     ): Page<TeacherWithPlatform> {
         val content =
             queryFactory
-                .select(teacher, userRole.platform)
+                .select(teacher, userRole.platform, userRole.state)
                 .from(teacher)
                 .join(teacher.user, user)
                 .join(userRole)
@@ -35,7 +35,7 @@ class TeacherCustomRepositoryImpl(
                     universityContains(condition.university),
                     majorContains(condition.major),
                     majorCategoryEq(condition.majorCategory),
-                    verificationStatusEq(condition.verificationStatus),
+                    stateEq(condition.state),
                     platformEq(condition.platform),
                     submittedAtGoe(condition.submittedAtFrom),
                     submittedAtLoe(condition.submittedAtTo),
@@ -49,6 +49,7 @@ class TeacherCustomRepositoryImpl(
                     TeacherWithPlatform(
                         teacher = tuple.get(teacher) ?: error("Teacher must not be null"),
                         platform = tuple.get(userRole.platform) ?: error("Platform must not be null"),
+                        state = tuple.get(userRole.state) ?: error("State must not be null"),
                     )
                 }
 
@@ -57,13 +58,16 @@ class TeacherCustomRepositoryImpl(
                 .select(teacher.count())
                 .from(teacher)
                 .join(teacher.user, user)
+                .join(userRole)
+                .on(user.id.eq(userRole.userId))
                 .where(
                     nameContains(condition.name),
                     emailContains(condition.email),
                     universityContains(condition.university),
                     majorContains(condition.major),
                     majorCategoryEq(condition.majorCategory),
-                    verificationStatusEq(condition.verificationStatus),
+                    stateEq(condition.state),
+                    platformEq(condition.platform),
                     submittedAtGoe(condition.submittedAtFrom),
                     submittedAtLoe(condition.submittedAtTo),
                     createdAtGoe(condition.createdAtFrom),
@@ -84,8 +88,7 @@ class TeacherCustomRepositoryImpl(
     private fun majorCategoryEq(majorCategory: MajorCategory?): BooleanExpression? =
         majorCategory?.let { teacher.education.majorCategory.eq(it) }
 
-    private fun verificationStatusEq(status: TeacherVerificationStatus?): BooleanExpression? =
-        status?.let { teacher.verification.verificationStatus.eq(it) }
+    private fun stateEq(state: UserRoleState?): BooleanExpression? = state?.let { userRole.state.eq(it) }
 
     private fun platformEq(platform: Platform?): BooleanExpression? = platform?.let { userRole.platform.eq(it) }
 

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/repository/TeacherRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/repository/TeacherRepository.kt
@@ -1,12 +1,7 @@
 package com.sclass.domain.domains.teacher.repository
 
 import com.sclass.domain.domains.teacher.domain.Teacher
-import com.sclass.domain.domains.teacher.domain.TeacherVerificationStatus
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 
 interface TeacherRepository :
     JpaRepository<Teacher, String>,
@@ -14,10 +9,4 @@ interface TeacherRepository :
     fun findByUserId(userId: String): Teacher?
 
     fun existsByUserId(userId: String): Boolean
-
-    @Query("SELECT t FROM Teacher t WHERE t.verification.verificationStatus = :status")
-    fun findAllByStatus(
-        @Param("status") status: TeacherVerificationStatus,
-        pageable: Pageable,
-    ): Page<Teacher>
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/service/TeacherDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/teacher/service/TeacherDomainService.kt
@@ -6,7 +6,12 @@ import com.sclass.domain.domains.teacher.adaptor.TeacherDocumentAdaptor
 import com.sclass.domain.domains.teacher.domain.MajorCategory
 import com.sclass.domain.domains.teacher.domain.Teacher
 import com.sclass.domain.domains.teacher.exception.TeacherAlreadyExistsException
+import com.sclass.domain.domains.user.adaptor.UserRoleAdaptor
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.Role
 import com.sclass.domain.domains.user.domain.User
+import com.sclass.domain.domains.user.domain.UserRoleState
+import com.sclass.domain.domains.user.exception.RoleNotFoundException
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
@@ -14,6 +19,7 @@ import java.time.LocalDate
 class TeacherDomainService(
     private val teacherAdaptor: TeacherAdaptor,
     private val teacherDocumentAdaptor: TeacherDocumentAdaptor,
+    private val userRoleAdaptor: UserRoleAdaptor,
 ) {
     @Transactional
     fun register(user: User): Teacher {
@@ -26,6 +32,7 @@ class TeacherDomainService(
     @Transactional
     fun updateProfile(
         teacher: Teacher,
+        platform: Platform,
         birthDate: LocalDate,
         selfIntroduction: String?,
         majorCategory: MajorCategory,
@@ -35,7 +42,11 @@ class TeacherDomainService(
         address: String,
         residentNumber: String,
     ): Teacher {
+        val userRole =
+            userRoleAdaptor.findByUserIdAndPlatformAndRole(teacher.user.id, platform, Role.TEACHER)
+                ?: throw RoleNotFoundException()
         teacher.updateProfile(
+            state = userRole.state,
             birthDate = birthDate,
             selfIntroduction = selfIntroduction,
             majorCategory = majorCategory,
@@ -49,27 +60,47 @@ class TeacherDomainService(
     }
 
     @Transactional
-    fun submitForVerification(teacher: Teacher): Teacher {
+    fun submitForVerification(
+        teacher: Teacher,
+        platform: Platform,
+    ): Teacher {
+        val userRole =
+            userRoleAdaptor.findByUserIdAndPlatformAndRole(teacher.user.id, platform, Role.TEACHER)
+                ?: throw RoleNotFoundException()
         val documents = teacherDocumentAdaptor.findAllByTeacherId(teacher.id)
-        teacher.submitForVerification(documents)
+        teacher.recordSubmission(documents, userRole.state)
+        userRole.changeStateTo(UserRoleState.PENDING)
+        userRoleAdaptor.save(userRole)
         return teacherAdaptor.save(teacher)
     }
 
     @Transactional
     fun approve(
         teacher: Teacher,
+        platform: Platform,
         approvedBy: String,
     ): Teacher {
-        teacher.approve(approvedBy)
+        val userRole =
+            userRoleAdaptor.findByUserIdAndPlatformAndRole(teacher.user.id, platform, Role.TEACHER)
+                ?: throw RoleNotFoundException()
+        userRole.changeStateTo(UserRoleState.APPROVED)
+        teacher.recordApproval(approvedBy)
+        userRoleAdaptor.save(userRole)
         return teacherAdaptor.save(teacher)
     }
 
     @Transactional
     fun reject(
         teacher: Teacher,
+        platform: Platform,
         reason: String,
     ): Teacher {
-        teacher.reject(reason)
+        val userRole =
+            userRoleAdaptor.findByUserIdAndPlatformAndRole(teacher.user.id, platform, Role.TEACHER)
+                ?: throw RoleNotFoundException()
+        userRole.changeStateTo(UserRoleState.REJECTED)
+        teacher.recordRejection(reason)
+        userRoleAdaptor.save(userRole)
         return teacherAdaptor.save(teacher)
     }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/domain/UserRole.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/domain/UserRole.kt
@@ -2,6 +2,7 @@ package com.sclass.domain.domains.user.domain
 
 import com.sclass.domain.common.model.BaseTimeEntity
 import com.sclass.domain.common.vo.Ulid
+import com.sclass.domain.domains.user.exception.InvalidUserRoleStateTransitionException
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -32,4 +33,25 @@ class UserRole(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     val role: Role,
-) : BaseTimeEntity()
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var state: UserRoleState = UserRoleState.NORMAL,
+) : BaseTimeEntity() {
+    fun changeStateTo(newState: UserRoleState) {
+        if (!VALID_TRANSITIONS[state].orEmpty().contains(newState)) {
+            throw InvalidUserRoleStateTransitionException()
+        }
+        state = newState
+    }
+
+    companion object {
+        private val VALID_TRANSITIONS =
+            mapOf(
+                UserRoleState.DRAFT to setOf(UserRoleState.PENDING),
+                UserRoleState.PENDING to setOf(UserRoleState.APPROVED, UserRoleState.REJECTED),
+                UserRoleState.REJECTED to setOf(UserRoleState.PENDING),
+                UserRoleState.APPROVED to setOf(UserRoleState.NORMAL),
+            )
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/domain/UserRoleState.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/domain/UserRoleState.kt
@@ -1,0 +1,9 @@
+package com.sclass.domain.domains.user.domain
+
+enum class UserRoleState {
+    NORMAL,
+    DRAFT,
+    PENDING,
+    APPROVED,
+    REJECTED,
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/exception/InvalidUserRoleStateTransitionException.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/exception/InvalidUserRoleStateTransitionException.kt
@@ -1,0 +1,5 @@
+package com.sclass.domain.domains.user.exception
+
+import com.sclass.common.exception.BusinessException
+
+class InvalidUserRoleStateTransitionException : BusinessException(UserErrorCode.INVALID_USER_ROLE_STATE_TRANSITION)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/exception/UserErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/exception/UserErrorCode.kt
@@ -10,4 +10,5 @@ enum class UserErrorCode(
     USER_NOT_FOUND("USER_001", "유저를 찾을 수 없습니다", 404),
     USER_ALREADY_EXISTS("USER_002", "이미 존재하는 이메일입니다", 409),
     ROLE_NOT_FOUND("USER_003", "해당 권한이 없습니다", 403),
+    INVALID_USER_ROLE_STATE_TRANSITION("USER_004", "허용되지 않는 상태 전이입니다", 400),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/service/UserDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/service/UserDomainService.kt
@@ -8,6 +8,7 @@ import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.domain.domains.user.domain.User
 import com.sclass.domain.domains.user.domain.UserRole
+import com.sclass.domain.domains.user.domain.UserRoleState
 import com.sclass.domain.domains.user.exception.InvalidPasswordException
 import com.sclass.domain.domains.user.exception.RoleNotFoundException
 import com.sclass.domain.domains.user.exception.UserAlreadyExistsException
@@ -38,6 +39,7 @@ class UserDomainService(
                 userId = savedUser.id,
                 platform = platform,
                 role = role,
+                state = initialStateFor(role),
             ),
         )
 
@@ -117,6 +119,7 @@ class UserDomainService(
                 userId = savedUser.id,
                 platform = platform,
                 role = role,
+                state = initialStateFor(role),
             ),
         )
 
@@ -134,8 +137,23 @@ class UserDomainService(
                     userId = userId,
                     platform = platform,
                     role = role,
+                    state = initialStateFor(role),
                 ),
             )
         }
     }
+
+    fun activateIfApproved(
+        userId: String,
+        platform: Platform,
+        role: Role,
+    ) {
+        val userRole = userRoleAdaptor.findByUserIdAndPlatformAndRole(userId, platform, role) ?: return
+        if (userRole.state == UserRoleState.APPROVED) {
+            userRole.changeStateTo(UserRoleState.NORMAL)
+            userRoleAdaptor.save(userRole)
+        }
+    }
+
+    private fun initialStateFor(role: Role): UserRoleState = if (role == Role.TEACHER) UserRoleState.DRAFT else UserRoleState.NORMAL
 }

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/teacher/service/TeacherDomainServiceTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/teacher/service/TeacherDomainServiceTest.kt
@@ -4,6 +4,7 @@ import com.sclass.domain.domains.teacher.adaptor.TeacherAdaptor
 import com.sclass.domain.domains.teacher.adaptor.TeacherDocumentAdaptor
 import com.sclass.domain.domains.teacher.domain.Teacher
 import com.sclass.domain.domains.teacher.exception.TeacherAlreadyExistsException
+import com.sclass.domain.domains.user.adaptor.UserRoleAdaptor
 import com.sclass.domain.domains.user.domain.User
 import io.mockk.every
 import io.mockk.mockk
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.assertThrows
 class TeacherDomainServiceTest {
     private lateinit var teacherAdaptor: TeacherAdaptor
     private lateinit var teacherDocumentAdaptor: TeacherDocumentAdaptor
+    private lateinit var userRoleAdaptor: UserRoleAdaptor
     private lateinit var teacherDomainService: TeacherDomainService
 
     private lateinit var user: User
@@ -25,7 +27,8 @@ class TeacherDomainServiceTest {
     fun setUp() {
         teacherAdaptor = mockk()
         teacherDocumentAdaptor = mockk()
-        teacherDomainService = TeacherDomainService(teacherAdaptor, teacherDocumentAdaptor)
+        userRoleAdaptor = mockk()
+        teacherDomainService = TeacherDomainService(teacherAdaptor, teacherDocumentAdaptor, userRoleAdaptor)
         user = mockk<User>()
         every { user.id } returns "user-id"
     }


### PR DESCRIPTION
## Summary
- `UserRole`에 `state` 필드(UserRoleState) 추가하여 선생님 인증 상태를 플랫폼별로 독립 관리
- `TeacherVerificationStatus` 삭제, 상태 전이 로직을 `UserRole.changeStateTo()`로 통합
- 로그인 시 APPROVED → NORMAL 자동 전환 (`UserDomainService.activateIfApproved`)
- `searchTeachers` count 쿼리에 UserRole join 누락 버그 수정
- endpoint/dto 리네임: `verification-status` → `state`

Closes #72

## Test plan
- [x] `./gradlew clean build` 전체 빌드 + 테스트 통과
- [x] `./gradlew ktlintCheck` 린트 통과
- [ ] APPROVED/REJECTED 상태 전이 API 수동 테스트
- [ ] 로그인 시 APPROVED → NORMAL 전환 확인
- [ ] 기존 데이터 마이그레이션 (user_roles.state 컬럼 추가, teachers.verification_status 컬럼 제거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)