### PR TITLE
fix: koverXmlReport Java heap OOM 수정 - JVM 힙 4g로 증설

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Build & Test & Coverage
         run: ./gradlew build koverXmlReport --no-daemon
+        env:
+          GRADLE_OPTS: "-Xmx4g -XX:MaxMetaspaceSize=512m"
 
       - name: Add coverage report to PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
릴리즈 CI에서 `koverXmlReport` 실행 시 Java heap space OOM으로 빌드가 실패하는 문제를 수정합니다.

## Changes
- `ci.yml` Build & Test 스텝에 `GRADLE_OPTS: "-Xmx4g -XX:MaxMetaspaceSize=512m"` 추가

## Affected Modules
- [x] CI/CD (`.github/workflows`)

## Test Plan
- [ ] PR 머지 후 develop CD에서 koverXmlReport 정상 완료 확인
- [ ] 이후 릴리즈 시 CI 통과 확인

## Checklist
- [x] 컨벤션 준수
- [x] 불필요한 코드 없음