### PR TITLE
feat(supporters): lesson detail에 학생 프로필/문서·inquiry plans 포함

### DIFF
--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/LessonDetailResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/LessonDetailResponse.kt
@@ -3,6 +3,8 @@ package com.sclass.supporters.lesson.dto
 import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.lesson.domain.LessonStatus
 import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
+import com.sclass.supporters.student.dto.StudentProfileResponse
 import java.time.LocalDateTime
 
 data class LessonDetailResponse(
@@ -12,17 +14,22 @@ data class LessonDetailResponse(
     val lessonType: LessonType,
     val enrollmentId: Long?,
     val sourceCommissionId: Long?,
+    val studentUserId: String,
+    val assignedTeacherUserId: String,
+    val substituteTeacherUserId: String?,
+    val student: StudentProfileResponse,
     val status: LessonStatus,
     val scheduledAt: LocalDateTime?,
     val startedAt: LocalDateTime?,
     val completedAt: LocalDateTime?,
-    val inquiryPlanId: Long?,
+    val inquiryPlans: List<InquiryPlanResponse>,
     val createdAt: LocalDateTime,
 ) {
     companion object {
         fun from(
             lesson: Lesson,
-            inquiryPlanId: Long?,
+            student: StudentProfileResponse,
+            inquiryPlans: List<InquiryPlanResponse>,
         ) = LessonDetailResponse(
             id = lesson.id,
             name = lesson.name,
@@ -30,11 +37,15 @@ data class LessonDetailResponse(
             lessonType = lesson.lessonType,
             enrollmentId = lesson.enrollmentId,
             sourceCommissionId = lesson.sourceCommissionId,
+            studentUserId = lesson.studentUserId,
+            assignedTeacherUserId = lesson.assignedTeacherUserId,
+            substituteTeacherUserId = lesson.substituteTeacherUserId,
+            student = student,
             status = lesson.status,
             scheduledAt = lesson.scheduledAt,
             startedAt = lesson.startedAt,
             completedAt = lesson.completedAt,
-            inquiryPlanId = inquiryPlanId,
+            inquiryPlans = inquiryPlans,
             createdAt = lesson.createdAt,
         )
     }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/GetLessonDetailUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/GetLessonDetailUseCase.kt
@@ -5,13 +5,23 @@ import com.sclass.domain.domains.inquiryplan.adaptor.InquiryPlanAdaptor
 import com.sclass.domain.domains.inquiryplan.domain.InquiryPlanSourceType
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.domain.domains.student.adaptor.StudentAdaptor
+import com.sclass.domain.domains.student.adaptor.StudentDocumentAdaptor
+import com.sclass.domain.domains.user.adaptor.UserRoleAdaptor
+import com.sclass.domain.domains.user.domain.activePlatforms
+import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
 import com.sclass.supporters.lesson.dto.LessonDetailResponse
+import com.sclass.supporters.student.dto.StudentDocumentResponse
+import com.sclass.supporters.student.dto.StudentProfileResponse
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class GetLessonDetailUseCase(
     private val lessonAdaptor: LessonAdaptor,
     private val inquiryPlanAdaptor: InquiryPlanAdaptor,
+    private val studentAdaptor: StudentAdaptor,
+    private val studentDocumentAdaptor: StudentDocumentAdaptor,
+    private val userRoleAdaptor: UserRoleAdaptor,
 ) {
     @Transactional(readOnly = true)
     fun execute(
@@ -19,11 +29,22 @@ class GetLessonDetailUseCase(
         lessonId: Long,
     ): LessonDetailResponse {
         val lesson = lessonAdaptor.findById(lessonId)
-        if (lesson.studentUserId != userId && !lesson.isTeacher(userId)) {
+        if (!lesson.isTeacher(userId)) {
             throw LessonUnauthorizedAccessException()
         }
-        val latestPlan =
-            inquiryPlanAdaptor.findLatestBySourceOrNull(InquiryPlanSourceType.LESSON, lessonId)
-        return LessonDetailResponse.from(lesson, latestPlan?.id)
+        val student = studentAdaptor.findByUserIdWithUser(lesson.studentUserId)
+        val documents = studentDocumentAdaptor.findAllByStudentId(student.id)
+        val platforms = userRoleAdaptor.findAllByUserId(lesson.studentUserId).activePlatforms()
+        val studentProfile =
+            StudentProfileResponse.from(
+                student = student,
+                platforms = platforms,
+                documents = documents.map { StudentDocumentResponse.from(it) },
+            )
+        val inquiryPlans =
+            inquiryPlanAdaptor
+                .findAllBySourceOrderByIdDesc(InquiryPlanSourceType.LESSON, lessonId)
+                .map { InquiryPlanResponse.from(it) }
+        return LessonDetailResponse.from(lesson, studentProfile, inquiryPlans)
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/GetLessonDetailUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/GetLessonDetailUseCase.kt
@@ -6,7 +6,6 @@ import com.sclass.domain.domains.inquiryplan.domain.InquiryPlanSourceType
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
 import com.sclass.domain.domains.student.adaptor.StudentAdaptor
-import com.sclass.domain.domains.student.adaptor.StudentDocumentAdaptor
 import com.sclass.domain.domains.user.adaptor.UserRoleAdaptor
 import com.sclass.domain.domains.user.domain.activePlatforms
 import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
@@ -20,7 +19,6 @@ class GetLessonDetailUseCase(
     private val lessonAdaptor: LessonAdaptor,
     private val inquiryPlanAdaptor: InquiryPlanAdaptor,
     private val studentAdaptor: StudentAdaptor,
-    private val studentDocumentAdaptor: StudentDocumentAdaptor,
     private val userRoleAdaptor: UserRoleAdaptor,
 ) {
     @Transactional(readOnly = true)
@@ -29,11 +27,11 @@ class GetLessonDetailUseCase(
         lessonId: Long,
     ): LessonDetailResponse {
         val lesson = lessonAdaptor.findById(lessonId)
-        if (!lesson.isTeacher(userId)) {
+        if (userId != lesson.assignedTeacherUserId && userId != lesson.substituteTeacherUserId) {
             throw LessonUnauthorizedAccessException()
         }
         val student = studentAdaptor.findByUserIdWithUser(lesson.studentUserId)
-        val documents = studentDocumentAdaptor.findAllByStudentId(student.id)
+        val documents = studentAdaptor.findDocumentsWithFileByStudentId(student.id)
         val platforms = userRoleAdaptor.findAllByUserId(lesson.studentUserId).activePlatforms()
         val studentProfile =
             StudentProfileResponse.from(

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/inquiryplan/adaptor/InquiryPlanAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/inquiryplan/adaptor/InquiryPlanAdaptor.kt
@@ -36,6 +36,11 @@ class InquiryPlanAdaptor(
         sourceRefId: Long,
     ): InquiryPlan? = repository.findFirstBySourceTypeAndSourceRefIdOrderByIdDesc(sourceType, sourceRefId)
 
+    fun findAllBySourceOrderByIdDesc(
+        sourceType: InquiryPlanSourceType,
+        sourceRefId: Long,
+    ): List<InquiryPlan> = repository.findAllBySourceTypeAndSourceRefIdOrderByIdDesc(sourceType, sourceRefId)
+
     fun findAllBySourceIn(
         sourceType: InquiryPlanSourceType,
         sourceRefIds: List<Long>,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/inquiryplan/repository/InquiryPlanRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/inquiryplan/repository/InquiryPlanRepository.kt
@@ -25,6 +25,11 @@ interface InquiryPlanRepository : JpaRepository<InquiryPlan, Long> {
         sourceRefId: Long,
     ): InquiryPlan?
 
+    fun findAllBySourceTypeAndSourceRefIdOrderByIdDesc(
+        sourceType: InquiryPlanSourceType,
+        sourceRefId: Long,
+    ): List<InquiryPlan>
+
     fun findAllBySourceTypeAndSourceRefIdIn(
         sourceType: InquiryPlanSourceType,
         sourceRefIds: List<Long>,


### PR DESCRIPTION
## Summary
- `GET /api/v1/lessons/{id}` 응답에 학생 프로필·학생부 문서·inquiry plans 배열 포함
- 권한을 effective teacher(담당/대타)만 접근 가능하도록 변경

## Changes
- `LessonDetailResponse`: `studentUserId`, `assignedTeacherUserId`, `substituteTeacherUserId`, `student`(StudentProfileResponse), `inquiryPlans`(배열) 필드 추가
- `GetLessonDetailUseCase`: 학생 프로필/문서/플랫폼 조회, inquiry plans 리스트 조회 추가. 권한 체크를 `isTeacher`만으로 단순화
- `InquiryPlanAdaptor/Repository`: `findAllBySourceOrderByIdDesc` 메서드 추가 (lesson당 plan 여러 개 지원)

## Affected Modules
- [x] SClass-Api-Supporters
- [x] SClass-Domain

## Test Plan
- [ ] `GET /api/v1/lessons/{id}` 담당 선생님 호출 → 학생 프로필/문서/inquiry plans 포함 응답
- [ ] 대타 선생님도 조회 가능
- [ ] 담당이 아닌 유저 호출 시 403

## Checklist
- [x] ktlintFormat 통과
- [x] build 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)