### PR TITLE
fix: 구글 폼 웹훅 answers 배열 역직렬화 오류 수정

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/webhook/dto/GoogleFormWebhookPayload.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/webhook/dto/GoogleFormWebhookPayload.kt
@@ -5,5 +5,5 @@ data class GoogleFormWebhookPayload(
     val formTitle: String?,
     val formResponseId: String,
     val submittedAt: String,
-    val answers: Map<String, String>,
+    val answers: Map<String, Any>,
 )

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/webhook/event/DiagnosisRequestedEvent.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/webhook/event/DiagnosisRequestedEvent.kt
@@ -4,7 +4,7 @@ data class DiagnosisRequestedEvent(
     val diagnosisId: String,
     val requestId: String,
     val studentName: String,
-    val answers: Map<String, String>,
+    val answers: Map<String, Any>,
     val callbackUrl: String,
     val submittedAt: String,
 )

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/webhook/domain/WebhookFieldMapping.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/webhook/domain/WebhookFieldMapping.kt
@@ -14,15 +14,15 @@ data class WebhookFieldMapping(
     @Column(name = "parent_phone_question")
     val parentPhoneQuestion: String?,
 ) {
-    fun extractFrom(answers: Map<String, String>): ExtractedFields {
+    fun extractFrom(answers: Map<String, Any>): ExtractedFields {
         val studentName =
-            answers[studentNameQuestion]
+            answers[studentNameQuestion]?.toString()
                 ?: throw IllegalArgumentException("학생 이름 필드를 찾을 수 없습니다: $studentNameQuestion")
 
         return ExtractedFields(
             studentName = studentName,
-            studentPhone = answers[studentPhoneQuestion]?.replace("-", ""),
-            parentPhone = parentPhoneQuestion?.let { answers[it] }?.replace("-", ""),
+            studentPhone = answers[studentPhoneQuestion]?.toString()?.replace("-", ""),
+            parentPhone = parentPhoneQuestion?.let { answers[it] }?.toString()?.replace("-", ""),
         )
     }
 }

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/report/ReportServiceClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/report/ReportServiceClient.kt
@@ -17,7 +17,7 @@ class ReportServiceClient(
     fun createSurveyReport(
         requestId: String,
         studentName: String,
-        answers: Map<String, String>,
+        answers: Map<String, Any>,
         callbackUrl: String,
         callbackSecret: String,
     ) {

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/report/dto/CreateSurveyReportRequest.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/report/dto/CreateSurveyReportRequest.kt
@@ -3,7 +3,7 @@ package com.sclass.infrastructure.report.dto
 data class CreateSurveyReportRequest(
     val requestId: String,
     val studentName: String,
-    val answers: Map<String, String>,
+    val answers: Map<String, Any>,
     val callback: CallbackConfig,
 )
 


### PR DESCRIPTION
## Summary
- 구글 폼 체크박스/복수선택 문항 응답이 `String[]` 배열로 전송될 때 `Map<String, String>` 역직렬화 실패 → 400 GLOBAL_001 오류 발생
- `answers` 타입을 `Map<String, Any>`로 변경 (`GoogleFormWebhookPayload`, `DiagnosisRequestedEvent`, `ReportServiceClient`, `CreateSurveyReportRequest`, `WebhookFieldMapping`)

## Root Cause
AppScript의 `r.getResponse()`는 단일 선택 문항은 `String`, 체크박스/복수 문항은 `String[]`를 반환함.
서버가 `Map<String, String>`으로 역직렬화 시도 → `HttpMessageNotReadableException` → GLOBAL_001

## Test plan
- [ ] 단일 텍스트 문항만 있는 구글 폼 제출 → 정상 처리 확인
- [ ] 체크박스 문항이 포함된 구글 폼 제출 → 정상 처리 확인 (기존엔 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)