### PR TITLE
fix: 레슨 조회 API 권한 검증 추가

### DIFF
--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/controller/CommissionController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/controller/CommissionController.kt
@@ -117,6 +117,7 @@ class CommissionController(
 
     @GetMapping("/{commissionId}/lesson")
     fun getLesson(
+        @CurrentUserId userId: String,
         @PathVariable commissionId: Long,
-    ): ApiResponse<LessonResponse> = ApiResponse.success(getCommissionLessonUseCase.execute(commissionId))
+    ): ApiResponse<LessonResponse> = ApiResponse.success(getCommissionLessonUseCase.execute(userId, commissionId))
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/GetCommissionLessonUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/GetCommissionLessonUseCase.kt
@@ -1,6 +1,8 @@
 package com.sclass.supporters.commission.usecase
 
 import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
+import com.sclass.domain.domains.commission.exception.CommissionUnauthorizedAccessException
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.exception.LessonNotFoundException
 import com.sclass.supporters.lesson.dto.LessonResponse
@@ -8,10 +10,18 @@ import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class GetCommissionLessonUseCase(
+    private val commissionAdaptor: CommissionAdaptor,
     private val lessonAdaptor: LessonAdaptor,
 ) {
     @Transactional(readOnly = true)
-    fun execute(commissionId: Long): LessonResponse {
+    fun execute(
+        userId: String,
+        commissionId: Long,
+    ): LessonResponse {
+        val commission = commissionAdaptor.findById(commissionId)
+        if (commission.studentUserId != userId && commission.teacherUserId != userId) {
+            throw CommissionUnauthorizedAccessException()
+        }
         val lesson = lessonAdaptor.findByCommission(commissionId) ?: throw LessonNotFoundException()
         return LessonResponse.from(lesson)
     }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/controller/EnrollmentController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/controller/EnrollmentController.kt
@@ -48,6 +48,7 @@ class EnrollmentController(
 
     @GetMapping("/{enrollmentId}/lessons")
     fun getEnrollmentLessons(
+        @CurrentUserId userId: String,
         @PathVariable enrollmentId: Long,
-    ): ApiResponse<List<LessonResponse>> = success(getEnrollmentLessonsUseCase.execute(enrollmentId))
+    ): ApiResponse<List<LessonResponse>> = success(getEnrollmentLessonsUseCase.execute(userId, enrollmentId))
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCase.kt
@@ -1,14 +1,26 @@
 package com.sclass.supporters.enrollment.usecase
 
 import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.exception.EnrollmentUnauthorizedAccessException
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.supporters.lesson.dto.LessonResponse
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class GetEnrollmentLessonsUseCase(
+    private val enrollmentAdaptor: EnrollmentAdaptor,
     private val lessonAdaptor: LessonAdaptor,
 ) {
     @Transactional(readOnly = true)
-    fun execute(enrollmentId: Long): List<LessonResponse> = lessonAdaptor.findAllByEnrollment(enrollmentId).map { LessonResponse.from(it) }
+    fun execute(
+        userId: String,
+        enrollmentId: Long,
+    ): List<LessonResponse> {
+        val enrollment = enrollmentAdaptor.findById(enrollmentId)
+        if (enrollment.studentUserId != userId) {
+            throw EnrollmentUnauthorizedAccessException()
+        }
+        return lessonAdaptor.findAllByEnrollment(enrollmentId).map { LessonResponse.from(it) }
+    }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonInquiryPlanUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonInquiryPlanUseCase.kt
@@ -3,6 +3,7 @@ package com.sclass.supporters.lesson.usecase
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.inquiryplan.domain.InquiryPlanSourceType
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
 import com.sclass.supporters.inquiry.dto.CreateInquiryPlanRequest
 import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
 import com.sclass.supporters.inquiry.usecase.CreateInquiryPlanUseCase
@@ -19,8 +20,8 @@ class CreateLessonInquiryPlanUseCase(
         request: CreateLessonInquiryPlanRequest,
     ): InquiryPlanResponse {
         val lesson = lessonAdaptor.findById(lessonId)
-        require(lesson.assignedTeacherUserId == userId) {
-            "선생님만 탐구 계획을 생성할 수 있습니다"
+        if (lesson.assignedTeacherUserId != userId) {
+            throw LessonUnauthorizedAccessException()
         }
         return createInquiryPlanUseCase.execute(
             userId,

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/GetCommissionLessonUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/GetCommissionLessonUseCaseTest.kt
@@ -1,5 +1,8 @@
 package com.sclass.supporters.commission.usecase
 
+import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
+import com.sclass.domain.domains.commission.domain.Commission
+import com.sclass.domain.domains.commission.exception.CommissionUnauthorizedAccessException
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.lesson.domain.LessonType
@@ -13,6 +16,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class GetCommissionLessonUseCaseTest {
+    private lateinit var commissionAdaptor: CommissionAdaptor
     private lateinit var lessonAdaptor: LessonAdaptor
     private lateinit var useCase: GetCommissionLessonUseCase
 
@@ -22,9 +26,16 @@ class GetCommissionLessonUseCaseTest {
 
     @BeforeEach
     fun setUp() {
+        commissionAdaptor = mockk()
         lessonAdaptor = mockk()
-        useCase = GetCommissionLessonUseCase(lessonAdaptor)
+        useCase = GetCommissionLessonUseCase(commissionAdaptor, lessonAdaptor)
     }
+
+    private fun commission() =
+        mockk<Commission>(relaxed = true) {
+            every { studentUserId } returns this@GetCommissionLessonUseCaseTest.studentUserId
+            every { teacherUserId } returns this@GetCommissionLessonUseCaseTest.teacherUserId
+        }
 
     private fun lesson() =
         Lesson(
@@ -37,10 +48,11 @@ class GetCommissionLessonUseCaseTest {
         )
 
     @Test
-    fun `의뢰에 연결된 레슨을 반환한다`() {
+    fun `학생이 자신의 의뢰 레슨을 조회한다`() {
+        every { commissionAdaptor.findById(commissionId) } returns commission()
         every { lessonAdaptor.findByCommission(commissionId) } returns lesson()
 
-        val result = useCase.execute(commissionId)
+        val result = useCase.execute(studentUserId, commissionId)
 
         assertAll(
             { assertEquals(LessonType.COMMISSION, result.lessonType) },
@@ -49,11 +61,34 @@ class GetCommissionLessonUseCaseTest {
     }
 
     @Test
-    fun `의뢰에 연결된 레슨이 없으면 예외가 발생한다`() {
+    fun `선생님이 담당 의뢰 레슨을 조회한다`() {
+        every { commissionAdaptor.findById(commissionId) } returns commission()
+        every { lessonAdaptor.findByCommission(commissionId) } returns lesson()
+
+        val result = useCase.execute(teacherUserId, commissionId)
+
+        assertAll(
+            { assertEquals(LessonType.COMMISSION, result.lessonType) },
+            { assertEquals(commissionId, result.sourceCommissionId) },
+        )
+    }
+
+    @Test
+    fun `당사자가 아니면 CommissionUnauthorizedAccessException이 발생한다`() {
+        every { commissionAdaptor.findById(commissionId) } returns commission()
+
+        assertThrows<CommissionUnauthorizedAccessException> {
+            useCase.execute("other-user-id-0000000000001", commissionId)
+        }
+    }
+
+    @Test
+    fun `의뢰에 연결된 레슨이 없으면 LessonNotFoundException이 발생한다`() {
+        every { commissionAdaptor.findById(commissionId) } returns commission()
         every { lessonAdaptor.findByCommission(commissionId) } returns null
 
         assertThrows<LessonNotFoundException> {
-            useCase.execute(commissionId)
+            useCase.execute(studentUserId, commissionId)
         }
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCaseTest.kt
@@ -1,5 +1,8 @@
 package com.sclass.supporters.enrollment.usecase
 
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.exception.EnrollmentUnauthorizedAccessException
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.lesson.domain.LessonStatus
@@ -10,8 +13,10 @@ import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class GetEnrollmentLessonsUseCaseTest {
+    private lateinit var enrollmentAdaptor: EnrollmentAdaptor
     private lateinit var lessonAdaptor: LessonAdaptor
     private lateinit var useCase: GetEnrollmentLessonsUseCase
 
@@ -21,9 +26,15 @@ class GetEnrollmentLessonsUseCaseTest {
 
     @BeforeEach
     fun setUp() {
+        enrollmentAdaptor = mockk()
         lessonAdaptor = mockk()
-        useCase = GetEnrollmentLessonsUseCase(lessonAdaptor)
+        useCase = GetEnrollmentLessonsUseCase(enrollmentAdaptor, lessonAdaptor)
     }
+
+    private fun enrollment() =
+        mockk<Enrollment>(relaxed = true) {
+            every { studentUserId } returns this@GetEnrollmentLessonsUseCaseTest.studentUserId
+        }
 
     private fun lesson(lessonNumber: Int = 1) =
         Lesson(
@@ -39,9 +50,10 @@ class GetEnrollmentLessonsUseCaseTest {
     @Test
     fun `수강신청에 속한 레슨 목록을 반환한다`() {
         val lessons = listOf(lesson(1), lesson(2))
+        every { enrollmentAdaptor.findById(enrollmentId) } returns enrollment()
         every { lessonAdaptor.findAllByEnrollment(enrollmentId) } returns lessons
 
-        val result = useCase.execute(enrollmentId)
+        val result = useCase.execute(studentUserId, enrollmentId)
 
         assertAll(
             { assertEquals(2, result.size) },
@@ -53,10 +65,20 @@ class GetEnrollmentLessonsUseCaseTest {
 
     @Test
     fun `레슨이 없으면 빈 목록을 반환한다`() {
+        every { enrollmentAdaptor.findById(enrollmentId) } returns enrollment()
         every { lessonAdaptor.findAllByEnrollment(enrollmentId) } returns emptyList()
 
-        val result = useCase.execute(enrollmentId)
+        val result = useCase.execute(studentUserId, enrollmentId)
 
         assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `본인의 수강이 아니면 EnrollmentUnauthorizedAccessException이 발생한다`() {
+        every { enrollmentAdaptor.findById(enrollmentId) } returns enrollment()
+
+        assertThrows<EnrollmentUnauthorizedAccessException> {
+            useCase.execute("other-user-id-0000000000001", enrollmentId)
+        }
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonInquiryPlanUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonInquiryPlanUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.sclass.domain.domains.inquiryplan.domain.InquiryPlanSourceType
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
 import com.sclass.supporters.inquiry.dto.CreateInquiryPlanRequest
 import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
 import com.sclass.supporters.inquiry.usecase.CreateInquiryPlanUseCase
@@ -68,7 +69,7 @@ class CreateLessonInquiryPlanUseCaseTest {
     fun `학생은 탐구 계획을 생성할 수 없다`() {
         every { lessonAdaptor.findById(1L) } returns lesson()
 
-        assertThrows<IllegalArgumentException> {
+        assertThrows<LessonUnauthorizedAccessException> {
             useCase.execute(studentUserId, 1L, CreateLessonInquiryPlanRequest(paragraph = "탐구 내용"))
         }
     }
@@ -77,7 +78,7 @@ class CreateLessonInquiryPlanUseCaseTest {
     fun `담당 선생님이 아니면 탐구 계획을 생성할 수 없다`() {
         every { lessonAdaptor.findById(1L) } returns lesson()
 
-        assertThrows<IllegalArgumentException> {
+        assertThrows<LessonUnauthorizedAccessException> {
             useCase.execute("other-teacher-id-000000001", 1L, CreateLessonInquiryPlanRequest(paragraph = "탐구 내용"))
         }
     }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/exception/CommissionUnauthorizedAccessException.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/exception/CommissionUnauthorizedAccessException.kt
@@ -1,0 +1,5 @@
+package com.sclass.domain.domains.commission.exception
+
+import com.sclass.common.exception.BusinessException
+
+class CommissionUnauthorizedAccessException : BusinessException(CommissionErrorCode.UNAUTHORIZED_ACCESS)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentErrorCode.kt
@@ -14,4 +14,5 @@ enum class EnrollmentErrorCode(
     ENROLLMENT_DUPLICATE_PAYMENT("ENROLLMENT_005", "이미 처리된 결제입니다", 409),
     ENROLLMENT_NOT_ACTIVE("ENROLLMENT_006", "활성 상태의 수강 등록이 아닙니다", 400),
     ENROLLMENT_TYPE_MISMATCH("ENROLLMENT_007", "해당 작업은 이 등록 유형에서 허용되지 않습니다", 400),
+    ENROLLMENT_UNAUTHORIZED_ACCESS("ENROLLMENT_008", "해당 수강에 대한 권한이 없습니다", 403),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentUnauthorizedAccessException.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentUnauthorizedAccessException.kt
@@ -1,0 +1,5 @@
+package com.sclass.domain.domains.enrollment.exception
+
+import com.sclass.common.exception.BusinessException
+
+class EnrollmentUnauthorizedAccessException : BusinessException(EnrollmentErrorCode.ENROLLMENT_UNAUTHORIZED_ACCESS)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonErrorCode.kt
@@ -17,4 +17,5 @@ enum class LessonErrorCode(
     LESSON_REPORT_ALREADY_APPROVED("LESSON_007", "이미 승인된 리포트입니다", 409),
     LESSON_REPORT_INVALID_STATUS_TRANSITION("LESSON_008", "잘못된 리포트 상태 전이입니다", 400),
     LESSON_REPORT_REJECT_REASON_REQUIRED("LESSON_009", "반려 사유가 필요합니다", 400),
+    LESSON_UNAUTHORIZED_ACCESS("LESSON_010", "해당 수업에 대한 권한이 없습니다", 403),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonUnauthorizedAccessException.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonUnauthorizedAccessException.kt
@@ -1,0 +1,5 @@
+package com.sclass.domain.domains.lesson.exception
+
+import com.sclass.common.exception.BusinessException
+
+class LessonUnauthorizedAccessException : BusinessException(LessonErrorCode.LESSON_UNAUTHORIZED_ACCESS)


### PR DESCRIPTION
## Summary
- `GetCommissionLessonUseCase`: 의뢰 당사자(학생/선생님)만 레슨 조회 가능하도록 권한 검증 추가
- `GetEnrollmentLessonsUseCase`: 수강 학생 본인만 레슨 목록 조회 가능하도록 권한 검증 추가
- `CreateLessonInquiryPlanUseCase`: `require` → `LessonUnauthorizedAccessException` (403) 도메인 예외로 변경
- 도메인 예외 3종 추가: `CommissionUnauthorizedAccessException`, `EnrollmentUnauthorizedAccessException`, `LessonUnauthorizedAccessException`

## Test plan
- [x] GetCommissionLessonUseCaseTest: 학생/선생님 조회 성공, 비당사자 403, 레슨 없음 404
- [x] GetEnrollmentLessonsUseCaseTest: 본인 조회 성공, 비본인 403, 빈 목록
- [x] CreateLessonInquiryPlanUseCaseTest: 비담당 선생님 403 (LessonUnauthorizedAccessException)
- [x] 전체 빌드 + 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)