### PR TITLE
hotfix: Products Single Table Inheritance 서브클래스 컬럼 nullable

### DIFF
--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CommissionProduct.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CommissionProduct.kt
@@ -12,6 +12,7 @@ class CommissionProduct(
     @Column(nullable = true)
     val coinCost: Int,
 
-    @Column(name = "teacher_payout_amount_won", nullable = false)
+    // Single Table Inheritance: 서브클래스 전용 컬럼은 DB NULL 허용 필수
+    @Column(name = "teacher_payout_amount_won", nullable = true)
     val teacherPayoutAmountWon: Int,
 ) : Product(name = name, priceWon = 0)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
@@ -10,9 +10,11 @@ class CourseProduct(
     name: String,
     priceWon: Int,
 
-    @Column(name = "total_lessons", nullable = false)
+    // Single Table Inheritance: 서브클래스 전용 컬럼은 DB NULL 허용 필수
+    // (다른 dtype insert 시 NOT NULL이면 실패). Kotlin 타입은 non-null 유지하여 코드 안정성 확보
+    @Column(name = "total_lessons", nullable = true)
     val totalLessons: Int,
 
-    @Column(name = "teacher_payout_per_lesson_won", nullable = false)
+    @Column(name = "teacher_payout_per_lesson_won", nullable = true)
     val teacherPayoutPerLessonWon: Int,
 ) : Product(name = name, priceWon = priceWon)


### PR DESCRIPTION
## Summary

CommissionProduct 생성 시 prod에서 500 에러 발생 복구용 hotfix.

## Problem

`products` 테이블(Single Table Inheritance)에서 서브클래스 전용 컬럼들이 DB NOT NULL로 되어 있어 다른 `dtype` 생성 시 insert 실패:

```
Field 'teacher_payout_per_lesson_won' doesn't have a default value
```

영향 범위:
- `CommissionProduct` 생성 → `total_lessons`, `teacher_payout_per_lesson_won` NOT NULL로 실패
- `CoinProduct` 생성 → 동일 + `teacher_payout_amount_won`도 걸림
- `CourseProduct` 생성 → `teacher_payout_amount_won` NOT NULL로 실패

## Root Cause

엔티티 선언에서 서브클래스 전용 필드에 `@Column(nullable = false)`를 지정하여 Hibernate DDL이 DB 컬럼을 NOT NULL로 생성. Single Table Inheritance에서는 서브클래스별로 다른 컬럼을 쓰므로 DB 레벨은 반드시 nullable이어야 함.

## Changes

- `CourseProduct.totalLessons`, `teacherPayoutPerLessonWon` → `@Column(nullable = true)`
- `CommissionProduct.teacherPayoutAmountWon` → `@Column(nullable = true)`
- Kotlin 타입은 non-null `Int` 유지 → 코드 레벨 NOT NULL 보장

## DB 수동 반영 (완료)

prod/dev 모두 수동 ALTER 완료 (DDL_AUTO=update는 기존 컬럼 nullability 자동 조정 안 함):

```sql
ALTER TABLE products
  MODIFY total_lessons INT NULL,
  MODIFY teacher_payout_per_lesson_won INT NULL,
  MODIFY teacher_payout_amount_won INT NULL;
```

## Affected Modules

- [x] SClass-Domain

## Test Plan

- [x] `./gradlew :SClass-Domain:ktlintCheck :SClass-Domain:compileKotlin` 통과
- [x] prod DB ALTER 적용 완료
- [x] dev DB ALTER 적용 완료
- [ ] 배포 후 Backoffice에서 CommissionProduct 생성 성공 확인

## Checklist

- [x] 컨벤션 준수
- [x] 관련 테스트 통과