### PR TITLE
fix: supporters application.yml.example에 report-service 섹션 추가

### DIFF
--- a/SClass-Api-Backoffice/src/main/resources/application.yml.example
+++ b/SClass-Api-Backoffice/src/main/resources/application.yml.example
@@ -22,6 +22,10 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
+      connection-pool-size: ${REDIS_CONNECTION_POOL_SIZE:8}
+      connection-minimum-idle-size: ${REDIS_CONNECTION_MIN_IDLE:2}
+      subscription-connection-pool-size: ${REDIS_SUBSCRIPTION_POOL_SIZE:4}
+      subscription-connection-minimum-idle-size: ${REDIS_SUBSCRIPTION_MIN_IDLE:1}
   mail:
     host: ${SMTP_HOST:}
     port: ${SMTP_PORT:587}

--- a/SClass-Api-Lms/src/main/resources/application.yml.example
+++ b/SClass-Api-Lms/src/main/resources/application.yml.example
@@ -22,6 +22,10 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
+      connection-pool-size: ${REDIS_CONNECTION_POOL_SIZE:8}
+      connection-minimum-idle-size: ${REDIS_CONNECTION_MIN_IDLE:2}
+      subscription-connection-pool-size: ${REDIS_SUBSCRIPTION_POOL_SIZE:4}
+      subscription-connection-minimum-idle-size: ${REDIS_SUBSCRIPTION_MIN_IDLE:1}
   mail:
     host: ${SMTP_HOST:}
     port: ${SMTP_PORT:587}

--- a/SClass-Api-Supporters/src/main/resources/application.yml.example
+++ b/SClass-Api-Supporters/src/main/resources/application.yml.example
@@ -73,6 +73,12 @@ alimtalk:
   plus-friend-id: ${ALIMTALK_PLUS_FRIEND_ID:}
   app-base-url: ${ALIMTALK_APP_BASE_URL:}
 
+report-service:
+  enabled: ${REPORT_SERVICE_ENABLED:false}
+  base-url: ${REPORT_SERVICE_BASE_URL:}
+  callback-secret: ${REPORT_SERVICE_CALLBACK_SECRET:}
+  callback-base-url: ${REPORT_SERVICE_CALLBACK_BASE_URL:}
+
 management:
   endpoints:
     web:

--- a/SClass-Api-Supporters/src/main/resources/application.yml.example
+++ b/SClass-Api-Supporters/src/main/resources/application.yml.example
@@ -74,8 +74,9 @@ alimtalk:
   app-base-url: ${ALIMTALK_APP_BASE_URL:}
 
 report-service:
-  enabled: ${REPORT_SERVICE_ENABLED:false}
+  enabled: ${REPORT_SERVICE_ENABLED:true}
   base-url: ${REPORT_SERVICE_BASE_URL:}
+  timeout-seconds: ${REPORT_SERVICE_TIMEOUT_SECONDS:30}
   callback-secret: ${REPORT_SERVICE_CALLBACK_SECRET:}
   callback-base-url: ${REPORT_SERVICE_CALLBACK_BASE_URL:}
 

--- a/SClass-Api-Supporters/src/main/resources/application.yml.example
+++ b/SClass-Api-Supporters/src/main/resources/application.yml.example
@@ -22,6 +22,10 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
+      connection-pool-size: ${REDIS_CONNECTION_POOL_SIZE:8}
+      connection-minimum-idle-size: ${REDIS_CONNECTION_MIN_IDLE:2}
+      subscription-connection-pool-size: ${REDIS_SUBSCRIPTION_POOL_SIZE:4}
+      subscription-connection-minimum-idle-size: ${REDIS_SUBSCRIPTION_MIN_IDLE:1}
   mail:
     host: ${SMTP_HOST:}
     port: ${SMTP_PORT:587}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/redis/RedisProperties.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/redis/RedisProperties.kt
@@ -7,4 +7,8 @@ data class RedisProperties(
     val host: String = "localhost",
     val port: Int = 6379,
     val password: String? = null,
+    val connectionPoolSize: Int = 8,
+    val connectionMinimumIdleSize: Int = 2,
+    val subscriptionConnectionPoolSize: Int = 4,
+    val subscriptionConnectionMinimumIdleSize: Int = 1,
 )

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/redis/RedissonConfig.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/redis/RedissonConfig.kt
@@ -18,6 +18,10 @@ class RedissonConfig(
         config
             .useSingleServer()
             .setAddress("redis://${redisProperties.host}:${redisProperties.port}")
+            .setConnectionPoolSize(redisProperties.connectionPoolSize)
+            .setConnectionMinimumIdleSize(redisProperties.connectionMinimumIdleSize)
+            .setSubscriptionConnectionPoolSize(redisProperties.subscriptionConnectionPoolSize)
+            .setSubscriptionConnectionMinimumIdleSize(redisProperties.subscriptionConnectionMinimumIdleSize)
             .apply {
                 redisProperties.password?.takeIf { it.isNotEmpty() }?.let { password = it }
             }


### PR DESCRIPTION
## Summary
- prod supporters-api 배포 시 `ReportServiceClient` Bean이 등록되지 않아 애플리케이션 기동 실패 → App Runner 자동 롤백이 반복되던 문제 수정
- `application.yml.example`에 `report-service` 섹션이 누락되어 있어서 추가

## 원인
- `ReportServiceClient`는 `@ConditionalOnProperty(prefix = "report-service", name = ["enabled"], havingValue = "true")`로 선언
- `CreateInquiryPlanUseCase`는 `ReportServiceClient`를 required로 주입 → Bean 없으면 앱 실패
- `application.yml.example`에 해당 섹션이 없어 env var 플레이스홀더가 매핑되지 않음

## Changes
- `SClass-Api-Supporters/src/main/resources/application.yml.example`에 `report-service` 섹션 추가
  - `REPORT_SERVICE_ENABLED`, `REPORT_SERVICE_BASE_URL`, `REPORT_SERVICE_CALLBACK_SECRET`, `REPORT_SERVICE_CALLBACK_BASE_URL` env vars 플레이스홀더

## Test Plan
- [ ] CI 빌드 통과
- [ ] develop 머지 후 prod 배포 시 supporters-api 정상 기동
- [ ] 추가로 infra 워크플로우 수동 실행 필요 (App Runner env vars 동기화)

## 참고
별도로 인프라 drift 해결 필요:
- App Runner `sclass-prod-supporters-api` 서비스에 `REPORT_SERVICE_*`, `REDIS_*` env vars가 누락됨
- Terraform 코드에는 선언되어 있으나 실제 apply가 안 된 상태 → infra 워크플로우 수동 트리거 예정