### PR TITLE
fix: Kotlin javaParameters 옵션 추가 (AOP argument binding)

### DIFF
--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/redis/DistributedLockAspect.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/redis/DistributedLockAspect.kt
@@ -29,11 +29,10 @@ class DistributedLockAspect(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    @Around("@annotation(distributedLock)")
-    fun around(
-        joinPoint: ProceedingJoinPoint,
-        distributedLock: DistributedLock,
-    ): Any? {
+    @Around("@annotation(com.sclass.infrastructure.redis.DistributedLock)")
+    fun around(joinPoint: ProceedingJoinPoint): Any? {
+        val signature = joinPoint.signature as MethodSignature
+        val distributedLock = signature.method.getAnnotation(DistributedLock::class.java)
         val keyValue = resolveKeyValue(joinPoint)
         val lockKey = "lock:${distributedLock.prefix}:$keyValue"
         val lock = redissonClient.getLock(lockKey)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,9 @@ subprojects {
 
     kotlin {
         jvmToolchain(21)
+        compilerOptions {
+            javaParameters.set(true)
+        }
     }
 
     repositories { mavenCentral() }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,10 @@ subprojects {
         testImplementation("com.h2database:h2")
     }
 
+    tasks.withType<JavaCompile> {
+        options.compilerArgs.add("-parameters")
+    }
+
     tasks.withType<Test> {
         useJUnitPlatform()
     }


### PR DESCRIPTION
## Summary
- Kotlin 컴파일에 `javaParameters.set(true)` 옵션 추가
- Spring Framework 7.0에서 AOP `@Around("@annotation(...)")` 파라미터 이름 resolve에 필요
- `DistributedLockAspect`에서 `IllegalStateException: Required to bind 2 arguments, but only bound 1` 발생하던 문제 수정

## Test plan
- [ ] `GrantEnrollmentUseCase` 호출 시 DistributedLock 정상 동작 확인
- [ ] 기존 DistributedLock 사용처 (payment, enrollment) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)