### PR TITLE
feat: 백오피스 코스/수강/의뢰 목록 조회 API

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/controller/CommissionController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/controller/CommissionController.kt
@@ -1,0 +1,28 @@
+package com.sclass.backoffice.commission.controller
+
+import com.sclass.backoffice.commission.dto.CommissionPageResponse
+import com.sclass.backoffice.commission.usecase.GetCommissionListUseCase
+import com.sclass.common.dto.ApiResponse
+import com.sclass.domain.domains.commission.domain.CommissionStatus
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/commissions")
+class CommissionController(
+    private val getCommissionListUseCase: GetCommissionListUseCase,
+) {
+    @GetMapping
+    fun getCommissionList(
+        @RequestParam(required = false) studentUserId: String?,
+        @RequestParam(required = false) teacherUserId: String?,
+        @RequestParam(required = false) status: CommissionStatus?,
+        @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
+    ): ApiResponse<CommissionPageResponse> =
+        ApiResponse.success(getCommissionListUseCase.execute(studentUserId, teacherUserId, status, pageable))
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/dto/CommissionPageResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/dto/CommissionPageResponse.kt
@@ -1,0 +1,72 @@
+package com.sclass.backoffice.commission.dto
+
+import com.sclass.domain.domains.commission.domain.ActivityType
+import com.sclass.domain.domains.commission.domain.CommissionStatus
+import com.sclass.domain.domains.commission.domain.OutputFormat
+import com.sclass.domain.domains.commission.dto.CommissionWithDetailDto
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import java.time.LocalDateTime
+
+data class CommissionPageResponse(
+    val content: List<CommissionListResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+)
+
+data class CommissionListResponse(
+    val id: Long,
+    val studentUserId: String,
+    val studentName: String,
+    val teacherUserId: String,
+    val teacherName: String,
+    val productId: String,
+    val outputFormat: OutputFormat,
+    val activityType: ActivityType,
+    val status: CommissionStatus,
+    val teacherPayoutAmountWon: Int,
+    val guideSubject: String,
+    val createdAt: LocalDateTime,
+    val lesson: LessonSummary?,
+) {
+    data class LessonSummary(
+        val id: Long,
+        val name: String,
+        val status: LessonStatus,
+        val scheduledAt: LocalDateTime?,
+        val startedAt: LocalDateTime?,
+        val completedAt: LocalDateTime?,
+    ) {
+        companion object {
+            fun from(lesson: Lesson) =
+                LessonSummary(
+                    id = lesson.id,
+                    name = lesson.name,
+                    status = lesson.status,
+                    scheduledAt = lesson.scheduledAt,
+                    startedAt = lesson.startedAt,
+                    completedAt = lesson.completedAt,
+                )
+        }
+    }
+
+    companion object {
+        fun from(dto: CommissionWithDetailDto) =
+            CommissionListResponse(
+                id = dto.commission.id,
+                studentUserId = dto.commission.studentUserId,
+                studentName = dto.studentName,
+                teacherUserId = dto.commission.teacherUserId,
+                teacherName = dto.teacherName,
+                productId = dto.commission.productId,
+                outputFormat = dto.commission.outputFormat,
+                activityType = dto.commission.activityType,
+                status = dto.commission.status,
+                teacherPayoutAmountWon = dto.commission.teacherPayoutAmountWon,
+                guideSubject = dto.commission.guideInfo.subject,
+                createdAt = dto.commission.createdAt,
+                lesson = dto.lesson?.let { LessonSummary.from(it) },
+            )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/usecase/GetCommissionListUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/usecase/GetCommissionListUseCase.kt
@@ -1,0 +1,30 @@
+package com.sclass.backoffice.commission.usecase
+
+import com.sclass.backoffice.commission.dto.CommissionListResponse
+import com.sclass.backoffice.commission.dto.CommissionPageResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
+import com.sclass.domain.domains.commission.domain.CommissionStatus
+import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetCommissionListUseCase(
+    private val commissionAdaptor: CommissionAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(
+        studentUserId: String?,
+        teacherUserId: String?,
+        status: CommissionStatus?,
+        pageable: Pageable,
+    ): CommissionPageResponse {
+        val page = commissionAdaptor.searchCommissions(studentUserId, teacherUserId, status, pageable)
+        return CommissionPageResponse(
+            content = page.content.map { CommissionListResponse.from(it) },
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+            currentPage = page.number,
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/controller/CourseController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/controller/CourseController.kt
@@ -1,18 +1,26 @@
 package com.sclass.backoffice.course.controller
 
+import com.sclass.backoffice.course.dto.CoursePageResponse
 import com.sclass.backoffice.course.dto.CourseResponse
 import com.sclass.backoffice.course.dto.CreateBulkCourseRequest
 import com.sclass.backoffice.course.dto.CreateCourseRequest
 import com.sclass.backoffice.course.usecase.ActivateCourseUseCase
 import com.sclass.backoffice.course.usecase.CreateBulkCourseUseCase
 import com.sclass.backoffice.course.usecase.CreateCourseUseCase
+import com.sclass.backoffice.course.usecase.GetCourseListUseCase
 import com.sclass.common.dto.ApiResponse
+import com.sclass.domain.domains.course.domain.CourseStatus
 import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -21,6 +29,7 @@ class CourseController(
     private val createCourseUseCase: CreateCourseUseCase,
     private val createBulkCourseUseCase: CreateBulkCourseUseCase,
     private val activateCourseUseCase: ActivateCourseUseCase,
+    private val getCourseListUseCase: GetCourseListUseCase,
 ) {
     @PostMapping
     fun createCourse(
@@ -36,4 +45,11 @@ class CourseController(
     fun activateCourse(
         @PathVariable courseId: Long,
     ): ApiResponse<CourseResponse> = ApiResponse.success(activateCourseUseCase.execute(courseId))
+
+    @GetMapping
+    fun getCourseList(
+        @RequestParam(required = false) teacherUserId: String?,
+        @RequestParam(required = false) status: CourseStatus?,
+        @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
+    ): ApiResponse<CoursePageResponse> = ApiResponse.success(getCourseListUseCase.execute(teacherUserId, status, pageable))
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/CoursePageResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/CoursePageResponse.kt
@@ -1,0 +1,41 @@
+package com.sclass.backoffice.course.dto
+
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.course.dto.CourseWithTeacherAndEnrollmentCountDto
+import java.time.LocalDateTime
+
+data class CoursePageResponse(
+    val content: List<CourseListResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+)
+
+data class CourseListResponse(
+    val id: Long,
+    val productId: String,
+    val teacherUserId: String,
+    val teacherName: String,
+    val organizationId: String?,
+    val name: String,
+    val description: String?,
+    val status: CourseStatus,
+    val enrollmentCount: Long,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(dto: CourseWithTeacherAndEnrollmentCountDto) =
+            CourseListResponse(
+                id = dto.course.id,
+                productId = dto.course.productId,
+                teacherUserId = dto.course.teacherUserId,
+                teacherName = dto.teacherName,
+                organizationId = dto.course.organizationId,
+                name = dto.course.name,
+                description = dto.course.description,
+                status = dto.course.status,
+                enrollmentCount = dto.enrollmentCount,
+                createdAt = dto.course.createdAt,
+            )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/usecase/GetCourseListUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/usecase/GetCourseListUseCase.kt
@@ -1,0 +1,29 @@
+package com.sclass.backoffice.course.usecase
+
+import com.sclass.backoffice.course.dto.CourseListResponse
+import com.sclass.backoffice.course.dto.CoursePageResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.course.domain.CourseStatus
+import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetCourseListUseCase(
+    private val courseAdaptor: CourseAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(
+        teacherUserId: String?,
+        status: CourseStatus?,
+        pageable: Pageable,
+    ): CoursePageResponse {
+        val page = courseAdaptor.searchCourses(teacherUserId, status, pageable)
+        return CoursePageResponse(
+            content = page.content.map { CourseListResponse.from(it) },
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+            currentPage = page.number,
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/controller/EnrollmentController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/controller/EnrollmentController.kt
@@ -1,20 +1,29 @@
 package com.sclass.backoffice.enrollment.controller
 
+import com.sclass.backoffice.enrollment.dto.EnrollmentPageResponse
 import com.sclass.backoffice.enrollment.dto.EnrollmentResponse
 import com.sclass.backoffice.enrollment.dto.GrantEnrollmentRequest
+import com.sclass.backoffice.enrollment.usecase.GetEnrollmentListUseCase
 import com.sclass.backoffice.enrollment.usecase.GrantEnrollmentUseCase
 import com.sclass.common.annotation.CurrentUserId
 import com.sclass.common.dto.ApiResponse
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/enrollments")
 class EnrollmentController(
     private val grantEnrollmentUseCase: GrantEnrollmentUseCase,
+    private val getEnrollmentListUseCase: GetEnrollmentListUseCase,
 ) {
     @PostMapping("/grant")
     fun grantEnrollment(
@@ -22,4 +31,13 @@ class EnrollmentController(
         @RequestBody @Valid request: GrantEnrollmentRequest,
     ): ApiResponse<EnrollmentResponse> =
         ApiResponse.success(grantEnrollmentUseCase.execute(userId, request.studentUserId, request.courseId, request.grantReason))
+
+    @GetMapping
+    fun getEnrollmentList(
+        @RequestParam(required = false) studentUserId: String?,
+        @RequestParam(required = false) courseId: Long?,
+        @RequestParam(required = false) status: EnrollmentStatus?,
+        @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
+    ): ApiResponse<EnrollmentPageResponse> =
+        ApiResponse.success(getEnrollmentListUseCase.execute(studentUserId, courseId, status, pageable))
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/EnrollmentPageResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/EnrollmentPageResponse.kt
@@ -1,0 +1,44 @@
+package com.sclass.backoffice.enrollment.dto
+
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.enrollment.domain.EnrollmentType
+import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
+import java.time.LocalDateTime
+
+data class EnrollmentPageResponse(
+    val content: List<EnrollmentListResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+)
+
+data class EnrollmentListResponse(
+    val id: Long,
+    val courseId: Long,
+    val courseName: String,
+    val studentUserId: String,
+    val studentName: String,
+    val teacherName: String,
+    val enrollmentType: EnrollmentType,
+    val tuitionAmountWon: Int,
+    val teacherPayoutPerLessonWon: Int,
+    val status: EnrollmentStatus,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(dto: EnrollmentWithDetailDto) =
+            EnrollmentListResponse(
+                id = dto.enrollment.id,
+                courseId = dto.enrollment.courseId,
+                courseName = dto.courseName,
+                studentUserId = dto.enrollment.studentUserId,
+                studentName = dto.studentName,
+                teacherName = dto.teacherName,
+                enrollmentType = dto.enrollment.enrollmentType,
+                tuitionAmountWon = dto.enrollment.tuitionAmountWon,
+                teacherPayoutPerLessonWon = dto.enrollment.teacherPayoutPerLessonWon,
+                status = dto.enrollment.status,
+                createdAt = dto.enrollment.createdAt,
+            )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentListUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentListUseCase.kt
@@ -1,0 +1,30 @@
+package com.sclass.backoffice.enrollment.usecase
+
+import com.sclass.backoffice.enrollment.dto.EnrollmentListResponse
+import com.sclass.backoffice.enrollment.dto.EnrollmentPageResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetEnrollmentListUseCase(
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(
+        studentUserId: String?,
+        courseId: Long?,
+        status: EnrollmentStatus?,
+        pageable: Pageable,
+    ): EnrollmentPageResponse {
+        val page = enrollmentAdaptor.searchEnrollments(studentUserId, courseId, status, pageable)
+        return EnrollmentPageResponse(
+            content = page.content.map { EnrollmentListResponse.from(it) },
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+            currentPage = page.number,
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/commission/usecase/GetCommissionListUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/commission/usecase/GetCommissionListUseCaseTest.kt
@@ -1,0 +1,195 @@
+package com.sclass.backoffice.commission.usecase
+
+import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
+import com.sclass.domain.domains.commission.domain.ActivityType
+import com.sclass.domain.domains.commission.domain.Commission
+import com.sclass.domain.domains.commission.domain.CommissionStatus
+import com.sclass.domain.domains.commission.domain.GuideInfo
+import com.sclass.domain.domains.commission.domain.OutputFormat
+import com.sclass.domain.domains.commission.dto.CommissionWithDetailDto
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+class GetCommissionListUseCaseTest {
+    private val commissionAdaptor = mockk<CommissionAdaptor>()
+    private val useCase = GetCommissionListUseCase(commissionAdaptor)
+
+    private fun createCommission(
+        studentUserId: String = "student01",
+        teacherUserId: String = "teacher01",
+        status: CommissionStatus = CommissionStatus.REQUESTED,
+    ) = Commission(
+        id = 1L,
+        studentUserId = studentUserId,
+        teacherUserId = teacherUserId,
+        productId = "prod01",
+        teacherPayoutAmountWon = 80000,
+        outputFormat = OutputFormat.REPORT,
+        activityType = ActivityType.CAREER_EXPLORATION,
+        status = status,
+        guideInfo =
+            GuideInfo(
+                subject = "진로탐색",
+                volume = "A4 3장",
+                requiredElements = null,
+                gradingCriteria = "평가 기준",
+                teacherEmphasis = "강조 사항",
+            ),
+    )
+
+    private fun createLesson() =
+        Lesson(
+            id = 1L,
+            lessonType = LessonType.COMMISSION,
+            sourceCommissionId = 1L,
+            studentUserId = "student01",
+            assignedTeacherUserId = "teacher01",
+            name = "탐구 수업 1회차",
+            teacherPayoutAmountWon = 80000,
+            status = LessonStatus.SCHEDULED,
+        )
+
+    private fun createDto(
+        studentUserId: String = "student01",
+        teacherUserId: String = "teacher01",
+        studentName: String = "홍길동",
+        teacherName: String = "김선생",
+        status: CommissionStatus = CommissionStatus.REQUESTED,
+        lesson: Lesson? = null,
+    ) = CommissionWithDetailDto(
+        commission = createCommission(studentUserId, teacherUserId, status),
+        studentName = studentName,
+        teacherName = teacherName,
+        lesson = lesson,
+    )
+
+    @Test
+    fun `commission 목록을 페이지로 반환한다`() {
+        val dtos =
+            listOf(
+                createDto(studentName = "홍길동", teacherName = "김선생"),
+                createDto(studentName = "김철수", teacherName = "이선생"),
+            )
+        val pageable = PageRequest.of(0, 20)
+        every { commissionAdaptor.searchCommissions(null, null, null, pageable) } returns PageImpl(dtos, pageable, 2)
+
+        val result = useCase.execute(null, null, null, pageable)
+
+        assertAll(
+            { assertEquals(2, result.totalElements) },
+            { assertEquals(1, result.totalPages) },
+            { assertEquals(0, result.currentPage) },
+            { assertEquals("홍길동", result.content[0].studentName) },
+            { assertEquals("김선생", result.content[0].teacherName) },
+            { assertEquals("김철수", result.content[1].studentName) },
+            { assertEquals("이선생", result.content[1].teacherName) },
+        )
+    }
+
+    @Test
+    fun `studentUserId 필터를 적용하면 해당 학생의 commission만 반환한다`() {
+        val dto = createDto(studentUserId = "student01", studentName = "홍길동")
+        val pageable = PageRequest.of(0, 20)
+        every { commissionAdaptor.searchCommissions("student01", null, null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute("student01", null, null, pageable)
+
+        assertAll(
+            { assertEquals(1, result.totalElements) },
+            { assertEquals("student01", result.content[0].studentUserId) },
+            { assertEquals("홍길동", result.content[0].studentName) },
+        )
+    }
+
+    @Test
+    fun `teacherUserId 필터를 적용하면 해당 선생님의 commission만 반환한다`() {
+        val dto = createDto(teacherUserId = "teacher01", teacherName = "김선생")
+        val pageable = PageRequest.of(0, 20)
+        every { commissionAdaptor.searchCommissions(null, "teacher01", null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, "teacher01", null, pageable)
+
+        assertAll(
+            { assertEquals(1, result.totalElements) },
+            { assertEquals("teacher01", result.content[0].teacherUserId) },
+            { assertEquals("김선생", result.content[0].teacherName) },
+        )
+    }
+
+    @Test
+    fun `status 필터를 적용하면 해당 상태의 commission만 반환한다`() {
+        val dto = createDto(status = CommissionStatus.ACCEPTED)
+        val pageable = PageRequest.of(0, 20)
+        every { commissionAdaptor.searchCommissions(null, null, CommissionStatus.ACCEPTED, pageable) } returns
+            PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, null, CommissionStatus.ACCEPTED, pageable)
+
+        assertAll(
+            { assertEquals(1, result.totalElements) },
+            { assertEquals(CommissionStatus.ACCEPTED, result.content[0].status) },
+        )
+    }
+
+    @Test
+    fun `lesson이 있는 commission은 lessonSummary가 포함된다`() {
+        val lesson = createLesson()
+        val dto = createDto(lesson = lesson)
+        val pageable = PageRequest.of(0, 20)
+        every { commissionAdaptor.searchCommissions(null, null, null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, null, null, pageable)
+
+        assertAll(
+            { assertNotNull(result.content[0].lesson) },
+            { assertEquals(1L, result.content[0].lesson!!.id) },
+            { assertEquals("탐구 수업 1회차", result.content[0].lesson!!.name) },
+            { assertEquals(LessonStatus.SCHEDULED, result.content[0].lesson!!.status) },
+        )
+    }
+
+    @Test
+    fun `lesson이 없는 commission은 lessonSummary가 null이다`() {
+        val dto = createDto(lesson = null)
+        val pageable = PageRequest.of(0, 20)
+        every { commissionAdaptor.searchCommissions(null, null, null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, null, null, pageable)
+
+        assertNull(result.content[0].lesson)
+    }
+
+    @Test
+    fun `guideSubject가 응답에 포함된다`() {
+        val dto = createDto()
+        val pageable = PageRequest.of(0, 20)
+        every { commissionAdaptor.searchCommissions(null, null, null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, null, null, pageable)
+
+        assertEquals("진로탐색", result.content[0].guideSubject)
+    }
+
+    @Test
+    fun `commission이 없으면 빈 페이지를 반환한다`() {
+        val pageable = PageRequest.of(0, 20)
+        every { commissionAdaptor.searchCommissions(null, null, null, pageable) } returns PageImpl(emptyList(), pageable, 0)
+
+        val result = useCase.execute(null, null, null, pageable)
+
+        assertAll(
+            { assertEquals(0, result.totalElements) },
+            { assertEquals(0, result.content.size) },
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/course/usecase/GetCourseListUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/course/usecase/GetCourseListUseCaseTest.kt
@@ -1,0 +1,114 @@
+package com.sclass.backoffice.course.usecase
+
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.course.dto.CourseWithTeacherAndEnrollmentCountDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+class GetCourseListUseCaseTest {
+    private val courseAdaptor = mockk<CourseAdaptor>()
+    private val useCase = GetCourseListUseCase(courseAdaptor)
+
+    private fun createCourseDto(
+        teacherUserId: String = "teacher01",
+        teacherName: String = "김선생",
+        courseName: String = "수학 기초",
+        status: CourseStatus = CourseStatus.ACTIVE,
+        enrollmentCount: Long = 5,
+    ) = CourseWithTeacherAndEnrollmentCountDto(
+        course =
+            Course(
+                id = 1L,
+                productId = "prod01",
+                teacherUserId = teacherUserId,
+                name = courseName,
+                description = "설명",
+                status = status,
+            ),
+        teacherName = teacherName,
+        enrollmentCount = enrollmentCount,
+    )
+
+    @Test
+    fun `코스 목록을 페이지로 반환한다`() {
+        val dtos =
+            listOf(
+                createCourseDto(courseName = "수학 기초", teacherName = "김선생"),
+                createCourseDto(courseName = "영어 회화", teacherName = "이선생"),
+            )
+        val pageable = PageRequest.of(0, 20)
+        every { courseAdaptor.searchCourses(null, null, pageable) } returns PageImpl(dtos, pageable, 2)
+
+        val result = useCase.execute(null, null, pageable)
+
+        assertAll(
+            { assertEquals(2, result.totalElements) },
+            { assertEquals(1, result.totalPages) },
+            { assertEquals(0, result.currentPage) },
+            { assertEquals("수학 기초", result.content[0].name) },
+            { assertEquals("김선생", result.content[0].teacherName) },
+            { assertEquals("영어 회화", result.content[1].name) },
+            { assertEquals("이선생", result.content[1].teacherName) },
+        )
+    }
+
+    @Test
+    fun `teacherUserId 필터를 적용하면 해당 선생님의 코스만 반환한다`() {
+        val dto = createCourseDto(teacherUserId = "teacher01", teacherName = "김선생")
+        val pageable = PageRequest.of(0, 20)
+        every { courseAdaptor.searchCourses("teacher01", null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute("teacher01", null, pageable)
+
+        assertAll(
+            { assertEquals(1, result.totalElements) },
+            { assertEquals("teacher01", result.content[0].teacherUserId) },
+            { assertEquals("김선생", result.content[0].teacherName) },
+        )
+    }
+
+    @Test
+    fun `status 필터를 적용하면 해당 상태의 코스만 반환한다`() {
+        val dto = createCourseDto(status = CourseStatus.DRAFT)
+        val pageable = PageRequest.of(0, 20)
+        every { courseAdaptor.searchCourses(null, CourseStatus.DRAFT, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, CourseStatus.DRAFT, pageable)
+
+        assertAll(
+            { assertEquals(1, result.totalElements) },
+            { assertEquals(CourseStatus.DRAFT, result.content[0].status) },
+        )
+    }
+
+    @Test
+    fun `enrollmentCount가 응답에 포함된다`() {
+        val dto = createCourseDto(enrollmentCount = 10)
+        val pageable = PageRequest.of(0, 20)
+        every { courseAdaptor.searchCourses(null, null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, null, pageable)
+
+        assertEquals(10, result.content[0].enrollmentCount)
+    }
+
+    @Test
+    fun `코스가 없으면 빈 페이지를 반환한다`() {
+        val pageable = PageRequest.of(0, 20)
+        every { courseAdaptor.searchCourses(null, null, pageable) } returns PageImpl(emptyList(), pageable, 0)
+
+        val result = useCase.execute(null, null, pageable)
+
+        assertAll(
+            { assertEquals(0, result.totalElements) },
+            { assertEquals(0, result.content.size) },
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentListUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentListUseCaseTest.kt
@@ -1,0 +1,131 @@
+package com.sclass.backoffice.enrollment.usecase
+
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+class GetEnrollmentListUseCaseTest {
+    private val enrollmentAdaptor = mockk<EnrollmentAdaptor>()
+    private val useCase = GetEnrollmentListUseCase(enrollmentAdaptor)
+
+    private fun createEnrollmentDto(
+        studentUserId: String = "student01",
+        studentName: String = "홍길동",
+        courseId: Long = 1L,
+        courseName: String = "수학 기초",
+        teacherName: String = "김선생",
+        status: EnrollmentStatus = EnrollmentStatus.ACTIVE,
+    ) = EnrollmentWithDetailDto(
+        enrollment =
+            Enrollment.createByGrant(
+                courseId = courseId,
+                studentUserId = studentUserId,
+                grantedByUserId = "admin01",
+                grantReason = "테스트",
+                teacherPayoutPerLessonWon = 50000,
+                tuitionAmountWon = 100000,
+            ),
+        studentName = studentName,
+        courseName = courseName,
+        teacherName = teacherName,
+    )
+
+    @Test
+    fun `enrollment 목록을 페이지로 반환한다`() {
+        val dtos =
+            listOf(
+                createEnrollmentDto(studentName = "홍길동", courseName = "수학 기초"),
+                createEnrollmentDto(studentName = "김철수", courseName = "영어 회화"),
+            )
+        val pageable = PageRequest.of(0, 20)
+        every { enrollmentAdaptor.searchEnrollments(null, null, null, pageable) } returns PageImpl(dtos, pageable, 2)
+
+        val result = useCase.execute(null, null, null, pageable)
+
+        assertAll(
+            { assertEquals(2, result.totalElements) },
+            { assertEquals(1, result.totalPages) },
+            { assertEquals(0, result.currentPage) },
+            { assertEquals("홍길동", result.content[0].studentName) },
+            { assertEquals("수학 기초", result.content[0].courseName) },
+            { assertEquals("김철수", result.content[1].studentName) },
+            { assertEquals("영어 회화", result.content[1].courseName) },
+        )
+    }
+
+    @Test
+    fun `studentUserId 필터를 적용하면 해당 학생의 enrollment만 반환한다`() {
+        val dto = createEnrollmentDto(studentUserId = "student01", studentName = "홍길동")
+        val pageable = PageRequest.of(0, 20)
+        every { enrollmentAdaptor.searchEnrollments("student01", null, null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute("student01", null, null, pageable)
+
+        assertAll(
+            { assertEquals(1, result.totalElements) },
+            { assertEquals("student01", result.content[0].studentUserId) },
+            { assertEquals("홍길동", result.content[0].studentName) },
+        )
+    }
+
+    @Test
+    fun `courseId 필터를 적용하면 해당 코스의 enrollment만 반환한다`() {
+        val dto = createEnrollmentDto(courseId = 1L, courseName = "수학 기초")
+        val pageable = PageRequest.of(0, 20)
+        every { enrollmentAdaptor.searchEnrollments(null, 1L, null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, 1L, null, pageable)
+
+        assertAll(
+            { assertEquals(1, result.totalElements) },
+            { assertEquals("수학 기초", result.content[0].courseName) },
+        )
+    }
+
+    @Test
+    fun `status 필터를 적용하면 해당 상태의 enrollment만 반환한다`() {
+        val dto = createEnrollmentDto(status = EnrollmentStatus.ACTIVE)
+        val pageable = PageRequest.of(0, 20)
+        every { enrollmentAdaptor.searchEnrollments(null, null, EnrollmentStatus.ACTIVE, pageable) } returns
+            PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, null, EnrollmentStatus.ACTIVE, pageable)
+
+        assertAll(
+            { assertEquals(1, result.totalElements) },
+            { assertEquals(EnrollmentStatus.ACTIVE, result.content[0].status) },
+        )
+    }
+
+    @Test
+    fun `teacherName이 응답에 포함된다`() {
+        val dto = createEnrollmentDto(teacherName = "김선생")
+        val pageable = PageRequest.of(0, 20)
+        every { enrollmentAdaptor.searchEnrollments(null, null, null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, null, null, pageable)
+
+        assertEquals("김선생", result.content[0].teacherName)
+    }
+
+    @Test
+    fun `enrollment이 없으면 빈 페이지를 반환한다`() {
+        val pageable = PageRequest.of(0, 20)
+        every { enrollmentAdaptor.searchEnrollments(null, null, null, pageable) } returns PageImpl(emptyList(), pageable, 0)
+
+        val result = useCase.execute(null, null, null, pageable)
+
+        assertAll(
+            { assertEquals(0, result.totalElements) },
+            { assertEquals(0, result.content.size) },
+        )
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/adaptor/CommissionAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/adaptor/CommissionAdaptor.kt
@@ -2,8 +2,12 @@ package com.sclass.domain.domains.commission.adaptor
 
 import com.sclass.common.annotation.Adaptor
 import com.sclass.domain.domains.commission.domain.Commission
+import com.sclass.domain.domains.commission.domain.CommissionStatus
+import com.sclass.domain.domains.commission.dto.CommissionWithDetailDto
 import com.sclass.domain.domains.commission.exception.CommissionNotFoundException
 import com.sclass.domain.domains.commission.repository.CommissionRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 @Adaptor
 class CommissionAdaptor(
@@ -18,4 +22,11 @@ class CommissionAdaptor(
     fun findByTeacherUserId(teacherUserId: String): List<Commission> = commissionRepository.findByTeacherUserId(teacherUserId)
 
     fun save(commission: Commission): Commission = commissionRepository.save(commission)
+
+    fun searchCommissions(
+        studentUserId: String?,
+        teacherUserId: String?,
+        status: CommissionStatus?,
+        pageable: Pageable,
+    ): Page<CommissionWithDetailDto> = commissionRepository.searchCommissions(studentUserId, teacherUserId, status, pageable)
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/dto/CommissionWithDetailDto.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/dto/CommissionWithDetailDto.kt
@@ -1,0 +1,11 @@
+package com.sclass.domain.domains.commission.dto
+
+import com.sclass.domain.domains.commission.domain.Commission
+import com.sclass.domain.domains.lesson.domain.Lesson
+
+data class CommissionWithDetailDto(
+    val commission: Commission,
+    val studentName: String,
+    val teacherName: String,
+    val lesson: Lesson?,
+)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/repository/CommissionCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/repository/CommissionCustomRepository.kt
@@ -1,0 +1,15 @@
+package com.sclass.domain.domains.commission.repository
+
+import com.sclass.domain.domains.commission.domain.CommissionStatus
+import com.sclass.domain.domains.commission.dto.CommissionWithDetailDto
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface CommissionCustomRepository {
+    fun searchCommissions(
+        studentUserId: String?,
+        teacherUserId: String?,
+        status: CommissionStatus?,
+        pageable: Pageable,
+    ): Page<CommissionWithDetailDto>
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/repository/CommissionCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/repository/CommissionCustomRepositoryImpl.kt
@@ -1,7 +1,11 @@
 package com.sclass.domain.domains.commission.repository
 
+import com.querydsl.core.types.Order
+import com.querydsl.core.types.OrderSpecifier
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.PathBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sclass.domain.domains.commission.domain.Commission
 import com.sclass.domain.domains.commission.domain.CommissionStatus
 import com.sclass.domain.domains.commission.domain.QCommission.commission
 import com.sclass.domain.domains.commission.dto.CommissionWithDetailDto
@@ -10,6 +14,7 @@ import com.sclass.domain.domains.user.domain.QUser
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 
 class CommissionCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
@@ -39,7 +44,7 @@ class CommissionCustomRepositoryImpl(
                 .leftJoin(lesson)
                 .on(lesson.id.eq(commission.acceptedLessonId))
                 .where(*where.toTypedArray())
-                .orderBy(commission.createdAt.desc())
+                .orderBy(*pageable.sort.toOrderSpecifiers())
                 .offset(pageable.offset)
                 .limit(pageable.pageSize.toLong())
                 .fetch()
@@ -60,5 +65,14 @@ class CommissionCustomRepositoryImpl(
                 .fetchOne() ?: 0L
 
         return PageImpl(content, pageable, total)
+    }
+
+    private fun Sort.toOrderSpecifiers(): Array<OrderSpecifier<*>> {
+        if (isUnsorted) return arrayOf(commission.createdAt.desc())
+        val path = PathBuilder(Commission::class.java, "commission")
+        return map { order ->
+            val direction = if (order.isAscending) Order.ASC else Order.DESC
+            OrderSpecifier(direction, path.get(order.property, Comparable::class.java))
+        }.toList().toTypedArray()
     }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/repository/CommissionCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/repository/CommissionCustomRepositoryImpl.kt
@@ -1,0 +1,64 @@
+package com.sclass.domain.domains.commission.repository
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sclass.domain.domains.commission.domain.CommissionStatus
+import com.sclass.domain.domains.commission.domain.QCommission.commission
+import com.sclass.domain.domains.commission.dto.CommissionWithDetailDto
+import com.sclass.domain.domains.lesson.domain.QLesson.lesson
+import com.sclass.domain.domains.user.domain.QUser
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+
+class CommissionCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : CommissionCustomRepository {
+    override fun searchCommissions(
+        studentUserId: String?,
+        teacherUserId: String?,
+        status: CommissionStatus?,
+        pageable: Pageable,
+    ): Page<CommissionWithDetailDto> {
+        val where = mutableListOf<BooleanExpression>()
+        studentUserId?.let { where += commission.studentUserId.eq(it) }
+        teacherUserId?.let { where += commission.teacherUserId.eq(it) }
+        status?.let { where += commission.status.eq(it) }
+
+        val studentUser = QUser("studentUser")
+        val teacherUser = QUser("teacherUser")
+
+        val content =
+            queryFactory
+                .select(commission, studentUser.name, teacherUser.name, lesson)
+                .from(commission)
+                .leftJoin(studentUser)
+                .on(studentUser.id.eq(commission.studentUserId))
+                .leftJoin(teacherUser)
+                .on(teacherUser.id.eq(commission.teacherUserId))
+                .leftJoin(lesson)
+                .on(lesson.id.eq(commission.acceptedLessonId))
+                .where(*where.toTypedArray())
+                .orderBy(commission.createdAt.desc())
+                .offset(pageable.offset)
+                .limit(pageable.pageSize.toLong())
+                .fetch()
+                .map { tuple ->
+                    CommissionWithDetailDto(
+                        commission = tuple[commission]!!,
+                        studentName = tuple[studentUser.name] ?: "",
+                        teacherName = tuple[teacherUser.name] ?: "",
+                        lesson = tuple[lesson],
+                    )
+                }
+
+        val total =
+            queryFactory
+                .select(commission.count())
+                .from(commission)
+                .where(*where.toTypedArray())
+                .fetchOne() ?: 0L
+
+        return PageImpl(content, pageable, total)
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/repository/CommissionRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/repository/CommissionRepository.kt
@@ -3,7 +3,9 @@ package com.sclass.domain.domains.commission.repository
 import com.sclass.domain.domains.commission.domain.Commission
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CommissionRepository : JpaRepository<Commission, Long> {
+interface CommissionRepository :
+    JpaRepository<Commission, Long>,
+    CommissionCustomRepository {
     fun findByStudentUserId(studentUserId: String): List<Commission>
 
     fun findByTeacherUserId(teacherUserId: String): List<Commission>

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/adaptor/CourseAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/adaptor/CourseAdaptor.kt
@@ -3,9 +3,12 @@ package com.sclass.domain.domains.course.adaptor
 import com.sclass.common.annotation.Adaptor
 import com.sclass.domain.domains.course.domain.Course
 import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.course.dto.CourseWithTeacherAndEnrollmentCountDto
 import com.sclass.domain.domains.course.dto.CourseWithTeacherDto
 import com.sclass.domain.domains.course.exception.CourseNotFoundException
 import com.sclass.domain.domains.course.repository.CourseRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 
 @Adaptor
@@ -23,6 +26,12 @@ class CourseAdaptor(
     fun findAllActive(): List<Course> = courseRepository.findAllByStatus(CourseStatus.ACTIVE)
 
     fun findAllActiveWithTeacher(): List<CourseWithTeacherDto> = courseRepository.findAllActiveWithTeacher()
+
+    fun searchCourses(
+        teacherUserId: String?,
+        status: CourseStatus?,
+        pageable: Pageable,
+    ): Page<CourseWithTeacherAndEnrollmentCountDto> = courseRepository.searchCourses(teacherUserId, status, pageable)
 
     fun findAllByTeacherUserId(teacherUserId: String): List<Course> = courseRepository.findAllByTeacherUserId(teacherUserId)
 

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/dto/CourseWithTeacherAndEnrollmentCountDto.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/dto/CourseWithTeacherAndEnrollmentCountDto.kt
@@ -1,0 +1,9 @@
+package com.sclass.domain.domains.course.dto
+
+import com.sclass.domain.domains.course.domain.Course
+
+data class CourseWithTeacherAndEnrollmentCountDto(
+    val course: Course,
+    val teacherName: String,
+    val enrollmentCount: Long,
+)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepository.kt
@@ -1,7 +1,17 @@
 package com.sclass.domain.domains.course.repository
 
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.course.dto.CourseWithTeacherAndEnrollmentCountDto
 import com.sclass.domain.domains.course.dto.CourseWithTeacherDto
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface CourseCustomRepository {
     fun findAllActiveWithTeacher(): List<CourseWithTeacherDto>
+
+    fun searchCourses(
+        teacherId: String?,
+        status: CourseStatus?,
+        pageable: Pageable,
+    ): Page<CourseWithTeacherAndEnrollmentCountDto>
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepositoryImpl.kt
@@ -1,7 +1,11 @@
 package com.sclass.domain.domains.course.repository
 
+import com.querydsl.core.types.Order
+import com.querydsl.core.types.OrderSpecifier
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.PathBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sclass.domain.domains.course.domain.Course
 import com.sclass.domain.domains.course.domain.CourseStatus
 import com.sclass.domain.domains.course.domain.QCourse.course
 import com.sclass.domain.domains.course.dto.CourseWithTeacherAndEnrollmentCountDto
@@ -12,6 +16,7 @@ import com.sclass.domain.domains.user.domain.QUser.user
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 
 class CourseCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
@@ -52,8 +57,8 @@ class CourseCustomRepositoryImpl(
                 .leftJoin(enrollment)
                 .on(enrollment.courseId.eq(course.id))
                 .where(*where.toTypedArray())
-                .groupBy(course.id)
-                .orderBy(course.createdAt.desc())
+                .groupBy(course.id, user.name)
+                .orderBy(*pageable.sort.toOrderSpecifiers())
                 .offset(pageable.offset)
                 .limit(pageable.pageSize.toLong())
                 .fetch()
@@ -73,5 +78,14 @@ class CourseCustomRepositoryImpl(
                 .fetchOne() ?: 0L
 
         return PageImpl(content, pageable, total)
+    }
+
+    private fun Sort.toOrderSpecifiers(): Array<OrderSpecifier<*>> {
+        if (isUnsorted) return arrayOf(course.createdAt.desc())
+        val path = PathBuilder(Course::class.java, "course")
+        return map { order ->
+            val direction = if (order.isAscending) Order.ASC else Order.DESC
+            OrderSpecifier(direction, path.get(order.property, Comparable::class.java))
+        }.toList().toTypedArray()
     }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepositoryImpl.kt
@@ -1,11 +1,17 @@
 package com.sclass.domain.domains.course.repository
 
+import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.sclass.domain.domains.course.domain.CourseStatus
 import com.sclass.domain.domains.course.domain.QCourse.course
+import com.sclass.domain.domains.course.dto.CourseWithTeacherAndEnrollmentCountDto
 import com.sclass.domain.domains.course.dto.CourseWithTeacherDto
+import com.sclass.domain.domains.enrollment.domain.QEnrollment.enrollment
 import com.sclass.domain.domains.teacher.domain.QTeacher.teacher
 import com.sclass.domain.domains.user.domain.QUser.user
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 
 class CourseCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
@@ -27,4 +33,45 @@ class CourseCustomRepositoryImpl(
                     teacherUser = tuple[user],
                 )
             }
+
+    override fun searchCourses(
+        teacherUserId: String?,
+        status: CourseStatus?,
+        pageable: Pageable,
+    ): Page<CourseWithTeacherAndEnrollmentCountDto> {
+        val where = mutableListOf<BooleanExpression>()
+        teacherUserId?.let { where += course.teacherUserId.eq(it) }
+        status?.let { where += course.status.eq(it) }
+
+        val content =
+            queryFactory
+                .select(course, user.name, enrollment.count())
+                .from(course)
+                .leftJoin(user)
+                .on(user.id.eq(course.teacherUserId))
+                .leftJoin(enrollment)
+                .on(enrollment.courseId.eq(course.id))
+                .where(*where.toTypedArray())
+                .groupBy(course.id)
+                .orderBy(course.createdAt.desc())
+                .offset(pageable.offset)
+                .limit(pageable.pageSize.toLong())
+                .fetch()
+                .map { tuple ->
+                    CourseWithTeacherAndEnrollmentCountDto(
+                        course = tuple[course]!!,
+                        teacherName = tuple[user.name] ?: "-",
+                        enrollmentCount = tuple[enrollment.count()] ?: 0L,
+                    )
+                }
+
+        val total =
+            queryFactory
+                .select(course.count())
+                .from(course)
+                .where(*where.toTypedArray())
+                .fetchOne() ?: 0L
+
+        return PageImpl(content, pageable, total)
+    }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
@@ -4,9 +4,12 @@ import com.sclass.common.annotation.Adaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.enrollment.domain.EnrollmentType
+import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithStudentDto
 import com.sclass.domain.domains.enrollment.exception.EnrollmentNotFoundException
 import com.sclass.domain.domains.enrollment.repository.EnrollmentRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 
 @Adaptor
@@ -23,6 +26,13 @@ class EnrollmentAdaptor(
 
     fun findAllByCourseWithStudent(courseId: Long): List<EnrollmentWithStudentDto> =
         enrollmentRepository.findAllByCourseIdWithStudent(courseId)
+
+    fun searchEnrollments(
+        studentUserId: String?,
+        courseId: Long?,
+        status: EnrollmentStatus?,
+        pageable: Pageable,
+    ): Page<EnrollmentWithDetailDto> = enrollmentRepository.searchEnrollments(studentUserId, courseId, status, pageable)
 
     fun findAllByCourse(courseId: Long): List<Enrollment> = enrollmentRepository.findAllByCourseId(courseId)
 

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/dto/EnrollmentWithDetailDto.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/dto/EnrollmentWithDetailDto.kt
@@ -1,0 +1,10 @@
+package com.sclass.domain.domains.enrollment.dto
+
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+
+data class EnrollmentWithDetailDto(
+    val enrollment: Enrollment,
+    val studentName: String,
+    val courseName: String,
+    val teacherName: String,
+)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepository.kt
@@ -1,7 +1,18 @@
 package com.sclass.domain.domains.enrollment.repository
 
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithStudentDto
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface EnrollmentCustomRepository {
     fun findAllByCourseIdWithStudent(courseId: Long): List<EnrollmentWithStudentDto>
+
+    fun searchEnrollments(
+        studentUserId: String?,
+        courseId: Long?,
+        status: EnrollmentStatus?,
+        pageable: Pageable,
+    ): Page<EnrollmentWithDetailDto>
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
@@ -1,9 +1,17 @@
 package com.sclass.domain.domains.enrollment.repository
 
+import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sclass.domain.domains.course.domain.QCourse.course
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.enrollment.domain.QEnrollment.enrollment
+import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithStudentDto
+import com.sclass.domain.domains.user.domain.QUser
 import com.sclass.domain.domains.user.domain.QUser.user
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 
 class EnrollmentCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
@@ -22,4 +30,54 @@ class EnrollmentCustomRepositoryImpl(
                     student = tuple[user],
                 )
             }
+
+    override fun searchEnrollments(
+        studentUserId: String?,
+        courseId: Long?,
+        status: EnrollmentStatus?,
+        pageable: Pageable,
+    ): Page<EnrollmentWithDetailDto> {
+        val where = mutableListOf<BooleanExpression>()
+        studentUserId?.let { where += enrollment.studentUserId.eq(it) }
+        courseId?.let { where += enrollment.courseId.eq(it) }
+        status?.let { where += enrollment.status.eq(it) }
+
+        val studentUser = QUser("studentUser")
+        val teacherUser = QUser("teacherUser")
+
+        val content =
+            queryFactory
+                .select(enrollment, studentUser.name, course.name, teacherUser.name)
+                .from(enrollment)
+                .join(course)
+                .on(course.id.eq(enrollment.courseId))
+                .leftJoin(studentUser)
+                .on(studentUser.id.eq(enrollment.studentUserId))
+                .leftJoin(teacherUser)
+                .on(teacherUser.id.eq(course.teacherUserId))
+                .where(*where.toTypedArray())
+                .orderBy(enrollment.createdAt.desc())
+                .offset(pageable.offset)
+                .limit(pageable.pageSize.toLong())
+                .fetch()
+                .map { tuple ->
+                    EnrollmentWithDetailDto(
+                        enrollment = tuple[enrollment]!!,
+                        studentName = tuple[studentUser.name] ?: "",
+                        courseName = tuple[course.name] ?: "",
+                        teacherName = tuple[teacherUser.name] ?: "",
+                    )
+                }
+
+        val total =
+            queryFactory
+                .select(enrollment.count())
+                .from(enrollment)
+                .join(course)
+                .on(course.id.eq(enrollment.courseId))
+                .where(*where.toTypedArray())
+                .fetchOne() ?: 0L
+
+        return PageImpl(content, pageable, total)
+    }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
@@ -1,8 +1,12 @@
 package com.sclass.domain.domains.enrollment.repository
 
+import com.querydsl.core.types.Order
+import com.querydsl.core.types.OrderSpecifier
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.PathBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.sclass.domain.domains.course.domain.QCourse.course
+import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.enrollment.domain.QEnrollment.enrollment
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
@@ -12,6 +16,7 @@ import com.sclass.domain.domains.user.domain.QUser.user
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 
 class EnrollmentCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
@@ -56,7 +61,7 @@ class EnrollmentCustomRepositoryImpl(
                 .leftJoin(teacherUser)
                 .on(teacherUser.id.eq(course.teacherUserId))
                 .where(*where.toTypedArray())
-                .orderBy(enrollment.createdAt.desc())
+                .orderBy(*pageable.sort.toOrderSpecifiers())
                 .offset(pageable.offset)
                 .limit(pageable.pageSize.toLong())
                 .fetch()
@@ -79,5 +84,14 @@ class EnrollmentCustomRepositoryImpl(
                 .fetchOne() ?: 0L
 
         return PageImpl(content, pageable, total)
+    }
+
+    private fun Sort.toOrderSpecifiers(): Array<OrderSpecifier<*>> {
+        if (isUnsorted) return arrayOf(enrollment.createdAt.desc())
+        val path = PathBuilder(Enrollment::class.java, "enrollment")
+        return map { order ->
+            val direction = if (order.isAscending) Order.ASC else Order.DESC
+            OrderSpecifier(direction, path.get(order.property, Comparable::class.java))
+        }.toList().toTypedArray()
     }
 }


### PR DESCRIPTION
## Summary
- 백오피스 코스, enrollment, commission 목록 조회 API 추가
- QueryDSL 기반 검색 필터링 + 페이지네이션 (teacherUserId, studentUserId, courseId, status)
- Commission 응답에 연결된 Lesson 정보(LessonSummary) 포함
- UseCase 단위 테스트 19개 추가

## Test plan
- [x] GetCourseListUseCaseTest (5 cases): 목록 반환, 필터링, 빈 페이지
- [x] GetEnrollmentListUseCaseTest (6 cases): 목록 반환, 필터링, 빈 페이지
- [x] GetCommissionListUseCaseTest (8 cases): 목록 반환, 필터링, lesson 포함/null, 빈 페이지
- [x] 전체 빌드 + ktlint 통과

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)