### PR TITLE
fix: CI 실패 원인 3종 수정

### DIFF
--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/inquiry/usecase/CreateInquiryPlanUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/inquiry/usecase/CreateInquiryPlanUseCase.kt
@@ -7,34 +7,46 @@ import com.sclass.infrastructure.report.ReportServiceClient
 import com.sclass.supporters.inquiry.dto.CreateInquiryPlanRequest
 import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
 import org.slf4j.LoggerFactory
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 
 @UseCase
 class CreateInquiryPlanUseCase(
     private val inquiryPlanAdaptor: InquiryPlanAdaptor,
     private val reportServiceClient: ReportServiceClient,
+    private val txTemplate: TransactionTemplate,
 ) {
-    @Transactional
     fun execute(
         userId: String,
         request: CreateInquiryPlanRequest,
     ): InquiryPlanResponse {
         val plan =
-            inquiryPlanAdaptor.save(
-                InquiryPlan(
-                    sourceType = request.sourceType,
-                    sourceRefId = request.sourceRefId,
-                    requestedByUserId = userId,
-                ),
-            )
+            txTemplate.execute {
+                inquiryPlanAdaptor.save(
+                    InquiryPlan(
+                        sourceType = request.sourceType,
+                        sourceRefId = request.sourceRefId,
+                        requestedByUserId = userId,
+                    ),
+                )
+            }!!
+
         runCatching {
             val jobId = reportServiceClient.createReport(plan.id.toString(), request.paragraph)
-            plan.acceptJobId(jobId)
+            txTemplate.execute {
+                val fresh = inquiryPlanAdaptor.findById(plan.id)
+                fresh.acceptJobId(jobId)
+                inquiryPlanAdaptor.save(fresh)
+            }
         }.onFailure {
             logger.error("[inquiry] ReportService 호출 실패 planId=${plan.id}", it)
-            plan.markFailed("ReportService 호출 실패")
+            txTemplate.execute {
+                val fresh = inquiryPlanAdaptor.findById(plan.id)
+                fresh.markFailed("ReportService 호출 실패")
+                inquiryPlanAdaptor.save(fresh)
+            }
         }
-        return InquiryPlanResponse.from(plan)
+
+        return InquiryPlanResponse.from(inquiryPlanAdaptor.findById(plan.id))
     }
 
     companion object {

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -100,11 +100,16 @@ class HandleNicePayWebhookUseCase(
                     fresh.markPgApproved(payload.tid)
                     paymentAdaptor.save(fresh)
                 }
+                val enrollment = enrollmentAdaptor.findByPaymentIdOrNull(payment.id)
+                if (enrollment == null) {
+                    log.warn("웹훅 수신: enrollment 없음 paymentId={}", payment.id)
+                    return
+                }
                 txTemplate.execute {
                     val fresh = paymentAdaptor.findById(payment.id)
-                    val enrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
-                    enrollment.markPaid()
-                    enrollmentAdaptor.save(enrollment)
+                    val freshEnrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
+                    freshEnrollment.markPaid()
+                    enrollmentAdaptor.save(freshEnrollment)
                     fresh.markCompleted()
                     paymentAdaptor.save(fresh)
                 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/config/IntegrationTestConfig.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/config/IntegrationTestConfig.kt
@@ -6,6 +6,7 @@ import com.sclass.infrastructure.message.CommissionNotificationSender
 import com.sclass.infrastructure.message.VerificationCodeSender
 import com.sclass.infrastructure.oauth.OAuthClientFactory
 import com.sclass.infrastructure.oauth.client.OAuthClient
+import com.sclass.infrastructure.report.ReportServiceClient
 import io.mockk.mockk
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
@@ -46,4 +47,8 @@ class IntegrationTestConfig {
     @Bean
     @Primary
     fun mockCommissionNotificationSender(): CommissionNotificationSender = mockk<CommissionNotificationSender>(relaxed = true)
+
+    @Bean
+    @Primary
+    fun mockReportServiceClient(): ReportServiceClient = mockk<ReportServiceClient>(relaxed = true)
 }


### PR DESCRIPTION
## Summary
- `CreateInquiryPlanUseCase`: `@Transactional` → `TransactionTemplate`으로 교체하여 외부 API 호출을 트랜잭션 밖에서 실행
- `HandleNicePayWebhookUseCase`: CourseProduct 웹훅 처리 시 enrollment null 체크 추가 (`findByPaymentIdOrNull`)
- `IntegrationTestConfig`: `ReportServiceClient` mock bean 추가 — `@ConditionalOnProperty`로 테스트 환경에서 Bean 미등록되어 Spring 컨텍스트 로드 실패하던 문제 수정

## Test plan
- [x] 전체 단위 테스트 로컬 통과 확인
- [x] 통합 테스트 컨텍스트 로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)