### PR TITLE
feat: Lesson 수정 API (수업명, 수업일 변경)

### DIFF
--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/controller/LessonController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/controller/LessonController.kt
@@ -4,8 +4,12 @@ import com.sclass.common.annotation.CurrentUserId
 import com.sclass.common.dto.ApiResponse
 import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
 import com.sclass.supporters.lesson.dto.CreateLessonInquiryPlanRequest
+import com.sclass.supporters.lesson.dto.LessonResponse
+import com.sclass.supporters.lesson.dto.UpdateLessonRequest
 import com.sclass.supporters.lesson.usecase.CreateLessonInquiryPlanUseCase
+import com.sclass.supporters.lesson.usecase.UpdateLessonUseCase
 import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -16,7 +20,15 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/lessons")
 class LessonController(
     private val createLessonInquiryPlanUseCase: CreateLessonInquiryPlanUseCase,
+    private val updateLessonUseCase: UpdateLessonUseCase,
 ) {
+    @PatchMapping("/{lessonId}")
+    fun update(
+        @CurrentUserId userId: String,
+        @PathVariable lessonId: Long,
+        @Valid @RequestBody request: UpdateLessonRequest,
+    ): ApiResponse<LessonResponse> = ApiResponse.success(updateLessonUseCase.execute(userId, lessonId, request))
+
     @PostMapping("/{lessonId}/inquiry-plans")
     fun createInquiryPlan(
         @CurrentUserId userId: String,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/UpdateLessonRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/UpdateLessonRequest.kt
@@ -1,0 +1,8 @@
+package com.sclass.supporters.lesson.dto
+
+import java.time.LocalDateTime
+
+data class UpdateLessonRequest(
+    val name: String? = null,
+    val scheduledAt: LocalDateTime? = null,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/UpdateLessonRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/UpdateLessonRequest.kt
@@ -1,8 +1,9 @@
 package com.sclass.supporters.lesson.dto
 
+import jakarta.validation.constraints.Size
 import java.time.LocalDateTime
 
 data class UpdateLessonRequest(
-    val name: String? = null,
+    @field:Size(max = 200) val name: String? = null,
     val scheduledAt: LocalDateTime? = null,
 )

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonUseCase.kt
@@ -22,6 +22,6 @@ class UpdateLessonUseCase(
             throw LessonUnauthorizedAccessException()
         }
         lesson.updateSchedule(request.name, request.scheduledAt)
-        return LessonResponse.from(lessonAdaptor.save(lesson))
+        return LessonResponse.from(lesson)
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonUseCase.kt
@@ -1,0 +1,27 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.supporters.lesson.dto.LessonResponse
+import com.sclass.supporters.lesson.dto.UpdateLessonRequest
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class UpdateLessonUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+) {
+    @Transactional
+    fun execute(
+        userId: String,
+        lessonId: Long,
+        request: UpdateLessonRequest,
+    ): LessonResponse {
+        val lesson = lessonAdaptor.findById(lessonId)
+        if (lesson.assignedTeacherUserId != userId) {
+            throw LessonUnauthorizedAccessException()
+        }
+        lesson.updateSchedule(request.name, request.scheduledAt)
+        return LessonResponse.from(lessonAdaptor.save(lesson))
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
@@ -1,6 +1,7 @@
 package com.sclass.domain.domains.lesson.domain
 
 import com.sclass.domain.common.model.BaseTimeEntity
+import com.sclass.domain.domains.lesson.exception.LessonInvalidStatusTransitionException
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -97,7 +98,9 @@ class Lesson(
         name: String?,
         scheduledAt: LocalDateTime?,
     ) {
-        require(status == LessonStatus.SCHEDULED) { "Cannot update lesson in $status status" }
+        if (status != LessonStatus.SCHEDULED) {
+            throw LessonInvalidStatusTransitionException()
+        }
         name?.let { this.name = it }
         scheduledAt?.let { this.scheduledAt = it }
     }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
@@ -97,8 +97,9 @@ class Lesson(
         name: String?,
         scheduledAt: LocalDateTime?,
     ) {
-        if (name != null) this.name = name
-        if (scheduledAt != null) this.scheduledAt = scheduledAt
+        require(status == LessonStatus.SCHEDULED) { "Cannot update lesson in $status status" }
+        name?.let { this.name = it }
+        scheduledAt?.let { this.scheduledAt = it }
     }
 
     private fun validateTransition(target: LessonStatus) {

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
@@ -93,6 +93,14 @@ class Lesson(
         this.status = LessonStatus.CANCELLED
     }
 
+    fun updateSchedule(
+        name: String?,
+        scheduledAt: LocalDateTime?,
+    ) {
+        if (name != null) this.name = name
+        if (scheduledAt != null) this.scheduledAt = scheduledAt
+    }
+
     private fun validateTransition(target: LessonStatus) {
         val allowed =
             when (target) {


### PR DESCRIPTION
## Summary
선생님이 수업명과 수업 예정일을 수정할 수 있는 API 추가

## Changes
- `PATCH /api/v1/lessons/{lessonId}` 엔드포인트 추가
- `UpdateLessonRequest`: `name`, `scheduledAt` 부분 수정 지원 (둘 다 nullable)
- `UpdateLessonUseCase`: 담당 선생님(`assignedTeacherUserId`)만 수정 가능하도록 권한 검증
- `Lesson.updateSchedule()` 도메인 메서드 추가

## Affected Modules
- [x] SClass-Domain
- [x] SClass-Api-Supporters

## Test Plan
- [x] `./gradlew clean build` 빌드 성공
- [x] `./gradlew ktlintCheck` 통과

## Checklist
- [x] CLAUDE.md 컨벤션을 준수했는지 확인
- [x] 불필요한 파일이 포함되지 않았는지 확인