### PR TITLE
feat: 백오피스 코스 목록 API에 totalLessons 필드 추가

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/CoursePageResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/CoursePageResponse.kt
@@ -21,6 +21,7 @@ data class CourseListResponse(
     val description: String?,
     val status: CourseStatus,
     val enrollmentCount: Long,
+    val totalLessons: Int,
     val createdAt: LocalDateTime,
 ) {
     companion object {
@@ -35,6 +36,7 @@ data class CourseListResponse(
                 description = dto.course.description,
                 status = dto.course.status,
                 enrollmentCount = dto.enrollmentCount,
+                totalLessons = dto.totalLessons,
                 createdAt = dto.course.createdAt,
             )
     }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/course/usecase/GetCourseListUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/course/usecase/GetCourseListUseCaseTest.kt
@@ -22,6 +22,7 @@ class GetCourseListUseCaseTest {
         courseName: String = "수학 기초",
         status: CourseStatus = CourseStatus.ACTIVE,
         enrollmentCount: Long = 5,
+        totalLessons: Int = 12,
     ) = CourseWithTeacherAndEnrollmentCountDto(
         course =
             Course(
@@ -34,6 +35,7 @@ class GetCourseListUseCaseTest {
             ),
         teacherName = teacherName,
         enrollmentCount = enrollmentCount,
+        totalLessons = totalLessons,
     )
 
     @Test
@@ -97,6 +99,17 @@ class GetCourseListUseCaseTest {
         val result = useCase.execute(null, null, pageable)
 
         assertEquals(10, result.content[0].enrollmentCount)
+    }
+
+    @Test
+    fun `totalLessons가 응답에 포함된다`() {
+        val dto = createCourseDto(totalLessons = 8)
+        val pageable = PageRequest.of(0, 20)
+        every { courseAdaptor.searchCourses(null, null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, null, pageable)
+
+        assertEquals(8, result.content[0].totalLessons)
     }
 
     @Test

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/dto/CourseWithTeacherAndEnrollmentCountDto.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/dto/CourseWithTeacherAndEnrollmentCountDto.kt
@@ -6,4 +6,5 @@ data class CourseWithTeacherAndEnrollmentCountDto(
     val course: Course,
     val teacherName: String,
     val enrollmentCount: Long,
+    val totalLessons: Int,
 )

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepositoryImpl.kt
@@ -81,7 +81,7 @@ class CourseCustomRepositoryImpl(
                 .leftJoin(courseProduct)
                 .on(courseProduct.id.eq(course.productId))
                 .where(*where.toTypedArray())
-                .groupBy(course.id, user.name, courseProduct.totalLessons)
+                .groupBy(course, user.name, courseProduct.totalLessons)
                 .orderBy(*pageable.sort.toOrderSpecifiers())
                 .offset(pageable.offset)
                 .limit(pageable.pageSize.toLong())

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.sclass.domain.domains.course.dto.CourseWithEnrollmentCountDto
 import com.sclass.domain.domains.course.dto.CourseWithTeacherAndEnrollmentCountDto
 import com.sclass.domain.domains.course.dto.CourseWithTeacherDto
 import com.sclass.domain.domains.enrollment.domain.QEnrollment.enrollment
+import com.sclass.domain.domains.product.domain.QCourseProduct.courseProduct
 import com.sclass.domain.domains.teacher.domain.QTeacher.teacher
 import com.sclass.domain.domains.user.domain.QUser.user
 import org.springframework.data.domain.Page
@@ -67,14 +68,20 @@ class CourseCustomRepositoryImpl(
 
         val content =
             queryFactory
-                .select(course, user.name, enrollment.count())
-                .from(course)
+                .select(
+                    course,
+                    user.name,
+                    enrollment.count(),
+                    courseProduct.totalLessons,
+                ).from(course)
                 .leftJoin(user)
                 .on(user.id.eq(course.teacherUserId))
                 .leftJoin(enrollment)
                 .on(enrollment.courseId.eq(course.id))
+                .leftJoin(courseProduct)
+                .on(courseProduct.id.eq(course.productId))
                 .where(*where.toTypedArray())
-                .groupBy(course.id, user.name)
+                .groupBy(course.id, user.name, courseProduct.totalLessons)
                 .orderBy(*pageable.sort.toOrderSpecifiers())
                 .offset(pageable.offset)
                 .limit(pageable.pageSize.toLong())
@@ -84,6 +91,7 @@ class CourseCustomRepositoryImpl(
                         course = tuple[course]!!,
                         teacherName = tuple[user.name] ?: "-",
                         enrollmentCount = tuple[enrollment.count()] ?: 0L,
+                        totalLessons = tuple[courseProduct.totalLessons] ?: 0,
                     )
                 }
 


### PR DESCRIPTION
## Summary
- 백오피스 코스 목록 조회 시 `totalLessons`(총 수업 횟수)를 응답에 포함
- QueryDSL에서 `QCourseProduct` join으로 Product 테이블에서 조회

## Changes
- `CourseCustomRepositoryImpl`: `QCourseProduct` left join 추가, `totalLessons` select/groupBy
- `CourseWithTeacherAndEnrollmentCountDto`: `totalLessons: Int` 필드 추가
- `CourseListResponse`: `totalLessons` 필드 + `from()` 매핑 추가
- `GetCourseListUseCaseTest`: `totalLessons` 테스트 추가

## Test Plan
- [x] `GetCourseListUseCaseTest` — totalLessons 응답 포함 검증
- [x] `./gradlew clean build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)