### PR TITLE
fix: SelectTopicRequest isSelected 역직렬화 오류 수정

### DIFF
--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/dto/SelectTopicRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/dto/SelectTopicRequest.kt
@@ -1,8 +1,10 @@
 package com.sclass.supporters.commission.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotNull
 
 data class SelectTopicRequest(
     @field:NotNull
+    @JsonProperty("isSelected")
     val isSelected: Boolean,
 )


### PR DESCRIPTION
## Summary
- Kotlin Boolean 프로퍼티의 `is` prefix로 인해 Jackson이 `isSelected` 필드를 역직렬화하지 못하는 문제 수정
- `@JsonProperty("isSelected")` 어노테이션을 추가하여 JSON 키 이름을 명시적으로 지정

## Test plan
- [x] 빌드 및 테스트 통과
- [ ] `PATCH /api/v1/commissions/{id}/topics/{topicId}` 에 `{"isSelected": true}` 요청 시 400 에러 없이 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)