### PR TITLE
feat: CommissionResponse lessonId 추가 및 백오피스 enrollment 레슨 목록 API

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/controller/EnrollmentController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/controller/EnrollmentController.kt
@@ -1,8 +1,10 @@
 package com.sclass.backoffice.enrollment.controller
 
+import com.sclass.backoffice.enrollment.dto.EnrollmentLessonListResponse
 import com.sclass.backoffice.enrollment.dto.EnrollmentPageResponse
 import com.sclass.backoffice.enrollment.dto.EnrollmentResponse
 import com.sclass.backoffice.enrollment.dto.GrantEnrollmentRequest
+import com.sclass.backoffice.enrollment.usecase.GetEnrollmentLessonListUseCase
 import com.sclass.backoffice.enrollment.usecase.GetEnrollmentListUseCase
 import com.sclass.backoffice.enrollment.usecase.GrantEnrollmentUseCase
 import com.sclass.common.annotation.CurrentUserId
@@ -13,6 +15,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -24,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 class EnrollmentController(
     private val grantEnrollmentUseCase: GrantEnrollmentUseCase,
     private val getEnrollmentListUseCase: GetEnrollmentListUseCase,
+    private val getEnrollmentLessonListUseCase: GetEnrollmentLessonListUseCase,
 ) {
     @PostMapping("/grant")
     fun grantEnrollment(
@@ -41,4 +45,9 @@ class EnrollmentController(
         @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
     ): ApiResponse<EnrollmentPageResponse> =
         ApiResponse.success(getEnrollmentListUseCase.execute(studentUserId, teacherUserId, courseId, status, pageable))
+
+    @GetMapping("/{enrollmentId}/lessons")
+    fun getEnrollmentLessonList(
+        @PathVariable enrollmentId: Long,
+    ): ApiResponse<EnrollmentLessonListResponse> = ApiResponse.success(getEnrollmentLessonListUseCase.execute(enrollmentId))
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/EnrollmentLessonListResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/EnrollmentLessonListResponse.kt
@@ -1,0 +1,39 @@
+package com.sclass.backoffice.enrollment.dto
+
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import java.time.LocalDateTime
+
+data class EnrollmentLessonListResponse(
+    val lessons: List<EnrollmentLessonResponse>,
+)
+
+data class EnrollmentLessonResponse(
+    val id: Long,
+    val lessonType: LessonType,
+    val lessonNumber: Int?,
+    val name: String,
+    val status: LessonStatus,
+    val scheduledAt: LocalDateTime?,
+    val startedAt: LocalDateTime?,
+    val completedAt: LocalDateTime?,
+    val teacherPayoutAmountWon: Int,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(lesson: Lesson) =
+            EnrollmentLessonResponse(
+                id = lesson.id,
+                lessonType = lesson.lessonType,
+                lessonNumber = lesson.lessonNumber,
+                name = lesson.name,
+                status = lesson.status,
+                scheduledAt = lesson.scheduledAt,
+                startedAt = lesson.startedAt,
+                completedAt = lesson.completedAt,
+                teacherPayoutAmountWon = lesson.teacherPayoutAmountWon,
+                createdAt = lesson.createdAt,
+            )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentLessonListUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentLessonListUseCase.kt
@@ -1,0 +1,20 @@
+package com.sclass.backoffice.enrollment.usecase
+
+import com.sclass.backoffice.enrollment.dto.EnrollmentLessonListResponse
+import com.sclass.backoffice.enrollment.dto.EnrollmentLessonResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetEnrollmentLessonListUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(enrollmentId: Long): EnrollmentLessonListResponse {
+        val lessons = lessonAdaptor.findAllByEnrollment(enrollmentId)
+        return EnrollmentLessonListResponse(
+            lessons = lessons.map { EnrollmentLessonResponse.from(it) },
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentLessonListUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentLessonListUseCase.kt
@@ -14,7 +14,10 @@ class GetEnrollmentLessonListUseCase(
     fun execute(enrollmentId: Long): EnrollmentLessonListResponse {
         val lessons = lessonAdaptor.findAllByEnrollment(enrollmentId)
         return EnrollmentLessonListResponse(
-            lessons = lessons.map { EnrollmentLessonResponse.from(it) },
+            lessons =
+                lessons
+                    .sortedBy { it.lessonNumber ?: Int.MAX_VALUE }
+                    .map { EnrollmentLessonResponse.from(it) },
         )
     }
 }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentLessonListUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentLessonListUseCaseTest.kt
@@ -1,0 +1,64 @@
+package com.sclass.backoffice.enrollment.usecase
+
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetEnrollmentLessonListUseCaseTest {
+    private val lessonAdaptor = mockk<LessonAdaptor>()
+    private val useCase = GetEnrollmentLessonListUseCase(lessonAdaptor)
+
+    private fun createLesson(
+        id: Long = 1L,
+        lessonNumber: Int = 1,
+        name: String = "수학 기초 ${lessonNumber}회차",
+        status: LessonStatus = LessonStatus.SCHEDULED,
+    ) = Lesson(
+        id = id,
+        lessonType = LessonType.COURSE,
+        enrollmentId = 100L,
+        studentUserId = "student-id-00000000001",
+        assignedTeacherUserId = "teacher-id-00000000001",
+        lessonNumber = lessonNumber,
+        name = name,
+        teacherPayoutAmountWon = 20000,
+        status = status,
+    )
+
+    @Test
+    fun `enrollment의 레슨 목록을 반환한다`() {
+        val lessons =
+            listOf(
+                createLesson(id = 1L, lessonNumber = 1),
+                createLesson(id = 2L, lessonNumber = 2),
+                createLesson(id = 3L, lessonNumber = 3),
+            )
+        every { lessonAdaptor.findAllByEnrollment(100L) } returns lessons
+
+        val result = useCase.execute(100L)
+
+        assertAll(
+            { assertEquals(3, result.lessons.size) },
+            { assertEquals(1, result.lessons[0].lessonNumber) },
+            { assertEquals("수학 기초 1회차", result.lessons[0].name) },
+            { assertEquals(LessonStatus.SCHEDULED, result.lessons[0].status) },
+            { assertEquals(20000, result.lessons[0].teacherPayoutAmountWon) },
+            { assertEquals(3, result.lessons[2].lessonNumber) },
+        )
+    }
+
+    @Test
+    fun `레슨이 없으면 빈 리스트를 반환한다`() {
+        every { lessonAdaptor.findAllByEnrollment(999L) } returns emptyList()
+
+        val result = useCase.execute(999L)
+
+        assertEquals(0, result.lessons.size)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/dto/CommissionResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/dto/CommissionResponse.kt
@@ -17,6 +17,7 @@ data class CommissionResponse(
     val status: CommissionStatus,
     val guideInfo: GuideInfoResponse,
     val commissionFiles: List<CommissionFileResponse>,
+    val lessonId: Long?,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
 ) {
@@ -41,6 +42,7 @@ data class CommissionResponse(
                         teacherEmphasis = commission.guideInfo.teacherEmphasis,
                     ),
                 commissionFiles = commissionFiles.map { CommissionFileResponse.from(it) },
+                lessonId = commission.acceptedLessonId,
                 createdAt = commission.createdAt,
                 updatedAt = commission.updatedAt,
             )


### PR DESCRIPTION
## Summary
- CommissionResponse에 `lessonId: Long?` 필드 추가 — 주제 선택(ACCEPTED) 후 생성된 lessonId를 프론트에 전달하여 탐구 생성 시 활용 가능
- 백오피스 `GET /api/v1/enrollments/{enrollmentId}/lessons` API 추가 — enrollment별 레슨 목록 조회

## Test plan
- [x] 빌드 및 테스트 통과
- [ ] Commission 상세 조회 시 ACCEPTED 상태에서 `lessonId` 필드 정상 반환 확인
- [ ] 백오피스 enrollment 레슨 목록 API 호출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)