### PR TITLE
feat: enrollment 생성 시 lesson 일괄 자동 생성

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GrantEnrollmentUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GrantEnrollmentUseCase.kt
@@ -5,6 +5,7 @@ import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.course.adaptor.CourseAdaptor
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.lesson.service.LessonDomainService
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
 import com.sclass.domain.domains.product.domain.CourseProduct
 import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
@@ -17,6 +18,7 @@ class GrantEnrollmentUseCase(
     private val courseAdaptor: CourseAdaptor,
     private val productAdaptor: ProductAdaptor,
     private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val lessonService: LessonDomainService,
 ) {
     @Transactional
     @DistributedLock(prefix = "enrollment")
@@ -42,6 +44,14 @@ class GrantEnrollmentUseCase(
                     tuitionAmountWon = product.priceWon,
                 ),
             )
+
+        lessonService.createLessonsForEnrollment(
+            enrollment,
+            course,
+            totalLessons = product.totalLessons,
+            teacherPayoutPerLessonWon = product.teacherPayoutPerLessonWon,
+        )
+
         return EnrollmentResponse.from(enrollment)
     }
 }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/usecase/GrantEnrollmentUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/usecase/GrantEnrollmentUseCaseTest.kt
@@ -7,6 +7,7 @@ import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.enrollment.domain.EnrollmentType
+import com.sclass.domain.domains.lesson.service.LessonDomainService
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
 import com.sclass.domain.domains.product.domain.CoinProduct
 import com.sclass.domain.domains.product.domain.CourseProduct
@@ -14,6 +15,7 @@ import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -24,6 +26,7 @@ class GrantEnrollmentUseCaseTest {
     private lateinit var courseAdaptor: CourseAdaptor
     private lateinit var productAdaptor: ProductAdaptor
     private lateinit var enrollmentAdaptor: EnrollmentAdaptor
+    private lateinit var lessonService: LessonDomainService
     private lateinit var useCase: GrantEnrollmentUseCase
 
     @BeforeEach
@@ -31,7 +34,8 @@ class GrantEnrollmentUseCaseTest {
         courseAdaptor = mockk()
         productAdaptor = mockk()
         enrollmentAdaptor = mockk()
-        useCase = GrantEnrollmentUseCase(courseAdaptor, productAdaptor, enrollmentAdaptor)
+        lessonService = mockk(relaxed = true)
+        useCase = GrantEnrollmentUseCase(courseAdaptor, productAdaptor, enrollmentAdaptor, lessonService)
     }
 
     private fun activeCourse() =
@@ -85,6 +89,25 @@ class GrantEnrollmentUseCaseTest {
 
             assertThat(enrollmentSlot.captured.tuitionAmountWon).isEqualTo(300000)
             assertThat(enrollmentSlot.captured.teacherPayoutPerLessonWon).isEqualTo(20000)
+        }
+
+        @Test
+        fun `수강 등록 시 totalLessons만큼 레슨이 일괄 생성된다`() {
+            val enrollmentSlot = slot<Enrollment>()
+            every { courseAdaptor.findById(1L) } returns activeCourse()
+            every { productAdaptor.findById(any()) } returns courseProduct()
+            every { enrollmentAdaptor.save(capture(enrollmentSlot)) } answers { enrollmentSlot.captured }
+
+            useCase.execute("admin-id-000000000001", "student-id-00000000001", 1L, "장학생 혜택")
+
+            verify {
+                lessonService.createLessonsForEnrollment(
+                    enrollment = any(),
+                    course = any(),
+                    totalLessons = 12,
+                    teacherPayoutPerLessonWon = 20000,
+                )
+            }
         }
     }
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -2,7 +2,9 @@ package com.sclass.supporters.payment.usecase
 
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.coin.service.CoinDomainService
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.lesson.service.LessonDomainService
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
@@ -24,6 +26,8 @@ class HandleNicePayWebhookUseCase(
     private val pgGateway: PgGateway,
     private val txTemplate: TransactionTemplate,
     private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val courseAdaptor: CourseAdaptor,
+    private val lessonService: LessonDomainService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -112,6 +116,14 @@ class HandleNicePayWebhookUseCase(
                     enrollmentAdaptor.save(freshEnrollment)
                     fresh.markCompleted()
                     paymentAdaptor.save(fresh)
+
+                    val course = courseAdaptor.findById(freshEnrollment.courseId)
+                    lessonService.createLessonsForEnrollment(
+                        enrollment,
+                        course,
+                        totalLessons = product.totalLessons,
+                        product.teacherPayoutPerLessonWon,
+                    )
                 }
             }
             else -> throw ProductTypeMismatchException()

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -119,10 +119,10 @@ class HandleNicePayWebhookUseCase(
 
                     val course = courseAdaptor.findById(freshEnrollment.courseId)
                     lessonService.createLessonsForEnrollment(
-                        enrollment,
+                        freshEnrollment,
                         course,
                         totalLessons = product.totalLessons,
-                        product.teacherPayoutPerLessonWon,
+                        teacherPayoutPerLessonWon = freshEnrollment.teacherPayoutPerLessonWon,
                     )
                 }
             }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
@@ -1,9 +1,13 @@
 package com.sclass.supporters.payment.usecase
 
 import com.sclass.domain.domains.coin.service.CoinDomainService
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.course.domain.CourseStatus
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.lesson.service.LessonDomainService
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.Payment
 import com.sclass.domain.domains.payment.domain.PaymentStatus
@@ -28,6 +32,8 @@ class HandleNicePayWebhookUseCaseTest {
     private lateinit var productAdaptor: ProductAdaptor
     private lateinit var coinDomainService: CoinDomainService
     private lateinit var enrollmentAdaptor: EnrollmentAdaptor
+    private lateinit var courseAdaptor: CourseAdaptor
+    private lateinit var lessonService: LessonDomainService
     private lateinit var pgGateway: PgGateway
     private lateinit var txTemplate: TransactionTemplate
     private lateinit var useCase: HandleNicePayWebhookUseCase
@@ -45,7 +51,19 @@ class HandleNicePayWebhookUseCaseTest {
         }
         every { paymentAdaptor.save(any()) } answers { firstArg() }
         enrollmentAdaptor = mockk()
-        useCase = HandleNicePayWebhookUseCase(paymentAdaptor, productAdaptor, coinDomainService, pgGateway, txTemplate, enrollmentAdaptor)
+        courseAdaptor = mockk()
+        lessonService = mockk(relaxed = true)
+        useCase =
+            HandleNicePayWebhookUseCase(
+                paymentAdaptor,
+                productAdaptor,
+                coinDomainService,
+                pgGateway,
+                txTemplate,
+                enrollmentAdaptor,
+                courseAdaptor,
+                lessonService,
+            )
     }
 
     @Test
@@ -161,6 +179,14 @@ class HandleNicePayWebhookUseCaseTest {
                 teacherPayoutPerLessonWon = 20000,
                 paymentId = payment.id,
             )
+        val course =
+            Course(
+                id = 1L,
+                productId = "prod-00000000000000000000000001",
+                teacherUserId = "teacher-id-00000000001",
+                name = "수학 코스",
+                status = CourseStatus.ACTIVE,
+            )
 
         every { pgGateway.verifyWebhookSignature(any(), any(), any(), any()) } returns true
         every { paymentAdaptor.findByPgOrderIdOrNull(any()) } returns payment
@@ -170,10 +196,21 @@ class HandleNicePayWebhookUseCaseTest {
         every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns enrollment
         every { enrollmentAdaptor.findByPaymentId(payment.id) } returns enrollment
         every { enrollmentAdaptor.save(any()) } answers { firstArg() }
+        every { courseAdaptor.findById(1L) } returns course
 
         useCase.execute(payment.pgOrderId, successPayload(payment.pgOrderId))
 
-        assertEquals(EnrollmentStatus.ACTIVE, enrollment.status)
+        assertAll(
+            { assertEquals(EnrollmentStatus.ACTIVE, enrollment.status) },
+        )
+        verify {
+            lessonService.createLessonsForEnrollment(
+                enrollment = any(),
+                course = course,
+                totalLessons = 12,
+                teacherPayoutPerLessonWon = 20000,
+            )
+        }
     }
 
     private fun pendingPayment() =

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/service/LessonDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/service/LessonDomainService.kt
@@ -1,0 +1,34 @@
+package com.sclass.domain.domains.lesson.service
+
+import com.sclass.common.annotation.DomainService
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonType
+
+@DomainService
+class LessonDomainService(
+    private val lessonAdaptor: LessonAdaptor,
+) {
+    fun createLessonsForEnrollment(
+        enrollment: Enrollment,
+        course: Course,
+        totalLessons: Int,
+        teacherPayoutPerLessonWon: Int,
+    ): List<Lesson> {
+        val lessons =
+            (1..totalLessons).map { lessonNumber ->
+                Lesson(
+                    lessonType = LessonType.COURSE,
+                    enrollmentId = enrollment.id,
+                    studentUserId = enrollment.studentUserId,
+                    assignedTeacherUserId = course.teacherUserId,
+                    lessonNumber = lessonNumber,
+                    name = "${course.name} ${lessonNumber}회차",
+                    teacherPayoutAmountWon = teacherPayoutPerLessonWon,
+                )
+            }
+        return lessonAdaptor.saveAll(lessons)
+    }
+}

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/service/LessonDomainServiceTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/service/LessonDomainServiceTest.kt
@@ -1,0 +1,80 @@
+package com.sclass.domain.domains.lesson.service
+
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class LessonDomainServiceTest {
+    private val lessonAdaptor = mockk<LessonAdaptor>()
+    private val service = LessonDomainService(lessonAdaptor)
+
+    private fun enrollment() =
+        Enrollment.createByGrant(
+            courseId = 1L,
+            studentUserId = "student-id-00000000001",
+            grantedByUserId = "admin-id-000000000001",
+            grantReason = "테스트",
+            teacherPayoutPerLessonWon = 20000,
+            tuitionAmountWon = 300000,
+        )
+
+    private fun course() =
+        Course(
+            id = 1L,
+            productId = "product-id-00000000001",
+            teacherUserId = "teacher-id-00000000001",
+            name = "수학 기초",
+            status = CourseStatus.ACTIVE,
+        )
+
+    @Test
+    fun `totalLessons만큼 레슨이 생성된다`() {
+        val lessonsSlot = slot<List<Lesson>>()
+        every { lessonAdaptor.saveAll(capture(lessonsSlot)) } answers { lessonsSlot.captured }
+
+        val result = service.createLessonsForEnrollment(enrollment(), course(), totalLessons = 4, teacherPayoutPerLessonWon = 20000)
+
+        assertEquals(4, result.size)
+    }
+
+    @Test
+    fun `생성된 레슨의 필드가 올바르게 매핑된다`() {
+        val lessonsSlot = slot<List<Lesson>>()
+        every { lessonAdaptor.saveAll(capture(lessonsSlot)) } answers { lessonsSlot.captured }
+
+        val result = service.createLessonsForEnrollment(enrollment(), course(), totalLessons = 3, teacherPayoutPerLessonWon = 20000)
+
+        val first = result[0]
+        val last = result[2]
+        assertAll(
+            { assertEquals(LessonType.COURSE, first.lessonType) },
+            { assertEquals("student-id-00000000001", first.studentUserId) },
+            { assertEquals("teacher-id-00000000001", first.assignedTeacherUserId) },
+            { assertEquals(1, first.lessonNumber) },
+            { assertEquals("수학 기초 1회차", first.name) },
+            { assertEquals(20000, first.teacherPayoutAmountWon) },
+            { assertEquals(LessonStatus.SCHEDULED, first.status) },
+            { assertEquals(3, last.lessonNumber) },
+            { assertEquals("수학 기초 3회차", last.name) },
+        )
+    }
+
+    @Test
+    fun `totalLessons가 0이면 빈 리스트를 반환한다`() {
+        every { lessonAdaptor.saveAll(emptyList()) } returns emptyList()
+
+        val result = service.createLessonsForEnrollment(enrollment(), course(), totalLessons = 0, teacherPayoutPerLessonWon = 20000)
+
+        assertEquals(0, result.size)
+    }
+}


### PR DESCRIPTION
## Summary
Enrollment이 활성화될 때 `CourseProduct.totalLessons`만큼 Lesson을 자동 생성하여, 수강 등록 즉시 수업 관리가 가능하도록 합니다.

Closes #208

## Changes
- `LessonDomainService` 신규 생성: `createLessonsForEnrollment()` — totalLessons만큼 SCHEDULED 상태 Lesson 일괄 생성
- `GrantEnrollmentUseCase` 수정: 어드민 grant 시 enrollment 저장 후 lesson 자동 생성
- `HandleNicePayWebhookUseCase` 수정: 결제 완료(`markPaid`) 후 같은 트랜잭션 내에서 lesson 자동 생성
- `LessonDomainServiceTest` 신규: 개수 검증, 필드 매핑 검증, totalLessons=0 케이스
- `GrantEnrollmentUseCaseTest` 수정: lessonService mock 추가 + 생성 verify
- `HandleNicePayWebhookUseCaseTest` 수정: courseAdaptor/lessonService mock 추가 + 생성 verify

## Affected Modules
- [x] SClass-Domain
- [x] SClass-Api-Backoffice
- [x] SClass-Api-Supporters

## Test Plan
- [x] `./gradlew clean build` 빌드 성공
- [x] `./gradlew ktlintCheck` 통과
- [x] LessonDomainServiceTest 통과 (3 cases)
- [x] GrantEnrollmentUseCaseTest 통과 (lesson 생성 verify)
- [x] HandleNicePayWebhookUseCaseTest 통과 (lesson 생성 verify)

## Checklist
- [x] CLAUDE.md 컨벤션을 준수했는지 확인
- [x] 불필요한 파일이 포함되지 않았는지 확인