### PR TITLE
feat: 선생님용 내 코스 목록 조회 + enrollment lessons 권한 확장

### DIFF
--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/controller/CourseController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/controller/CourseController.kt
@@ -1,6 +1,7 @@
 package com.sclass.supporters.course.controller
 
 import com.sclass.common.annotation.CurrentUserId
+import com.sclass.common.annotation.CurrentUserRole
 import com.sclass.common.dto.ApiResponse
 import com.sclass.supporters.course.dto.CourseResponse
 import com.sclass.supporters.course.dto.MyCourseResponse
@@ -22,5 +23,6 @@ class CourseController(
     @GetMapping("/me")
     fun getMyCourseList(
         @CurrentUserId userId: String,
-    ): ApiResponse<List<MyCourseResponse>> = ApiResponse.success(getMyCourseListUseCase.execute(userId))
+        @CurrentUserRole role: String,
+    ): ApiResponse<List<MyCourseResponse>> = ApiResponse.success(getMyCourseListUseCase.execute(userId, role))
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/controller/CourseController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/controller/CourseController.kt
@@ -1,8 +1,11 @@
 package com.sclass.supporters.course.controller
 
+import com.sclass.common.annotation.CurrentUserId
 import com.sclass.common.dto.ApiResponse
 import com.sclass.supporters.course.dto.CourseResponse
+import com.sclass.supporters.course.dto.MyCourseResponse
 import com.sclass.supporters.course.usecase.GetCourseListUseCase
+import com.sclass.supporters.course.usecase.GetMyCourseListUseCase
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -11,7 +14,13 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/courses")
 class CourseController(
     private val getCourseListUseCase: GetCourseListUseCase,
+    private val getMyCourseListUseCase: GetMyCourseListUseCase,
 ) {
     @GetMapping
     fun getCourseList(): ApiResponse<List<CourseResponse>> = ApiResponse.success(getCourseListUseCase.execute())
+
+    @GetMapping("/me")
+    fun getMyCourseList(
+        @CurrentUserId userId: String,
+    ): ApiResponse<List<MyCourseResponse>> = ApiResponse.success(getMyCourseListUseCase.execute(userId))
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/dto/MyCourseResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/dto/MyCourseResponse.kt
@@ -1,0 +1,25 @@
+package com.sclass.supporters.course.dto
+
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.course.dto.CourseWithEnrollmentCountDto
+
+data class MyCourseResponse(
+    val id: Long,
+    val name: String,
+    val description: String?,
+    val productId: String,
+    val status: CourseStatus,
+    val enrollmentCount: Long,
+) {
+    companion object {
+        fun from(dto: CourseWithEnrollmentCountDto) =
+            MyCourseResponse(
+                id = dto.course.id,
+                name = dto.course.name,
+                description = dto.course.description,
+                productId = dto.course.productId,
+                status = dto.course.status,
+                enrollmentCount = dto.enrollmentCount,
+            )
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/usecase/GetMyCourseListUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/usecase/GetMyCourseListUseCase.kt
@@ -1,17 +1,35 @@
 package com.sclass.supporters.course.usecase
 
 import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.ForbiddenException
 import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.user.adaptor.UserRoleAdaptor
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.Role
 import com.sclass.supporters.course.dto.MyCourseResponse
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class GetMyCourseListUseCase(
     private val courseAdaptor: CourseAdaptor,
+    private val userRoleAdaptor: UserRoleAdaptor,
 ) {
     @Transactional(readOnly = true)
-    fun execute(teacherUserId: String): List<MyCourseResponse> =
-        courseAdaptor
-            .findAllByTeacherUserIdWithEnrollmentCount(teacherUserId)
+    fun execute(
+        userId: String,
+        role: String,
+    ): List<MyCourseResponse> {
+        if (Role.valueOf(role) != Role.TEACHER) throw ForbiddenException()
+
+        val hasLmsTeacher =
+            userRoleAdaptor
+                .findAllByUserIdAndRole(userId, Role.TEACHER)
+                .any { it.platform == Platform.LMS && it.state.isActive }
+
+        if (!hasLmsTeacher) return emptyList()
+
+        return courseAdaptor
+            .findAllByTeacherUserIdWithEnrollmentCount(userId)
             .map { MyCourseResponse.from(it) }
+    }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/usecase/GetMyCourseListUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/usecase/GetMyCourseListUseCase.kt
@@ -22,9 +22,7 @@ class GetMyCourseListUseCase(
         if (Role.valueOf(role) != Role.TEACHER) throw ForbiddenException()
 
         val hasLmsTeacher =
-            userRoleAdaptor
-                .findAllByUserIdAndRole(userId, Role.TEACHER)
-                .any { it.platform == Platform.LMS && it.state.isActive }
+            userRoleAdaptor.existsActiveByUserIdAndPlatformAndRole(userId, Platform.LMS, Role.TEACHER)
 
         if (!hasLmsTeacher) return emptyList()
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/usecase/GetMyCourseListUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/usecase/GetMyCourseListUseCase.kt
@@ -1,0 +1,17 @@
+package com.sclass.supporters.course.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.supporters.course.dto.MyCourseResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetMyCourseListUseCase(
+    private val courseAdaptor: CourseAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(teacherUserId: String): List<MyCourseResponse> =
+        courseAdaptor
+            .findAllByTeacherUserIdWithEnrollmentCount(teacherUserId)
+            .map { MyCourseResponse.from(it) }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCase.kt
@@ -1,6 +1,7 @@
 package com.sclass.supporters.enrollment.usecase
 
 import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.exception.EnrollmentUnauthorizedAccessException
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional
 @UseCase
 class GetEnrollmentLessonsUseCase(
     private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val courseAdaptor: CourseAdaptor,
     private val lessonAdaptor: LessonAdaptor,
 ) {
     @Transactional(readOnly = true)
@@ -18,9 +20,15 @@ class GetEnrollmentLessonsUseCase(
         enrollmentId: Long,
     ): List<LessonResponse> {
         val enrollment = enrollmentAdaptor.findById(enrollmentId)
-        if (enrollment.studentUserId != userId) {
+        val course = courseAdaptor.findById(enrollment.courseId)
+
+        val isStudent = enrollment.studentUserId == userId
+        val isTeacher = course.teacherUserId == userId
+
+        if (!isStudent && !isTeacher) {
             throw EnrollmentUnauthorizedAccessException()
         }
+
         return lessonAdaptor.findAllByEnrollment(enrollmentId).map { LessonResponse.from(it) }
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/course/usecase/GetMyCourseListUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/course/usecase/GetMyCourseListUseCaseTest.kt
@@ -1,0 +1,131 @@
+package com.sclass.supporters.course.usecase
+
+import com.sclass.common.exception.ForbiddenException
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.course.dto.CourseWithEnrollmentCountDto
+import com.sclass.domain.domains.user.adaptor.UserRoleAdaptor
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.domain.domains.user.domain.UserRole
+import com.sclass.domain.domains.user.domain.UserRoleState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class GetMyCourseListUseCaseTest {
+    private lateinit var courseAdaptor: CourseAdaptor
+    private lateinit var userRoleAdaptor: UserRoleAdaptor
+    private lateinit var useCase: GetMyCourseListUseCase
+
+    @BeforeEach
+    fun setUp() {
+        courseAdaptor = mockk()
+        userRoleAdaptor = mockk()
+        useCase = GetMyCourseListUseCase(courseAdaptor, userRoleAdaptor)
+    }
+
+    private fun createUserRole(
+        platform: Platform,
+        role: Role = Role.TEACHER,
+        state: UserRoleState = UserRoleState.NORMAL,
+    ) = UserRole(
+        userId = USER_ID,
+        platform = platform,
+        role = role,
+        state = state,
+    )
+
+    private fun createCourseWithCount(
+        id: Long,
+        enrollmentCount: Long,
+    ) = CourseWithEnrollmentCountDto(
+        course =
+            Course(
+                id = id,
+                productId = "product-id-0000000000000001",
+                teacherUserId = USER_ID,
+                name = "코스 $id",
+                status = CourseStatus.ACTIVE,
+            ),
+        enrollmentCount = enrollmentCount,
+    )
+
+    @Test
+    fun `LMS TEACHER는 내 코스 목록을 조회한다`() {
+        val userRoles = listOf(createUserRole(Platform.LMS))
+        val courses = listOf(createCourseWithCount(1L, 5), createCourseWithCount(2L, 3))
+
+        every { userRoleAdaptor.findAllByUserIdAndRole(USER_ID, Role.TEACHER) } returns userRoles
+        every { courseAdaptor.findAllByTeacherUserIdWithEnrollmentCount(USER_ID) } returns courses
+
+        val result = useCase.execute(USER_ID, "TEACHER")
+
+        assertEquals(2, result.size)
+        assertEquals(1L, result[0].id)
+        assertEquals(5L, result[0].enrollmentCount)
+        assertEquals(2L, result[1].id)
+        assertEquals(3L, result[1].enrollmentCount)
+        verify { courseAdaptor.findAllByTeacherUserIdWithEnrollmentCount(USER_ID) }
+    }
+
+    @Test
+    fun `Supporters TEACHER는 빈 배열을 반환한다`() {
+        val userRoles = listOf(createUserRole(Platform.SUPPORTERS))
+
+        every { userRoleAdaptor.findAllByUserIdAndRole(USER_ID, Role.TEACHER) } returns userRoles
+
+        val result = useCase.execute(USER_ID, "TEACHER")
+
+        assertTrue(result.isEmpty())
+        verify(exactly = 0) { courseAdaptor.findAllByTeacherUserIdWithEnrollmentCount(any()) }
+    }
+
+    @Test
+    fun `LMS TEACHER이지만 비활성 상태면 빈 배열을 반환한다`() {
+        val userRoles = listOf(createUserRole(Platform.LMS, state = UserRoleState.PENDING))
+
+        every { userRoleAdaptor.findAllByUserIdAndRole(USER_ID, Role.TEACHER) } returns userRoles
+
+        val result = useCase.execute(USER_ID, "TEACHER")
+
+        assertTrue(result.isEmpty())
+        verify(exactly = 0) { courseAdaptor.findAllByTeacherUserIdWithEnrollmentCount(any()) }
+    }
+
+    @Test
+    fun `STUDENT 역할이면 ForbiddenException을 던진다`() {
+        assertThrows<ForbiddenException> {
+            useCase.execute(USER_ID, "STUDENT")
+        }
+    }
+
+    @Test
+    fun `ADMIN 역할이면 ForbiddenException을 던진다`() {
+        assertThrows<ForbiddenException> {
+            useCase.execute(USER_ID, "ADMIN")
+        }
+    }
+
+    @Test
+    fun `코스가 없으면 빈 배열을 반환한다`() {
+        val userRoles = listOf(createUserRole(Platform.LMS))
+
+        every { userRoleAdaptor.findAllByUserIdAndRole(USER_ID, Role.TEACHER) } returns userRoles
+        every { courseAdaptor.findAllByTeacherUserIdWithEnrollmentCount(USER_ID) } returns emptyList()
+
+        val result = useCase.execute(USER_ID, "TEACHER")
+
+        assertTrue(result.isEmpty())
+    }
+
+    companion object {
+        private const val USER_ID = "01HXXXXXXXXXXXXXXXXXTCHRID"
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/course/usecase/GetMyCourseListUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/course/usecase/GetMyCourseListUseCaseTest.kt
@@ -8,8 +8,6 @@ import com.sclass.domain.domains.course.dto.CourseWithEnrollmentCountDto
 import com.sclass.domain.domains.user.adaptor.UserRoleAdaptor
 import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.Role
-import com.sclass.domain.domains.user.domain.UserRole
-import com.sclass.domain.domains.user.domain.UserRoleState
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -31,17 +29,6 @@ class GetMyCourseListUseCaseTest {
         useCase = GetMyCourseListUseCase(courseAdaptor, userRoleAdaptor)
     }
 
-    private fun createUserRole(
-        platform: Platform,
-        role: Role = Role.TEACHER,
-        state: UserRoleState = UserRoleState.NORMAL,
-    ) = UserRole(
-        userId = USER_ID,
-        platform = platform,
-        role = role,
-        state = state,
-    )
-
     private fun createCourseWithCount(
         id: Long,
         enrollmentCount: Long,
@@ -59,10 +46,9 @@ class GetMyCourseListUseCaseTest {
 
     @Test
     fun `LMS TEACHER는 내 코스 목록을 조회한다`() {
-        val userRoles = listOf(createUserRole(Platform.LMS))
         val courses = listOf(createCourseWithCount(1L, 5), createCourseWithCount(2L, 3))
 
-        every { userRoleAdaptor.findAllByUserIdAndRole(USER_ID, Role.TEACHER) } returns userRoles
+        every { userRoleAdaptor.existsActiveByUserIdAndPlatformAndRole(USER_ID, Platform.LMS, Role.TEACHER) } returns true
         every { courseAdaptor.findAllByTeacherUserIdWithEnrollmentCount(USER_ID) } returns courses
 
         val result = useCase.execute(USER_ID, "TEACHER")
@@ -77,9 +63,7 @@ class GetMyCourseListUseCaseTest {
 
     @Test
     fun `Supporters TEACHER는 빈 배열을 반환한다`() {
-        val userRoles = listOf(createUserRole(Platform.SUPPORTERS))
-
-        every { userRoleAdaptor.findAllByUserIdAndRole(USER_ID, Role.TEACHER) } returns userRoles
+        every { userRoleAdaptor.existsActiveByUserIdAndPlatformAndRole(USER_ID, Platform.LMS, Role.TEACHER) } returns false
 
         val result = useCase.execute(USER_ID, "TEACHER")
 
@@ -89,9 +73,7 @@ class GetMyCourseListUseCaseTest {
 
     @Test
     fun `LMS TEACHER이지만 비활성 상태면 빈 배열을 반환한다`() {
-        val userRoles = listOf(createUserRole(Platform.LMS, state = UserRoleState.PENDING))
-
-        every { userRoleAdaptor.findAllByUserIdAndRole(USER_ID, Role.TEACHER) } returns userRoles
+        every { userRoleAdaptor.existsActiveByUserIdAndPlatformAndRole(USER_ID, Platform.LMS, Role.TEACHER) } returns false
 
         val result = useCase.execute(USER_ID, "TEACHER")
 
@@ -115,9 +97,7 @@ class GetMyCourseListUseCaseTest {
 
     @Test
     fun `코스가 없으면 빈 배열을 반환한다`() {
-        val userRoles = listOf(createUserRole(Platform.LMS))
-
-        every { userRoleAdaptor.findAllByUserIdAndRole(USER_ID, Role.TEACHER) } returns userRoles
+        every { userRoleAdaptor.existsActiveByUserIdAndPlatformAndRole(USER_ID, Platform.LMS, Role.TEACHER) } returns true
         every { courseAdaptor.findAllByTeacherUserIdWithEnrollmentCount(USER_ID) } returns emptyList()
 
         val result = useCase.execute(USER_ID, "TEACHER")

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCaseTest.kt
@@ -1,5 +1,8 @@
 package com.sclass.supporters.enrollment.usecase
 
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.course.domain.CourseStatus
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.exception.EnrollmentUnauthorizedAccessException
@@ -17,9 +20,11 @@ import org.junit.jupiter.api.assertThrows
 
 class GetEnrollmentLessonsUseCaseTest {
     private lateinit var enrollmentAdaptor: EnrollmentAdaptor
+    private lateinit var courseAdaptor: CourseAdaptor
     private lateinit var lessonAdaptor: LessonAdaptor
     private lateinit var useCase: GetEnrollmentLessonsUseCase
 
+    private val courseId = 1L
     private val enrollmentId = 1L
     private val teacherUserId = "teacher-user-id-00000000001"
     private val studentUserId = "student-user-id-00000000001"
@@ -27,14 +32,25 @@ class GetEnrollmentLessonsUseCaseTest {
     @BeforeEach
     fun setUp() {
         enrollmentAdaptor = mockk()
+        courseAdaptor = mockk()
         lessonAdaptor = mockk()
-        useCase = GetEnrollmentLessonsUseCase(enrollmentAdaptor, lessonAdaptor)
+        useCase = GetEnrollmentLessonsUseCase(enrollmentAdaptor, courseAdaptor, lessonAdaptor)
     }
 
     private fun enrollment() =
         mockk<Enrollment>(relaxed = true) {
             every { studentUserId } returns this@GetEnrollmentLessonsUseCaseTest.studentUserId
+            every { courseId } returns this@GetEnrollmentLessonsUseCaseTest.courseId
         }
+
+    private fun course() =
+        Course(
+            id = courseId,
+            productId = "product-id-0000000000000001",
+            teacherUserId = teacherUserId,
+            name = "수학반",
+            status = CourseStatus.ACTIVE,
+        )
 
     private fun lesson(lessonNumber: Int = 1) =
         Lesson(
@@ -48,9 +64,10 @@ class GetEnrollmentLessonsUseCaseTest {
         )
 
     @Test
-    fun `수강신청에 속한 레슨 목록을 반환한다`() {
+    fun `학생이 본인 수강의 레슨 목록을 조회한다`() {
         val lessons = listOf(lesson(1), lesson(2))
         every { enrollmentAdaptor.findById(enrollmentId) } returns enrollment()
+        every { courseAdaptor.findById(courseId) } returns course()
         every { lessonAdaptor.findAllByEnrollment(enrollmentId) } returns lessons
 
         val result = useCase.execute(studentUserId, enrollmentId)
@@ -64,8 +81,24 @@ class GetEnrollmentLessonsUseCaseTest {
     }
 
     @Test
+    fun `선생님이 담당 코스의 레슨 목록을 조회한다`() {
+        val lessons = listOf(lesson(1), lesson(2))
+        every { enrollmentAdaptor.findById(enrollmentId) } returns enrollment()
+        every { courseAdaptor.findById(courseId) } returns course()
+        every { lessonAdaptor.findAllByEnrollment(enrollmentId) } returns lessons
+
+        val result = useCase.execute(teacherUserId, enrollmentId)
+
+        assertAll(
+            { assertEquals(2, result.size) },
+            { assertEquals(LessonType.COURSE, result.first().lessonType) },
+        )
+    }
+
+    @Test
     fun `레슨이 없으면 빈 목록을 반환한다`() {
         every { enrollmentAdaptor.findById(enrollmentId) } returns enrollment()
+        every { courseAdaptor.findById(courseId) } returns course()
         every { lessonAdaptor.findAllByEnrollment(enrollmentId) } returns emptyList()
 
         val result = useCase.execute(studentUserId, enrollmentId)
@@ -74,8 +107,9 @@ class GetEnrollmentLessonsUseCaseTest {
     }
 
     @Test
-    fun `본인의 수강이 아니면 EnrollmentUnauthorizedAccessException이 발생한다`() {
+    fun `학생도 선생님도 아니면 EnrollmentUnauthorizedAccessException이 발생한다`() {
         every { enrollmentAdaptor.findById(enrollmentId) } returns enrollment()
+        every { courseAdaptor.findById(courseId) } returns course()
 
         assertThrows<EnrollmentUnauthorizedAccessException> {
             useCase.execute("other-user-id-0000000000001", enrollmentId)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/adaptor/CourseAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/adaptor/CourseAdaptor.kt
@@ -3,6 +3,7 @@ package com.sclass.domain.domains.course.adaptor
 import com.sclass.common.annotation.Adaptor
 import com.sclass.domain.domains.course.domain.Course
 import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.course.dto.CourseWithEnrollmentCountDto
 import com.sclass.domain.domains.course.dto.CourseWithTeacherDto
 import com.sclass.domain.domains.course.exception.CourseNotFoundException
 import com.sclass.domain.domains.course.repository.CourseRepository
@@ -23,6 +24,9 @@ class CourseAdaptor(
     fun findAllActive(): List<Course> = courseRepository.findAllByStatus(CourseStatus.ACTIVE)
 
     fun findAllActiveWithTeacher(): List<CourseWithTeacherDto> = courseRepository.findAllActiveWithTeacher()
+
+    fun findAllByTeacherUserIdWithEnrollmentCount(teacherUserId: String): List<CourseWithEnrollmentCountDto> =
+        courseRepository.findAllByTeacherUserIdWithEnrollmentCount(teacherUserId)
 
     fun findAllByTeacherUserId(teacherUserId: String): List<Course> = courseRepository.findAllByTeacherUserId(teacherUserId)
 

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/dto/CourseWithEnrollmentCountDto.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/dto/CourseWithEnrollmentCountDto.kt
@@ -1,0 +1,8 @@
+package com.sclass.domain.domains.course.dto
+
+import com.sclass.domain.domains.course.domain.Course
+
+data class CourseWithEnrollmentCountDto(
+    val course: Course,
+    val enrollmentCount: Long,
+)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepository.kt
@@ -1,7 +1,10 @@
 package com.sclass.domain.domains.course.repository
 
+import com.sclass.domain.domains.course.dto.CourseWithEnrollmentCountDto
 import com.sclass.domain.domains.course.dto.CourseWithTeacherDto
 
 interface CourseCustomRepository {
     fun findAllActiveWithTeacher(): List<CourseWithTeacherDto>
+
+    fun findAllByTeacherUserIdWithEnrollmentCount(teacherUserId: String): List<CourseWithEnrollmentCountDto>
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepositoryImpl.kt
@@ -1,9 +1,12 @@
 package com.sclass.domain.domains.course.repository
 
+import com.querydsl.core.types.Projections.tuple
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.sclass.domain.domains.course.domain.CourseStatus
 import com.sclass.domain.domains.course.domain.QCourse.course
+import com.sclass.domain.domains.course.dto.CourseWithEnrollmentCountDto
 import com.sclass.domain.domains.course.dto.CourseWithTeacherDto
+import com.sclass.domain.domains.enrollment.domain.QEnrollment.enrollment
 import com.sclass.domain.domains.teacher.domain.QTeacher.teacher
 import com.sclass.domain.domains.user.domain.QUser.user
 
@@ -25,6 +28,22 @@ class CourseCustomRepositoryImpl(
                     course = tuple[course]!!,
                     teacher = tuple[teacher],
                     teacherUser = tuple[user],
+                )
+            }
+
+    override fun findAllByTeacherUserIdWithEnrollmentCount(teacherUserId: String): List<CourseWithEnrollmentCountDto> =
+        queryFactory
+            .select(course, enrollment.count())
+            .from(course)
+            .leftJoin(enrollment)
+            .on(enrollment.courseId.eq(course.id))
+            .where(course.teacherUserId.eq(teacherUserId))
+            .groupBy(course.id)
+            .fetch()
+            .map { tuple ->
+                CourseWithEnrollmentCountDto(
+                    course = tuple[course]!!,
+                    enrollmentCount = tuple[enrollment.count()] ?: 0L,
                 )
             }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/adaptor/UserRoleAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/adaptor/UserRoleAdaptor.kt
@@ -4,6 +4,7 @@ import com.sclass.common.annotation.Adaptor
 import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.domain.domains.user.domain.UserRole
+import com.sclass.domain.domains.user.domain.UserRoleState
 import com.sclass.domain.domains.user.exception.RoleNotFoundException
 import com.sclass.domain.domains.user.repository.UserRoleRepository
 
@@ -33,4 +34,16 @@ class UserRoleAdaptor(
         userId: String,
         role: Role,
     ): List<UserRole> = userRoleRepository.findAllByUserIdAndRole(userId, role)
+
+    fun existsActiveByUserIdAndPlatformAndRole(
+        userId: String,
+        platform: Platform,
+        role: Role,
+    ): Boolean =
+        userRoleRepository.existsByUserIdAndPlatformAndRoleAndStateIn(
+            userId,
+            platform,
+            role,
+            UserRoleState.entries.filter { it.isActive },
+        )
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/repository/UserRoleRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/repository/UserRoleRepository.kt
@@ -3,6 +3,7 @@ package com.sclass.domain.domains.user.repository
 import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.domain.domains.user.domain.UserRole
+import com.sclass.domain.domains.user.domain.UserRoleState
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRoleRepository : JpaRepository<UserRole, String> {
@@ -22,4 +23,11 @@ interface UserRoleRepository : JpaRepository<UserRole, String> {
         userId: String,
         role: Role,
     ): List<UserRole>
+
+    fun existsByUserIdAndPlatformAndRoleAndStateIn(
+        userId: String,
+        platform: Platform,
+        role: Role,
+        states: Collection<UserRoleState>,
+    ): Boolean
 }


### PR DESCRIPTION
## Summary
- `GET /api/v1/courses/me`: 선생님용 내 코스 목록 조회 (enrollment 수 포함)
  - LMS TEACHER: 코스 목록 반환
  - Supporters TEACHER: 빈 배열
  - STUDENT/ADMIN: 403
- `GET /api/v1/enrollments/{id}/lessons`: 선생님도 조회 가능하도록 권한 확장
  - 기존: studentUserId만 허용 → 선생님 403
  - 변경: 해당 코스의 teacherUserId도 허용

## Test plan
- [x] GetMyCourseListUseCase 테스트 6개 (LMS TEACHER, Supporters TEACHER, 비활성, STUDENT 403, ADMIN 403, 빈 목록)
- [x] GetEnrollmentLessonsUseCase 테스트 4개 (학생 조회, 선생님 조회, 빈 목록, 권한 없는 유저 403)

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)