### PR TITLE
chore(infra): dev 환경 CloudWatch custom metric 발행 비활성화

### DIFF
--- a/infra/env/app-runner.tf
+++ b/infra/env/app-runner.tf
@@ -44,7 +44,7 @@ resource "aws_apprunner_service" "services" {
           SMTP_ENABLED               = "true"
           SMTP_HOST                  = var.smtp_host
           SMTP_PORT                  = var.smtp_port
-          CLOUDWATCH_METRICS_ENABLED = var.environment == "dev" ? "false" : "true"
+          CLOUDWATCH_METRICS_ENABLED = var.environment == "prod" ? "true" : "false"
           CLOUDWATCH_NAMESPACE       = "SClass/${title(each.key)}"
           ALIMTALK_ENABLED           = "true"
           ALIMTALK_PLUS_FRIEND_ID    = "@학생부종합전형"

--- a/infra/env/app-runner.tf
+++ b/infra/env/app-runner.tf
@@ -44,7 +44,7 @@ resource "aws_apprunner_service" "services" {
           SMTP_ENABLED               = "true"
           SMTP_HOST                  = var.smtp_host
           SMTP_PORT                  = var.smtp_port
-          CLOUDWATCH_METRICS_ENABLED = "true"
+          CLOUDWATCH_METRICS_ENABLED = var.environment == "dev" ? "false" : "true"
           CLOUDWATCH_NAMESPACE       = "SClass/${title(each.key)}"
           ALIMTALK_ENABLED           = "true"
           ALIMTALK_PLUS_FRIEND_ID    = "@학생부종합전형"


### PR DESCRIPTION
## Summary
- dev App Runner 3개 서비스의 `CLOUDWATCH_METRICS_ENABLED`를 `false`로 전환 (prod는 `true` 유지)
- 원인: Micrometer가 `http.server.requests`를 URI/method/status/outcome 등 6개 태그 조합으로 차원화해 발행 → 현재 ap-northeast-1 기준 `SClass/*` 커스텀 메트릭 **729개** 누적 (backoffice 311, supporters 307, lms 111)
- 효과: custom metric 요금(첫 10K 구간 \$0.30/개/월) 기준 **월 약 \$218 → prod만 남겨 약 \$30~40 수준**으로 감소 예상 (실제는 prod의 URI 수에 따라 달라짐)

## 이후 작업(별도 PR 예정)
- `CloudWatchMetricsConfig` MeterFilter에 URI 태그 정리(화이트리스트/`replaceTagValues`) 추가 → prod 메트릭 수도 축소
- step 60s → 300s 조정 검토
- 로그 그룹 retention 설정 (현재 28개 전부 무제한)

## Test plan
- [ ] `terraform plan -var-file=envs/dev.tfvars` 에서 dev 서비스 3개에 `CLOUDWATCH_METRICS_ENABLED: "true" → "false"` 변경만 감지되는지 확인
- [ ] `terraform plan -var-file=envs/prod.tfvars` 에서 prod 서비스는 diff 없음 확인
- [ ] 배포 후 CloudWatch Metrics 콘솔에서 `SClass/*` 네임스페이스의 dev 관련 시리즈가 신규 발행 중단되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)