### PR TITLE
feat: 레슨 목록 조회 및 탐구 계획 생성 API (#188)

### DIFF
--- a/SClass-Api-Backoffice/src/test/resources/application-test.yml
+++ b/SClass-Api-Backoffice/src/test/resources/application-test.yml
@@ -46,3 +46,9 @@ nicepay:
   client-key: test-client-key
   secret-key: test-secret-key
   base-url: https://sandbox-api.nicepay.co.kr
+
+report-service:
+  enabled: true
+  base-url: http://localhost:9999
+  callback-secret: test-secret
+  callback-base-url: http://localhost:8081

--- a/SClass-Api-Lms/src/test/resources/application-test.yml
+++ b/SClass-Api-Lms/src/test/resources/application-test.yml
@@ -46,3 +46,9 @@ nicepay:
   client-key: test-client-key
   secret-key: test-secret-key
   base-url: https://sandbox-api.nicepay.co.kr
+
+report-service:
+  enabled: true
+  base-url: http://localhost:9999
+  callback-secret: test-secret
+  callback-base-url: http://localhost:8081

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/controller/CommissionController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/controller/CommissionController.kt
@@ -18,12 +18,14 @@ import com.sclass.supporters.commission.dto.TransitionStatusRequest
 import com.sclass.supporters.commission.usecase.CreateCommissionUseCase
 import com.sclass.supporters.commission.usecase.CreateSupportTicketUseCase
 import com.sclass.supporters.commission.usecase.GetCommissionDetailUseCase
+import com.sclass.supporters.commission.usecase.GetCommissionLessonUseCase
 import com.sclass.supporters.commission.usecase.GetCommissionListUseCase
 import com.sclass.supporters.commission.usecase.GetCommissionTopicsUseCase
 import com.sclass.supporters.commission.usecase.GetSupportTicketsUseCase
 import com.sclass.supporters.commission.usecase.ProposeTopicsUseCase
 import com.sclass.supporters.commission.usecase.SelectTopicUseCase
 import com.sclass.supporters.commission.usecase.TransitionCommissionStatusUseCase
+import com.sclass.supporters.lesson.dto.LessonResponse
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -45,6 +47,7 @@ class CommissionController(
     private val transitionCommissionStatusUseCase: TransitionCommissionStatusUseCase,
     private val createSupportTicketUseCase: CreateSupportTicketUseCase,
     private val getSupportTicketsUseCase: GetSupportTicketsUseCase,
+    private val getCommissionLessonUseCase: GetCommissionLessonUseCase,
 ) {
     @PostMapping
     fun create(
@@ -111,4 +114,9 @@ class CommissionController(
         @CurrentUserId userId: String,
         @PathVariable commissionId: Long,
     ): ApiResponse<SupportTicketListResponse> = ApiResponse.success(getSupportTicketsUseCase.execute(userId, commissionId))
+
+    @GetMapping("/{commissionId}/lesson")
+    fun getLesson(
+        @PathVariable commissionId: Long,
+    ): ApiResponse<LessonResponse> = ApiResponse.success(getCommissionLessonUseCase.execute(commissionId))
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/GetCommissionLessonUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/GetCommissionLessonUseCase.kt
@@ -1,0 +1,18 @@
+package com.sclass.supporters.commission.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.exception.LessonNotFoundException
+import com.sclass.supporters.lesson.dto.LessonResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetCommissionLessonUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(commissionId: Long): LessonResponse {
+        val lesson = lessonAdaptor.findByCommission(commissionId) ?: throw LessonNotFoundException()
+        return LessonResponse.from(lesson)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/controller/EnrollmentController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/controller/EnrollmentController.kt
@@ -8,10 +8,13 @@ import com.sclass.supporters.enrollment.dto.MyEnrollmentResponse
 import com.sclass.supporters.enrollment.dto.PrepareEnrollmentRequest
 import com.sclass.supporters.enrollment.dto.PrepareEnrollmentResponse
 import com.sclass.supporters.enrollment.usecase.GetCourseEnrollmentsUseCase
+import com.sclass.supporters.enrollment.usecase.GetEnrollmentLessonsUseCase
 import com.sclass.supporters.enrollment.usecase.GetMyEnrollmentsUseCase
 import com.sclass.supporters.enrollment.usecase.PrepareEnrollmentUseCase
+import com.sclass.supporters.lesson.dto.LessonResponse
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -24,6 +27,7 @@ class EnrollmentController(
     private val prepareEnrollmentUseCase: PrepareEnrollmentUseCase,
     private val getMyEnrollmentsUseCase: GetMyEnrollmentsUseCase,
     private val getCourseEnrollmentsUseCase: GetCourseEnrollmentsUseCase,
+    private val getEnrollmentLessonsUseCase: GetEnrollmentLessonsUseCase,
 ) {
     @PostMapping
     fun prepareEnrollment(
@@ -41,4 +45,9 @@ class EnrollmentController(
         @CurrentUserId userId: String,
         @RequestParam courseId: Long,
     ): ApiResponse<List<EnrollmentWithStudentResponse>> = success(getCourseEnrollmentsUseCase.execute(userId, courseId))
+
+    @GetMapping("/{enrollmentId}/lessons")
+    fun getEnrollmentLessons(
+        @PathVariable enrollmentId: Long,
+    ): ApiResponse<List<LessonResponse>> = success(getEnrollmentLessonsUseCase.execute(enrollmentId))
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCase.kt
@@ -1,0 +1,14 @@
+package com.sclass.supporters.enrollment.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.supporters.lesson.dto.LessonResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetEnrollmentLessonsUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(enrollmentId: Long): List<LessonResponse> = lessonAdaptor.findAllByEnrollment(enrollmentId).map { LessonResponse.from(it) }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/controller/LessonController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/controller/LessonController.kt
@@ -1,0 +1,26 @@
+package com.sclass.supporters.lesson.controller
+
+import com.sclass.common.annotation.CurrentUserId
+import com.sclass.common.dto.ApiResponse
+import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
+import com.sclass.supporters.lesson.dto.CreateLessonInquiryPlanRequest
+import com.sclass.supporters.lesson.usecase.CreateLessonInquiryPlanUseCase
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/lessons")
+class LessonController(
+    private val createLessonInquiryPlanUseCase: CreateLessonInquiryPlanUseCase,
+) {
+    @PostMapping("/{lessonId}/inquiry-plans")
+    fun createInquiryPlan(
+        @CurrentUserId userId: String,
+        @PathVariable lessonId: Long,
+        @Valid @RequestBody request: CreateLessonInquiryPlanRequest,
+    ): ApiResponse<InquiryPlanResponse> = ApiResponse.success(createLessonInquiryPlanUseCase.execute(userId, lessonId, request))
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/CreateLessonInquiryPlanRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/CreateLessonInquiryPlanRequest.kt
@@ -1,0 +1,7 @@
+package com.sclass.supporters.lesson.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class CreateLessonInquiryPlanRequest(
+    @field:NotBlank val paragraph: String,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/LessonResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/LessonResponse.kt
@@ -1,0 +1,35 @@
+package com.sclass.supporters.lesson.dto
+
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import java.time.LocalDateTime
+
+data class LessonResponse(
+    val id: Long,
+    val name: String,
+    val lessonNumber: Int?,
+    val lessonType: LessonType,
+    val enrollmentId: Long?,
+    val sourceCommissionId: Long?,
+    val status: LessonStatus,
+    val scheduledAt: LocalDateTime?,
+    val startedAt: LocalDateTime?,
+    val completedAt: LocalDateTime?,
+) {
+    companion object {
+        fun from(lesson: Lesson) =
+            LessonResponse(
+                id = lesson.id,
+                name = lesson.name,
+                lessonNumber = lesson.lessonNumber,
+                lessonType = lesson.lessonType,
+                enrollmentId = lesson.enrollmentId,
+                sourceCommissionId = lesson.sourceCommissionId,
+                status = lesson.status,
+                scheduledAt = lesson.scheduledAt,
+                startedAt = lesson.startedAt,
+                completedAt = lesson.completedAt,
+            )
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonInquiryPlanUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonInquiryPlanUseCase.kt
@@ -1,0 +1,34 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.inquiryplan.domain.InquiryPlanSourceType
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.supporters.inquiry.dto.CreateInquiryPlanRequest
+import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
+import com.sclass.supporters.inquiry.usecase.CreateInquiryPlanUseCase
+import com.sclass.supporters.lesson.dto.CreateLessonInquiryPlanRequest
+
+@UseCase
+class CreateLessonInquiryPlanUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+    private val createInquiryPlanUseCase: CreateInquiryPlanUseCase,
+) {
+    fun execute(
+        userId: String,
+        lessonId: Long,
+        request: CreateLessonInquiryPlanRequest,
+    ): InquiryPlanResponse {
+        val lesson = lessonAdaptor.findById(lessonId)
+        require(lesson.assignedTeacherUserId == userId) {
+            "선생님만 탐구 계획을 생성할 수 있습니다"
+        }
+        return createInquiryPlanUseCase.execute(
+            userId,
+            CreateInquiryPlanRequest(
+                paragraph = request.paragraph,
+                sourceType = InquiryPlanSourceType.LESSON,
+                sourceRefId = lessonId,
+            ),
+        )
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/GetCommissionLessonUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/GetCommissionLessonUseCaseTest.kt
@@ -1,0 +1,59 @@
+package com.sclass.supporters.commission.usecase
+
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonNotFoundException
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class GetCommissionLessonUseCaseTest {
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var useCase: GetCommissionLessonUseCase
+
+    private val commissionId = 1L
+    private val teacherUserId = "teacher-user-id-00000000001"
+    private val studentUserId = "student-user-id-00000000001"
+
+    @BeforeEach
+    fun setUp() {
+        lessonAdaptor = mockk()
+        useCase = GetCommissionLessonUseCase(lessonAdaptor)
+    }
+
+    private fun lesson() =
+        Lesson(
+            lessonType = LessonType.COMMISSION,
+            sourceCommissionId = commissionId,
+            studentUserId = studentUserId,
+            assignedTeacherUserId = teacherUserId,
+            name = "1회성 수학 의뢰",
+            teacherPayoutAmountWon = 80_000,
+        )
+
+    @Test
+    fun `의뢰에 연결된 레슨을 반환한다`() {
+        every { lessonAdaptor.findByCommission(commissionId) } returns lesson()
+
+        val result = useCase.execute(commissionId)
+
+        assertAll(
+            { assertEquals(LessonType.COMMISSION, result.lessonType) },
+            { assertEquals(commissionId, result.sourceCommissionId) },
+        )
+    }
+
+    @Test
+    fun `의뢰에 연결된 레슨이 없으면 예외가 발생한다`() {
+        every { lessonAdaptor.findByCommission(commissionId) } returns null
+
+        assertThrows<LessonNotFoundException> {
+            useCase.execute(commissionId)
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCaseTest.kt
@@ -1,0 +1,62 @@
+package com.sclass.supporters.enrollment.usecase
+
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetEnrollmentLessonsUseCaseTest {
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var useCase: GetEnrollmentLessonsUseCase
+
+    private val enrollmentId = 1L
+    private val teacherUserId = "teacher-user-id-00000000001"
+    private val studentUserId = "student-user-id-00000000001"
+
+    @BeforeEach
+    fun setUp() {
+        lessonAdaptor = mockk()
+        useCase = GetEnrollmentLessonsUseCase(lessonAdaptor)
+    }
+
+    private fun lesson(lessonNumber: Int = 1) =
+        Lesson(
+            lessonType = LessonType.COURSE,
+            enrollmentId = enrollmentId,
+            studentUserId = studentUserId,
+            assignedTeacherUserId = teacherUserId,
+            lessonNumber = lessonNumber,
+            name = "수학 ${lessonNumber}회차",
+            teacherPayoutAmountWon = 50_000,
+        )
+
+    @Test
+    fun `수강신청에 속한 레슨 목록을 반환한다`() {
+        val lessons = listOf(lesson(1), lesson(2))
+        every { lessonAdaptor.findAllByEnrollment(enrollmentId) } returns lessons
+
+        val result = useCase.execute(enrollmentId)
+
+        assertAll(
+            { assertEquals(2, result.size) },
+            { assertEquals(LessonType.COURSE, result.first().lessonType) },
+            { assertEquals(enrollmentId, result.first().enrollmentId) },
+            { assertEquals(LessonStatus.SCHEDULED, result.first().status) },
+        )
+    }
+
+    @Test
+    fun `레슨이 없으면 빈 목록을 반환한다`() {
+        every { lessonAdaptor.findAllByEnrollment(enrollmentId) } returns emptyList()
+
+        val result = useCase.execute(enrollmentId)
+
+        assertEquals(0, result.size)
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonInquiryPlanUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonInquiryPlanUseCaseTest.kt
@@ -1,0 +1,84 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.domain.domains.inquiryplan.domain.InquiryPlanSourceType
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.supporters.inquiry.dto.CreateInquiryPlanRequest
+import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
+import com.sclass.supporters.inquiry.usecase.CreateInquiryPlanUseCase
+import com.sclass.supporters.lesson.dto.CreateLessonInquiryPlanRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CreateLessonInquiryPlanUseCaseTest {
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var createInquiryPlanUseCase: CreateInquiryPlanUseCase
+    private lateinit var useCase: CreateLessonInquiryPlanUseCase
+
+    private val teacherUserId = "teacher-user-id-00000000001"
+    private val studentUserId = "student-user-id-0000000001"
+
+    @BeforeEach
+    fun setUp() {
+        lessonAdaptor = mockk()
+        createInquiryPlanUseCase = mockk()
+        useCase = CreateLessonInquiryPlanUseCase(lessonAdaptor, createInquiryPlanUseCase)
+    }
+
+    private fun lesson(id: Long = 1L) =
+        Lesson(
+            id = id,
+            lessonType = LessonType.COURSE,
+            enrollmentId = 1L,
+            studentUserId = studentUserId,
+            assignedTeacherUserId = teacherUserId,
+            lessonNumber = 1,
+            name = "수학 1회차",
+            teacherPayoutAmountWon = 50_000,
+        )
+
+    @Test
+    fun `선생님이 담당 레슨의 탐구 계획을 생성한다`() {
+        val lesson = lesson()
+        val requestSlot = slot<CreateInquiryPlanRequest>()
+        val mockResponse = mockk<InquiryPlanResponse>()
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every { createInquiryPlanUseCase.execute(teacherUserId, capture(requestSlot)) } returns mockResponse
+
+        useCase.execute(teacherUserId, 1L, CreateLessonInquiryPlanRequest(paragraph = "탐구 내용"))
+
+        assertAll(
+            { assertEquals(InquiryPlanSourceType.LESSON, requestSlot.captured.sourceType) },
+            { assertEquals(1L, requestSlot.captured.sourceRefId) },
+            { assertEquals("탐구 내용", requestSlot.captured.paragraph) },
+        )
+        verify(exactly = 1) { createInquiryPlanUseCase.execute(any(), any()) }
+    }
+
+    @Test
+    fun `학생은 탐구 계획을 생성할 수 없다`() {
+        every { lessonAdaptor.findById(1L) } returns lesson()
+
+        assertThrows<IllegalArgumentException> {
+            useCase.execute(studentUserId, 1L, CreateLessonInquiryPlanRequest(paragraph = "탐구 내용"))
+        }
+    }
+
+    @Test
+    fun `담당 선생님이 아니면 탐구 계획을 생성할 수 없다`() {
+        every { lessonAdaptor.findById(1L) } returns lesson()
+
+        assertThrows<IllegalArgumentException> {
+            useCase.execute("other-teacher-id-000000001", 1L, CreateLessonInquiryPlanRequest(paragraph = "탐구 내용"))
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/test/resources/application-test.yml
+++ b/SClass-Api-Supporters/src/test/resources/application-test.yml
@@ -49,3 +49,9 @@ nicepay:
 
 sclass:
   frontend-url: http://localhost:3000
+
+report-service:
+  enabled: true
+  base-url: http://localhost:9999
+  callback-secret: test-secret
+  callback-base-url: http://localhost:8081


### PR DESCRIPTION
## Summary
- `GET /api/v1/enrollments/{enrollmentId}/lessons` — 정규과정(COURSE) 레슨 목록 조회
- `GET /api/v1/commissions/{commissionId}/lesson` — 1회성 의뢰(COMMISSION) 레슨 조회
- `POST /api/v1/lessons/{lessonId}/inquiry-plans` — 담당 선생님 전용 탐구 계획 생성
- `GET /api/v1/lessons` 범용 엔드포인트 및 `GetMyLessonsUseCase` 제거 (레슨 조회는 컨텍스트별로 분리)

## Changes
- `GetEnrollmentLessonsUseCase` — `EnrollmentController`에 추가
- `GetCommissionLessonUseCase` — `CommissionController`에 추가
- `CreateLessonInquiryPlanUseCase` — `assignedTeacherUserId` 검증 (선생님 전용)
- `LessonResponse` — `lessonType`, `enrollmentId`, `sourceCommissionId` 포함

## Test plan
- [ ] `GetEnrollmentLessonsUseCaseTest` — 레슨 목록 반환, 빈 목록 반환
- [ ] `GetCommissionLessonUseCaseTest` — 레슨 반환, 없으면 LessonNotFoundException
- [ ] `CreateLessonInquiryPlanUseCaseTest` — 선생님 생성 성공, 학생 불가, 미담당 선생님 불가

🤖 Generated with [Claude Code](https://claude.com/claude-code)