### PR TITLE
feat: platform 무관 로그인 지원

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/usecase/LoginUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/usecase/LoginUseCase.kt
@@ -4,7 +4,6 @@ import com.sclass.backoffice.auth.dto.LoginRequest
 import com.sclass.backoffice.auth.dto.TokenResponse
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.token.service.TokenDomainService
-import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.domain.domains.user.service.UserDomainService
 import org.springframework.transaction.annotation.Transactional
@@ -20,11 +19,10 @@ class LoginUseCase(
             userDomainService.authenticate(
                 email = request.email,
                 rawPassword = request.password,
-                platform = Platform.BACKOFFICE,
                 role = Role.ADMIN,
             )
 
-        val tokens = tokenDomainService.issueTokens(user.id, Role.ADMIN, Platform.BACKOFFICE)
+        val tokens = tokenDomainService.issueTokens(user.id, Role.ADMIN)
         return TokenResponse(
             accessToken = tokens.accessToken,
             refreshToken = tokens.refreshToken,

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/config/WebConfig.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/config/WebConfig.kt
@@ -2,8 +2,6 @@ package com.sclass.backoffice.config
 
 import com.sclass.common.jwt.CurrentUserIdArgumentResolver
 import com.sclass.common.jwt.JwtAuthInterceptor
-import com.sclass.common.jwt.PlatformAuthInterceptor
-import com.sclass.domain.domains.user.domain.Platform
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
@@ -17,10 +15,6 @@ class WebConfig(
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry
             .addInterceptor(jwtAuthInterceptor)
-            .addPathPatterns("/api/**")
-            .excludePathPatterns("/api/v1/auth/**", "/api/v1/oauth/**", "/api/report-webhooks/**")
-        registry
-            .addInterceptor(PlatformAuthInterceptor(Platform.BACKOFFICE.name))
             .addPathPatterns("/api/**")
             .excludePathPatterns("/api/v1/auth/**", "/api/v1/oauth/**", "/api/report-webhooks/**")
     }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/auth/usecase/LoginUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/auth/usecase/LoginUseCaseTest.kt
@@ -3,7 +3,6 @@ package com.sclass.backoffice.auth.usecase
 import com.sclass.backoffice.auth.dto.LoginRequest
 import com.sclass.domain.domains.token.dto.TokenResult
 import com.sclass.domain.domains.token.service.TokenDomainService
-import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.domain.domains.user.domain.User
 import com.sclass.domain.domains.user.service.UserDomainService
@@ -36,13 +35,12 @@ class LoginUseCaseTest {
             userDomainService.authenticate(
                 email = "admin@sclass.com",
                 rawPassword = "password123",
-                platform = Platform.BACKOFFICE,
                 role = Role.ADMIN,
             )
         } returns user
 
         every {
-            tokenDomainService.issueTokens("user-id-123", Role.ADMIN, Platform.BACKOFFICE)
+            tokenDomainService.issueTokens("user-id-123", Role.ADMIN)
         } returns
             TokenResult(
                 accessToken = "encrypted-access-token",

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/student/controller/StudentManagementControllerIntegrationTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/student/controller/StudentManagementControllerIntegrationTest.kt
@@ -84,7 +84,6 @@ class StudentManagementControllerIntegrationTest {
             jwtTokenProvider.generateAccessToken(
                 userId = adminUser.id,
                 role = "ADMIN",
-                platform = "BACKOFFICE",
             )
         adminToken = "Bearer ${aesTokenEncryptor.encrypt(jwt)}"
     }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/teacher/controller/TeacherManagementControllerIntegrationTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/teacher/controller/TeacherManagementControllerIntegrationTest.kt
@@ -85,7 +85,6 @@ class TeacherManagementControllerIntegrationTest {
             jwtTokenProvider.generateAccessToken(
                 userId = adminUser.id,
                 role = "ADMIN",
-                platform = "BACKOFFICE",
             )
         adminToken = "Bearer ${aesTokenEncryptor.encrypt(jwt)}"
     }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/teacherassignment/controller/TeacherAssignmentControllerIntegrationTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/teacherassignment/controller/TeacherAssignmentControllerIntegrationTest.kt
@@ -115,7 +115,6 @@ class TeacherAssignmentControllerIntegrationTest {
             jwtTokenProvider.generateAccessToken(
                 userId = adminUser.id,
                 role = "ADMIN",
-                platform = "BACKOFFICE",
             )
         adminToken = "Bearer ${aesTokenEncryptor.encrypt(jwt)}"
     }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/userrole/controller/UserRoleControllerIntegrationTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/userrole/controller/UserRoleControllerIntegrationTest.kt
@@ -87,7 +87,6 @@ class UserRoleControllerIntegrationTest {
             jwtTokenProvider.generateAccessToken(
                 userId = adminUser.id,
                 role = "ADMIN",
-                platform = "BACKOFFICE",
             )
         adminToken = "Bearer ${aesTokenEncryptor.encrypt(jwt)}"
     }

--- a/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/usecase/OAuthLoginUseCase.kt
+++ b/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/auth/usecase/OAuthLoginUseCase.kt
@@ -35,8 +35,8 @@ class OAuthLoginUseCase(
             )
 
         if (user != null) {
-            userService.activateIfApproved(user.id, request.platform, request.role)
-            val tokens = tokenService.issueTokens(user.id, request.role, request.platform)
+            userService.activateIfApproved(user.id, request.role)
+            val tokens = tokenService.issueTokens(user.id, request.role)
             return OAuthLoginResponse(
                 isNewUser = false,
                 accessToken = tokens.accessToken,
@@ -80,7 +80,7 @@ class OAuthLoginUseCase(
                 role = role,
             )
 
-        val tokens = tokenService.issueTokens(user.id, role, platform)
+        val tokens = tokenService.issueTokens(user.id, role)
         return TokenResponse(
             accessToken = tokens.accessToken,
             refreshToken = tokens.refreshToken,

--- a/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/config/WebConfig.kt
+++ b/SClass-Api-Lms/src/main/kotlin/com/sclass/lms/config/WebConfig.kt
@@ -2,8 +2,6 @@ package com.sclass.lms.config
 
 import com.sclass.common.jwt.CurrentUserIdArgumentResolver
 import com.sclass.common.jwt.JwtAuthInterceptor
-import com.sclass.common.jwt.PlatformAuthInterceptor
-import com.sclass.domain.domains.user.domain.Platform
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
@@ -17,10 +15,6 @@ class WebConfig(
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry
             .addInterceptor(jwtAuthInterceptor)
-            .addPathPatterns("/api/**")
-            .excludePathPatterns("/api/v1/auth/**", "/api/v1/oauth/**", "/api/v1/diagnosis/**")
-        registry
-            .addInterceptor(PlatformAuthInterceptor(Platform.LMS.name))
             .addPathPatterns("/api/**")
             .excludePathPatterns("/api/v1/auth/**", "/api/v1/oauth/**", "/api/v1/diagnosis/**")
     }

--- a/SClass-Api-Lms/src/test/kotlin/com/sclass/lms/auth/usecase/OAuthLoginUseCaseTest.kt
+++ b/SClass-Api-Lms/src/test/kotlin/com/sclass/lms/auth/usecase/OAuthLoginUseCaseTest.kt
@@ -62,8 +62,8 @@ class OAuthLoginUseCaseTest {
         every { oAuthClient.fetchUserInfo("oauth-access-token") } returns userInfo
         every { userService.findByOAuthOrNull("oauth-id", AuthProvider.GOOGLE) } returns user
         every { userService.ensureUserRole("user-id", Platform.LMS, Role.ADMIN) } just runs
-        every { userService.activateIfApproved("user-id", Platform.LMS, Role.ADMIN) } just Runs
-        every { tokenService.issueTokens("user-id", Role.ADMIN, Platform.LMS) } returns tokenResult
+        every { userService.activateIfApproved("user-id", Role.ADMIN) } just Runs
+        every { tokenService.issueTokens("user-id", Role.ADMIN) } returns tokenResult
 
         val result = useCase.login(request)
 
@@ -148,7 +148,7 @@ class OAuthLoginUseCaseTest {
                 role = Role.ADMIN,
             )
         } returns user
-        every { tokenService.issueTokens("user-id", Role.ADMIN, Platform.LMS) } returns tokenResult
+        every { tokenService.issueTokens("user-id", Role.ADMIN) } returns tokenResult
 
         useCase.completeSignup(request)
 
@@ -200,7 +200,7 @@ class OAuthLoginUseCaseTest {
                 role = Role.TEACHER,
             )
         } returns user
-        every { tokenService.issueTokens("new-user-id", Role.TEACHER, Platform.LMS) } returns tokenResult
+        every { tokenService.issueTokens("new-user-id", Role.TEACHER) } returns tokenResult
 
         val result = useCase.completeSignup(request)
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/LoginUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/LoginUseCase.kt
@@ -2,7 +2,6 @@ package com.sclass.supporters.auth.usecase
 
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.token.service.TokenDomainService
-import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.service.UserDomainService
 import com.sclass.supporters.auth.dto.LoginRequest
 import com.sclass.supporters.auth.dto.TokenResponse
@@ -15,17 +14,11 @@ class LoginUseCase(
 ) {
     @Transactional
     fun execute(request: LoginRequest): TokenResponse {
-        val user =
-            userService.authenticate(
-                request.email,
-                request.password,
-                Platform.SUPPORTERS,
-                request.role,
-            )
+        val user = userService.authenticate(request.email, request.password, request.role)
 
-        userService.activateIfApproved(user.id, Platform.SUPPORTERS, request.role)
+        userService.activateIfApproved(user.id, request.role)
 
-        val tokens = tokenService.issueTokens(user.id, request.role, Platform.SUPPORTERS)
+        val tokens = tokenService.issueTokens(user.id, request.role)
         return TokenResponse(
             accessToken = tokens.accessToken,
             refreshToken = tokens.refreshToken,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/OAuthLoginUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/OAuthLoginUseCase.kt
@@ -41,8 +41,8 @@ class OAuthLoginUseCase(
             )
 
         if (user != null) {
-            userService.activateIfApproved(user.id, request.platform, request.role)
-            val tokens = tokenService.issueTokens(user.id, request.role, request.platform)
+            userService.activateIfApproved(user.id, request.role)
+            val tokens = tokenService.issueTokens(user.id, request.role)
             return OAuthLoginResponse(
                 isNewUser = false,
                 accessToken = tokens.accessToken,
@@ -89,7 +89,7 @@ class OAuthLoginUseCase(
 
         createRoleProfile(user, role)
 
-        val tokens = tokenService.issueTokens(user.id, role, platform)
+        val tokens = tokenService.issueTokens(user.id, role)
         return TokenResponse(
             accessToken = tokens.accessToken,
             refreshToken = tokens.refreshToken,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/RefreshUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/RefreshUseCase.kt
@@ -3,7 +3,6 @@ package com.sclass.supporters.auth.usecase
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.token.service.TokenDomainService
 import com.sclass.domain.domains.user.adaptor.UserAdaptor
-import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.supporters.auth.dto.RefreshRequest
 import com.sclass.supporters.auth.dto.TokenResponse
@@ -22,7 +21,7 @@ class RefreshUseCase(
         val userId = tokenDomainService.resolveUserId(request.refreshToken)
         userAdaptor.findById(userId)
         tokenDomainService.revokeAllByUserId(userId)
-        val tokens = tokenDomainService.issueTokens(userId, role, Platform.SUPPORTERS)
+        val tokens = tokenDomainService.issueTokens(userId, role)
         return TokenResponse(
             accessToken = tokens.accessToken,
             refreshToken = tokens.refreshToken,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/RegisterUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/RegisterUseCase.kt
@@ -44,7 +44,7 @@ class RegisterUseCase(
 
         createRoleProfile(user, request.role)
 
-        val tokens = tokenService.issueTokens(user.id, request.role, Platform.SUPPORTERS)
+        val tokens = tokenService.issueTokens(user.id, request.role)
         return TokenResponse(
             accessToken = tokens.accessToken,
             refreshToken = tokens.refreshToken,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/config/WebConfig.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/config/WebConfig.kt
@@ -3,8 +3,6 @@ package com.sclass.supporters.config
 import com.sclass.common.jwt.CurrentUserIdArgumentResolver
 import com.sclass.common.jwt.CurrentUserRoleArgumentResolver
 import com.sclass.common.jwt.JwtAuthInterceptor
-import com.sclass.common.jwt.PlatformAuthInterceptor
-import com.sclass.domain.domains.user.domain.Platform
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
@@ -19,15 +17,6 @@ class WebConfig(
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry
             .addInterceptor(jwtAuthInterceptor)
-            .addPathPatterns("/api/**")
-            .excludePathPatterns(
-                "/api/v1/auth/**",
-                "/api/v1/oauth/**",
-                "/api/v1/auth/phone/**",
-                "/api/v1/payments/nicepay",
-            )
-        registry
-            .addInterceptor(PlatformAuthInterceptor(Platform.SUPPORTERS.name))
             .addPathPatterns("/api/**")
             .excludePathPatterns(
                 "/api/v1/auth/**",

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/OAuthLoginUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/OAuthLoginUseCaseTest.kt
@@ -68,8 +68,8 @@ class OAuthLoginUseCaseTest {
         every { oAuthClient.fetchUserInfo("oauth-access-token") } returns userInfo
         every { userService.findByOAuthOrNull("oauth-id", AuthProvider.GOOGLE) } returns user
         every { userService.ensureUserRole("user-id", Platform.SUPPORTERS, Role.STUDENT) } just runs
-        every { userService.activateIfApproved("user-id", Platform.SUPPORTERS, Role.STUDENT) } just Runs
-        every { tokenService.issueTokens("user-id", Role.STUDENT, Platform.SUPPORTERS) } returns tokenResult
+        every { userService.activateIfApproved("user-id", Role.STUDENT) } just Runs
+        every { tokenService.issueTokens("user-id", Role.STUDENT) } returns tokenResult
 
         val result = useCase.login(request)
 
@@ -96,8 +96,8 @@ class OAuthLoginUseCaseTest {
         every { oAuthClient.fetchUserInfo("oauth-access-token") } returns userInfo
         every { userService.findByOAuthOrNull("oauth-id", AuthProvider.GOOGLE) } returns user
         every { userService.ensureUserRole("user-id", Platform.SUPPORTERS, Role.TEACHER) } just runs
-        every { userService.activateIfApproved("user-id", Platform.SUPPORTERS, Role.TEACHER) } just Runs
-        every { tokenService.issueTokens("user-id", Role.TEACHER, Platform.SUPPORTERS) } returns tokenResult
+        every { userService.activateIfApproved("user-id", Role.TEACHER) } just Runs
+        every { tokenService.issueTokens("user-id", Role.TEACHER) } returns tokenResult
 
         useCase.login(request)
 
@@ -128,8 +128,8 @@ class OAuthLoginUseCaseTest {
                 role = Role.STUDENT,
             )
         } returns user
-        every { userService.activateIfApproved("linked-user-id", Platform.SUPPORTERS, Role.STUDENT) } just Runs
-        every { tokenService.issueTokens("linked-user-id", Role.STUDENT, Platform.SUPPORTERS) } returns tokenResult
+        every { userService.activateIfApproved("linked-user-id", Role.STUDENT) } just Runs
+        every { tokenService.issueTokens("linked-user-id", Role.STUDENT) } returns tokenResult
 
         val result = useCase.login(request)
 
@@ -231,7 +231,7 @@ class OAuthLoginUseCaseTest {
                 role = Role.STUDENT,
             )
         } returns user
-        every { tokenService.issueTokens("new-user-id", Role.STUDENT, Platform.SUPPORTERS) } returns tokenResult
+        every { tokenService.issueTokens("new-user-id", Role.STUDENT) } returns tokenResult
 
         val result = useCase.completeSignup(request)
 
@@ -274,7 +274,7 @@ class OAuthLoginUseCaseTest {
                 role = Role.TEACHER,
             )
         } returns user
-        every { tokenService.issueTokens("user-id", Role.TEACHER, Platform.SUPPORTERS) } returns tokenResult
+        every { tokenService.issueTokens("user-id", Role.TEACHER) } returns tokenResult
 
         useCase.completeSignup(request)
 
@@ -326,7 +326,7 @@ class OAuthLoginUseCaseTest {
                 role = Role.STUDENT,
             )
         } returns user
-        every { tokenService.issueTokens("user-id", Role.STUDENT, Platform.SUPPORTERS) } returns tokenResult
+        every { tokenService.issueTokens("user-id", Role.STUDENT) } returns tokenResult
 
         useCase.completeSignup(request)
 
@@ -342,7 +342,7 @@ class OAuthLoginUseCaseTest {
                 role = Role.STUDENT,
             )
         }
-        verify { tokenService.issueTokens("user-id", Role.STUDENT, Platform.SUPPORTERS) }
+        verify { tokenService.issueTokens("user-id", Role.STUDENT) }
     }
 
     @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/RegisterUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/RegisterUseCaseTest.kt
@@ -62,7 +62,7 @@ class RegisterUseCaseTest {
 
         val user = User(email = "test@example.com", name = "홍길동", authProvider = AuthProvider.EMAIL, phoneNumber = "010-1234-5678")
         every { userService.register(any(), any(), Platform.SUPPORTERS, Role.STUDENT) } returns user
-        every { tokenService.issueTokens(user.id, Role.STUDENT, Platform.SUPPORTERS) } returns
+        every { tokenService.issueTokens(user.id, Role.STUDENT) } returns
             TokenResult(accessToken = "access", refreshToken = "refresh")
 
         val result = useCase.execute(createRequest())

--- a/SClass-Common/src/main/kotlin/com/sclass/common/jwt/AccessTokenInfo.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/jwt/AccessTokenInfo.kt
@@ -3,5 +3,4 @@ package com.sclass.common.jwt
 data class AccessTokenInfo(
     val userId: String,
     val role: String,
-    val platform: String,
 )

--- a/SClass-Common/src/main/kotlin/com/sclass/common/jwt/JwtAuthInterceptor.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/jwt/JwtAuthInterceptor.kt
@@ -38,7 +38,6 @@ class JwtAuthInterceptor(
 
         request.setAttribute(USER_ID_ATTRIBUTE, tokenInfo.userId)
         request.setAttribute(USER_ROLE_ATTRIBUTE, tokenInfo.role)
-        request.setAttribute(USER_PLATFORM_ATTRIBUTE, tokenInfo.platform)
         return true
     }
 }

--- a/SClass-Common/src/main/kotlin/com/sclass/common/jwt/JwtTokenProvider.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/jwt/JwtTokenProvider.kt
@@ -65,7 +65,6 @@ class JwtTokenProvider(
     fun generateAccessToken(
         userId: String,
         role: String,
-        platform: String,
     ): String {
         val issuedAt = Date()
         val expiration = Date(issuedAt.time + jwtProperties.accessExp * MILLI_TO_SECOND)
@@ -76,7 +75,6 @@ class JwtTokenProvider(
             .subject(userId)
             .claim(TOKEN_TYPE, ACCESS_TOKEN)
             .claim(ROLE, role)
-            .claim(PLATFORM, platform)
             .expiration(expiration)
             .signWith(secretKey)
             .compact()
@@ -102,11 +100,9 @@ class JwtTokenProvider(
             throw InvalidTokenException()
         }
         val role = claims.get(ROLE, String::class.java)
-        val platform = claims.get(PLATFORM, String::class.java)
         return AccessTokenInfo(
             userId = claims.subject,
             role = role,
-            platform = platform,
         )
     }
 

--- a/SClass-Common/src/test/kotlin/com/sclass/common/jwt/JwtAuthInterceptorTest.kt
+++ b/SClass-Common/src/test/kotlin/com/sclass/common/jwt/JwtAuthInterceptorTest.kt
@@ -26,7 +26,7 @@ class JwtAuthInterceptorTest {
 
     @Test
     fun `유효한 Bearer 토큰이면 userId와 role을 request에 저장한다`() {
-        val accessToken = jwtTokenProvider.generateAccessToken("user-123", "ADMIN", "BACKOFFICE")
+        val accessToken = jwtTokenProvider.generateAccessToken("user-123", "ADMIN")
         val encryptedToken = aesTokenEncryptor.encrypt(accessToken)
 
         val request = MockHttpServletRequest()
@@ -38,7 +38,6 @@ class JwtAuthInterceptorTest {
         assertTrue(result)
         assertEquals("user-123", request.getAttribute(JwtAuthInterceptor.USER_ID_ATTRIBUTE))
         assertEquals("ADMIN", request.getAttribute(JwtAuthInterceptor.USER_ROLE_ATTRIBUTE))
-        assertEquals("BACKOFFICE", request.getAttribute(JwtAuthInterceptor.USER_PLATFORM_ATTRIBUTE))
     }
 
     @Test

--- a/SClass-Common/src/test/kotlin/com/sclass/common/jwt/JwtTokenProviderTest.kt
+++ b/SClass-Common/src/test/kotlin/com/sclass/common/jwt/JwtTokenProviderTest.kt
@@ -24,13 +24,12 @@ class JwtTokenProviderTest {
 
     @Test
     fun `access token 생성 후 파싱하면 userId와 role이 복원된다`() {
-        val token = provider.generateAccessToken("user-123", "STUDENT", "SUPPORTERS")
+        val token = provider.generateAccessToken("user-123", "STUDENT")
 
         val info = provider.parseAccessToken(token)
 
         assertEquals("user-123", info.userId)
         assertEquals("STUDENT", info.role)
-        assertEquals("SUPPORTERS", info.platform)
     }
 
     @Test
@@ -95,7 +94,7 @@ class JwtTokenProviderTest {
 
     @Test
     fun `access token으로 refresh token 파싱을 시도하면 InvalidTokenException이 발생한다`() {
-        val accessToken = provider.generateAccessToken("user-id", "STUDENT", "SUPPORTERS")
+        val accessToken = provider.generateAccessToken("user-id", "STUDENT")
 
         assertThrows<InvalidTokenException> {
             provider.parseRefreshToken(accessToken)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/service/TokenDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/service/TokenDomainService.kt
@@ -26,9 +26,8 @@ class TokenDomainService(
     fun issueTokens(
         userId: String,
         role: Role,
-        platform: Platform,
     ): TokenResult {
-        val accessToken = jwtTokenProvider.generateAccessToken(userId, role.name, platform.name)
+        val accessToken = jwtTokenProvider.generateAccessToken(userId, role.name)
         val refreshJwt = jwtTokenProvider.generateRefreshToken(userId)
 
         refreshTokenAdaptor.save(

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/adaptor/UserRoleAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/adaptor/UserRoleAdaptor.kt
@@ -29,8 +29,8 @@ class UserRoleAdaptor(
         role: Role,
     ): UserRole? = userRoleRepository.findByUserIdAndPlatformAndRole(userId, platform, role)
 
-    fun findByUserIdAndRole(
+    fun findAllByUserIdAndRole(
         userId: String,
         role: Role,
-    ): UserRole? = userRoleRepository.findFirstByUserIdAndRoleOrderByCreatedAtDesc(userId, role)
+    ): List<UserRole> = userRoleRepository.findAllByUserIdAndRole(userId, role)
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/adaptor/UserRoleAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/adaptor/UserRoleAdaptor.kt
@@ -32,5 +32,5 @@ class UserRoleAdaptor(
     fun findByUserIdAndRole(
         userId: String,
         role: Role,
-    ): UserRole? = userRoleRepository.findFirstByUserIdAndRole(userId, role)
+    ): UserRole? = userRoleRepository.findFirstByUserIdAndRoleOrderByCreatedAtDesc(userId, role)
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/adaptor/UserRoleAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/adaptor/UserRoleAdaptor.kt
@@ -28,4 +28,9 @@ class UserRoleAdaptor(
         platform: Platform,
         role: Role,
     ): UserRole? = userRoleRepository.findByUserIdAndPlatformAndRole(userId, platform, role)
+
+    fun findByUserIdAndRole(
+        userId: String,
+        role: Role,
+    ): UserRole? = userRoleRepository.findFirstByUserIdAndRole(userId, role)
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/repository/UserRoleRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/repository/UserRoleRepository.kt
@@ -17,4 +17,9 @@ interface UserRoleRepository : JpaRepository<UserRole, String> {
         platform: Platform,
         role: Role,
     ): UserRole?
+
+    fun findFirstByUserIdAndRole(
+        userId: String,
+        role: Role,
+    ): UserRole?
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/repository/UserRoleRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/repository/UserRoleRepository.kt
@@ -18,8 +18,8 @@ interface UserRoleRepository : JpaRepository<UserRole, String> {
         role: Role,
     ): UserRole?
 
-    fun findFirstByUserIdAndRoleOrderByCreatedAtDesc(
+    fun findAllByUserIdAndRole(
         userId: String,
         role: Role,
-    ): UserRole?
+    ): List<UserRole>
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/repository/UserRoleRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/repository/UserRoleRepository.kt
@@ -18,7 +18,7 @@ interface UserRoleRepository : JpaRepository<UserRole, String> {
         role: Role,
     ): UserRole?
 
-    fun findFirstByUserIdAndRole(
+    fun findFirstByUserIdAndRoleOrderByCreatedAtDesc(
         userId: String,
         role: Role,
     ): UserRole?

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/service/UserDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/service/UserDomainService.kt
@@ -64,8 +64,9 @@ class UserDomainService(
             throw InvalidPasswordException()
         }
 
-        userRoleAdaptor.findByUserIdAndRole(user.id, role)
-            ?: throw RoleNotFoundException()
+        if (userRoleAdaptor.findAllByUserIdAndRole(user.id, role).isEmpty()) {
+            throw RoleNotFoundException()
+        }
 
         return user
     }
@@ -187,11 +188,13 @@ class UserDomainService(
         userId: String,
         role: Role,
     ) {
-        val userRole = userRoleAdaptor.findByUserIdAndRole(userId, role) ?: return
-        if (userRole.state == UserRoleState.APPROVED) {
-            userRole.changeStateTo(UserRoleState.NORMAL)
-            userRoleAdaptor.save(userRole)
-        }
+        userRoleAdaptor
+            .findAllByUserIdAndRole(userId, role)
+            .filter { it.state == UserRoleState.APPROVED }
+            .forEach {
+                it.changeStateTo(UserRoleState.NORMAL)
+                userRoleAdaptor.save(it)
+            }
     }
 
     private fun initialStateFor(role: Role): UserRoleState = if (role == Role.TEACHER) UserRoleState.DRAFT else UserRoleState.NORMAL

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/service/UserDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/service/UserDomainService.kt
@@ -52,7 +52,6 @@ class UserDomainService(
     fun authenticate(
         email: String,
         rawPassword: String,
-        platform: Platform,
         role: Role,
     ): User {
         val user = userAdaptor.findByEmail(email)
@@ -65,7 +64,7 @@ class UserDomainService(
             throw InvalidPasswordException()
         }
 
-        userRoleAdaptor.findByUserIdAndPlatformAndRole(user.id, platform, role)
+        userRoleAdaptor.findByUserIdAndRole(user.id, role)
             ?: throw RoleNotFoundException()
 
         return user
@@ -186,10 +185,9 @@ class UserDomainService(
 
     fun activateIfApproved(
         userId: String,
-        platform: Platform,
         role: Role,
     ) {
-        val userRole = userRoleAdaptor.findByUserIdAndPlatformAndRole(userId, platform, role) ?: return
+        val userRole = userRoleAdaptor.findByUserIdAndRole(userId, role) ?: return
         if (userRole.state == UserRoleState.APPROVED) {
             userRole.changeStateTo(UserRoleState.NORMAL)
             userRoleAdaptor.save(userRole)

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceIntegrationTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceIntegrationTest.kt
@@ -32,7 +32,7 @@ class TokenDomainServiceIntegrationTest {
         val userId = "test-user-id-0000000000001"
 
         // when
-        val result = tokenDomainService.issueTokens(userId, Role.STUDENT, Platform.SUPPORTERS)
+        val result = tokenDomainService.issueTokens(userId, Role.STUDENT)
 
         // then
         assertThat(result.accessToken).isNotBlank()
@@ -72,8 +72,8 @@ class TokenDomainServiceIntegrationTest {
     fun `revokeAllByUserId로 해당 유저의 모든 RefreshToken이 삭제된다`() {
         // given
         val userId = "test-user-id-0000000000002"
-        tokenDomainService.issueTokens(userId, Role.STUDENT, Platform.SUPPORTERS)
-        tokenDomainService.issueTokens(userId, Role.STUDENT, Platform.SUPPORTERS)
+        tokenDomainService.issueTokens(userId, Role.STUDENT)
+        tokenDomainService.issueTokens(userId, Role.STUDENT)
         assertThat(refreshTokenRepository.findAllByUserId(userId)).hasSize(2)
 
         // when

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceTest.kt
@@ -40,14 +40,14 @@ class TokenDomainServiceTest {
     inner class IssueTokens {
         @Test
         fun `암호화된 access token과 refresh token을 반환한다`() {
-            every { jwtTokenProvider.generateAccessToken("user-id", "STUDENT", "SUPPORTERS") } returns "raw-access"
+            every { jwtTokenProvider.generateAccessToken("user-id", "STUDENT") } returns "raw-access"
             every { jwtTokenProvider.generateRefreshToken("user-id") } returns "raw-refresh"
             every { jwtTokenProvider.getRefreshTokenTtlSecond() } returns 604800L
             every { aesTokenEncryptor.encrypt("raw-access") } returns "encrypted-access"
             every { aesTokenEncryptor.encrypt("raw-refresh") } returns "encrypted-refresh"
             every { refreshTokenAdaptor.save(any()) } returns mockk()
 
-            val result = tokenDomainService.issueTokens("user-id", Role.STUDENT, Platform.SUPPORTERS)
+            val result = tokenDomainService.issueTokens("user-id", Role.STUDENT)
 
             assertEquals("encrypted-access", result.accessToken)
             assertEquals("encrypted-refresh", result.refreshToken)
@@ -56,13 +56,13 @@ class TokenDomainServiceTest {
         @Test
         fun `RefreshToken이 저장된다`() {
             val refreshTokenSlot = slot<RefreshToken>()
-            every { jwtTokenProvider.generateAccessToken("user-id", "STUDENT", "SUPPORTERS") } returns "raw-access"
+            every { jwtTokenProvider.generateAccessToken("user-id", "STUDENT") } returns "raw-access"
             every { jwtTokenProvider.generateRefreshToken("user-id") } returns "raw-refresh"
             every { jwtTokenProvider.getRefreshTokenTtlSecond() } returns 604800L
             every { aesTokenEncryptor.encrypt(any()) } returns "encrypted"
             every { refreshTokenAdaptor.save(capture(refreshTokenSlot)) } returns mockk()
 
-            tokenDomainService.issueTokens("user-id", Role.STUDENT, Platform.SUPPORTERS)
+            tokenDomainService.issueTokens("user-id", Role.STUDENT)
 
             assertEquals("user-id", refreshTokenSlot.captured.userId)
         }

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/user/service/UserDomainServiceTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/user/service/UserDomainServiceTest.kt
@@ -111,11 +111,9 @@ class UserDomainServiceTest {
                 )
             every { userAdaptor.findByEmail("test@example.com") } returns user
             every { passwordService.matches("rawPw", "hashedPw") } returns true
-            every {
-                userRoleAdaptor.findByUserIdAndPlatformAndRole(user.id, Platform.SUPPORTERS, Role.STUDENT)
-            } returns mockk()
+            every { userRoleAdaptor.findByUserIdAndRole(user.id, Role.STUDENT) } returns mockk()
 
-            val result = userDomainService.authenticate("test@example.com", "rawPw", Platform.SUPPORTERS, Role.STUDENT)
+            val result = userDomainService.authenticate("test@example.com", "rawPw", Role.STUDENT)
 
             assertEquals(user, result)
         }
@@ -132,7 +130,7 @@ class UserDomainServiceTest {
             every { userAdaptor.findByEmail("test@example.com") } returns user
 
             assertThrows<InvalidPasswordException> {
-                userDomainService.authenticate("test@example.com", "rawPw", Platform.SUPPORTERS, Role.STUDENT)
+                userDomainService.authenticate("test@example.com", "rawPw", Role.STUDENT)
             }
         }
 
@@ -149,7 +147,7 @@ class UserDomainServiceTest {
             every { passwordService.matches("wrongPw", "hashedPw") } returns false
 
             assertThrows<InvalidPasswordException> {
-                userDomainService.authenticate("test@example.com", "wrongPw", Platform.SUPPORTERS, Role.STUDENT)
+                userDomainService.authenticate("test@example.com", "wrongPw", Role.STUDENT)
             }
         }
 
@@ -164,12 +162,10 @@ class UserDomainServiceTest {
                 )
             every { userAdaptor.findByEmail("test@example.com") } returns user
             every { passwordService.matches("rawPw", "hashedPw") } returns true
-            every {
-                userRoleAdaptor.findByUserIdAndPlatformAndRole(user.id, Platform.LMS, Role.ADMIN)
-            } returns null
+            every { userRoleAdaptor.findByUserIdAndRole(user.id, Role.ADMIN) } returns null
 
             assertThrows<RoleNotFoundException> {
-                userDomainService.authenticate("test@example.com", "rawPw", Platform.LMS, Role.ADMIN)
+                userDomainService.authenticate("test@example.com", "rawPw", Role.ADMIN)
             }
         }
     }

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/user/service/UserDomainServiceTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/user/service/UserDomainServiceTest.kt
@@ -111,7 +111,7 @@ class UserDomainServiceTest {
                 )
             every { userAdaptor.findByEmail("test@example.com") } returns user
             every { passwordService.matches("rawPw", "hashedPw") } returns true
-            every { userRoleAdaptor.findByUserIdAndRole(user.id, Role.STUDENT) } returns mockk()
+            every { userRoleAdaptor.findAllByUserIdAndRole(user.id, Role.STUDENT) } returns listOf(mockk())
 
             val result = userDomainService.authenticate("test@example.com", "rawPw", Role.STUDENT)
 
@@ -162,7 +162,7 @@ class UserDomainServiceTest {
                 )
             every { userAdaptor.findByEmail("test@example.com") } returns user
             every { passwordService.matches("rawPw", "hashedPw") } returns true
-            every { userRoleAdaptor.findByUserIdAndRole(user.id, Role.ADMIN) } returns null
+            every { userRoleAdaptor.findAllByUserIdAndRole(user.id, Role.ADMIN) } returns emptyList()
 
             assertThrows<RoleNotFoundException> {
                 userDomainService.authenticate("test@example.com", "rawPw", Role.ADMIN)


### PR DESCRIPTION
## Summary
- 로그인 시 platform 체크 제거 — Supporters/LMS 구분 없이 동일한 계정으로 로그인 가능
- JWT access token에서 `platform` claim 제거
- `PlatformAuthInterceptor` 전체 모듈에서 제거

## Changes
- `JwtTokenProvider.generateAccessToken()` — platform 파라미터 제거
- `AccessTokenInfo` — platform 필드 제거
- `UserDomainService.authenticate()` — platform 파라미터 제거, `findByUserIdAndRole()`로 조회
- `UserDomainService.activateIfApproved()` — platform 파라미터 제거
- `TokenDomainService.issueTokens()` — platform 파라미터 제거
- `UserRoleAdaptor/Repository` — `findByUserIdAndRole()` 추가
- Supporters / LMS / Backoffice `WebConfig` — `PlatformAuthInterceptor` 제거

## 유지되는 것
- 회원가입 시 `UserRole.platform` 저장 (DB 마이그레이션 불필요)
- OAuth signup token에는 platform 유지 (가입 플로우에서 필요)

## Test plan
- [ ] 기존 테스트 전체 통과 확인
- [ ] Supporters 계정으로 로그인 → 토큰 발급 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)