### PR TITLE
fix: Dockerfile에서 삭제된 SClass-Api-Lms 참조 제거

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ COPY SClass-Common/build.gradle.kts SClass-Common/
 COPY SClass-Domain/build.gradle.kts SClass-Domain/
 COPY SClass-Infrastructure/build.gradle.kts SClass-Infrastructure/
 COPY SClass-Api-Supporters/build.gradle.kts SClass-Api-Supporters/
-COPY SClass-Api-Lms/build.gradle.kts SClass-Api-Lms/
 COPY SClass-Api-Backoffice/build.gradle.kts SClass-Api-Backoffice/
 COPY SClass-Batch/build.gradle.kts SClass-Batch/
 RUN chmod +x gradlew && ./gradlew dependencies --no-daemon || true


### PR DESCRIPTION
## Summary
- PR #228에서 LMS 모듈 삭제 시 Dockerfile 업데이트가 누락되어 Docker 빌드 실패
- `COPY SClass-Api-Lms/build.gradle.kts` 라인 제거

## Test plan
- [ ] Docker 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)