### PR TITLE
fix: CI 워크플로우 pull_request 트리거 직접 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [develop, main]
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- PR Labeler를 통한 간접 CI 호출이 트리거되지 않는 문제로 `ci.yml`에 `pull_request` 트리거 직접 추가
- `opened`, `synchronize`, `reopened` 이벤트 + `develop`/`main` 브랜치 대상으로 직접 실행
- CI 실패 원인 3종 수정 포함 (cherry-pick from #197)

🤖 Generated with [Claude Code](https://claude.com/claude-code)