### PR TITLE
feat: 파트너십 리드 도메인 + 공개 API + 백오피스 관리 API

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"a3a0e03b-e4c5-489f-bad9-f241578274e1","pid":17882,"acquiredAt":1776357097461}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"a3a0e03b-e4c5-489f-bad9-f241578274e1","pid":17882,"acquiredAt":1776357097461}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ build
 
 # Claude Code
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 # 로컬 전용 커맨드 (원격 저장소에 포함하지 않음)
 .claude/commands/troubleshoot.md
 

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/controller/PartnershipLeadAdminController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/controller/PartnershipLeadAdminController.kt
@@ -9,6 +9,7 @@ import com.sclass.domain.domains.partnership.domain.PartnershipLeadStatus
 import jakarta.validation.Valid
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -27,7 +28,7 @@ class PartnershipLeadAdminController(
     @GetMapping
     fun list(
         @RequestParam(required = false) status: PartnershipLeadStatus?,
-        @PageableDefault(size = 20) pageable: Pageable,
+        @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
     ): ApiResponse<Page<PartnershipLeadDetailResponse>> = ApiResponse.success(getPartnershipLeadsUseCase.execute(status, pageable))
 
     @PatchMapping("/{id}/status")

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/controller/PartnershipLeadAdminController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/controller/PartnershipLeadAdminController.kt
@@ -1,0 +1,38 @@
+package com.sclass.backoffice.partnership.controller
+
+import com.sclass.backoffice.partnership.dto.PartnershipLeadDetailResponse
+import com.sclass.backoffice.partnership.dto.UpdatePartnershipLeadStatusRequest
+import com.sclass.backoffice.partnership.usecase.GetPartnershipLeadsUseCase
+import com.sclass.backoffice.partnership.usecase.UpdatePartnershipLeadStatusUseCase
+import com.sclass.common.dto.ApiResponse
+import com.sclass.domain.domains.partnership.domain.PartnershipLeadStatus
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/partnership-leads")
+class PartnershipLeadAdminController(
+    private val getPartnershipLeadsUseCase: GetPartnershipLeadsUseCase,
+    private val updatePartnershipLeadStatusUseCase: UpdatePartnershipLeadStatusUseCase,
+) {
+    @GetMapping
+    fun list(
+        @RequestParam(required = false) status: PartnershipLeadStatus?,
+        @PageableDefault(size = 20) pageable: Pageable,
+    ): ApiResponse<Page<PartnershipLeadDetailResponse>> = ApiResponse.success(getPartnershipLeadsUseCase.execute(status, pageable))
+
+    @PatchMapping("/{id}/status")
+    fun updateStatus(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdatePartnershipLeadStatusRequest,
+    ): ApiResponse<PartnershipLeadDetailResponse> = ApiResponse.success(updatePartnershipLeadStatusUseCase.execute(id, request))
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/dto/PartnershipLeadDetailResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/dto/PartnershipLeadDetailResponse.kt
@@ -1,0 +1,32 @@
+package com.sclass.backoffice.partnership.dto
+
+import com.sclass.domain.domains.partnership.domain.PartnershipLead
+import com.sclass.domain.domains.partnership.domain.PartnershipLeadStatus
+import java.time.LocalDateTime
+
+data class PartnershipLeadDetailResponse(
+    val id: Long,
+    val academyName: String,
+    val phone: String,
+    val email: String?,
+    val message: String?,
+    val status: PartnershipLeadStatus,
+    val note: String?,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun from(lead: PartnershipLead) =
+            PartnershipLeadDetailResponse(
+                id = lead.id,
+                academyName = lead.academyName,
+                phone = lead.phone,
+                email = lead.email,
+                message = lead.message,
+                status = lead.status,
+                note = lead.note,
+                createdAt = lead.createdAt,
+                updatedAt = lead.updatedAt,
+            )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/dto/UpdatePartnershipLeadStatusRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/dto/UpdatePartnershipLeadStatusRequest.kt
@@ -2,12 +2,9 @@ package com.sclass.backoffice.partnership.dto
 
 import com.sclass.domain.domains.partnership.domain.PartnershipLeadStatus
 import jakarta.validation.constraints.Size
-import software.amazon.awssdk.annotations.NotNull
 
 data class UpdatePartnershipLeadStatusRequest(
-    @field:NotNull
     val status: PartnershipLeadStatus,
-
     @field:Size(max = 2000)
     val note: String?,
 )

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/dto/UpdatePartnershipLeadStatusRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/dto/UpdatePartnershipLeadStatusRequest.kt
@@ -1,0 +1,13 @@
+package com.sclass.backoffice.partnership.dto
+
+import com.sclass.domain.domains.partnership.domain.PartnershipLeadStatus
+import jakarta.validation.constraints.Size
+import software.amazon.awssdk.annotations.NotNull
+
+data class UpdatePartnershipLeadStatusRequest(
+    @field:NotNull
+    val status: PartnershipLeadStatus,
+
+    @field:Size(max = 2000)
+    val note: String?,
+)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/usecase/GetPartnershipLeadsUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/usecase/GetPartnershipLeadsUseCase.kt
@@ -1,0 +1,28 @@
+package com.sclass.backoffice.partnership.usecase
+
+import com.sclass.backoffice.partnership.dto.PartnershipLeadDetailResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.partnership.adaptor.PartnershipLeadAdaptor
+import com.sclass.domain.domains.partnership.domain.PartnershipLeadStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetPartnershipLeadsUseCase(
+    private val partnershipLeadAdaptor: PartnershipLeadAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(
+        status: PartnershipLeadStatus?,
+        pageable: Pageable,
+    ): Page<PartnershipLeadDetailResponse> {
+        val page =
+            if (status == null) {
+                partnershipLeadAdaptor.findAll(pageable)
+            } else {
+                partnershipLeadAdaptor.findAllByStatus(status, pageable)
+            }
+        return page.map { PartnershipLeadDetailResponse.from(it) }
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/usecase/UpdatePartnershipLeadStatusUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/partnership/usecase/UpdatePartnershipLeadStatusUseCase.kt
@@ -1,0 +1,22 @@
+package com.sclass.backoffice.partnership.usecase
+
+import com.sclass.backoffice.partnership.dto.PartnershipLeadDetailResponse
+import com.sclass.backoffice.partnership.dto.UpdatePartnershipLeadStatusRequest
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.partnership.adaptor.PartnershipLeadAdaptor
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class UpdatePartnershipLeadStatusUseCase(
+    private val partnershipLeadAdaptor: PartnershipLeadAdaptor,
+) {
+    @Transactional
+    fun execute(
+        id: Long,
+        request: UpdatePartnershipLeadStatusRequest,
+    ): PartnershipLeadDetailResponse {
+        val lead = partnershipLeadAdaptor.findById(id)
+        lead.updateStatus(request.status, request.note)
+        return PartnershipLeadDetailResponse.from(lead)
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/partnership/usecase/GetPartnershipLeadsUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/partnership/usecase/GetPartnershipLeadsUseCaseTest.kt
@@ -1,0 +1,81 @@
+package com.sclass.backoffice.partnership.usecase
+
+import com.sclass.domain.domains.partnership.adaptor.PartnershipLeadAdaptor
+import com.sclass.domain.domains.partnership.domain.PartnershipLead
+import com.sclass.domain.domains.partnership.domain.PartnershipLeadStatus
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+
+class GetPartnershipLeadsUseCaseTest {
+    private lateinit var partnershipLeadAdaptor: PartnershipLeadAdaptor
+    private lateinit var useCase: GetPartnershipLeadsUseCase
+
+    @BeforeEach
+    fun setUp() {
+        partnershipLeadAdaptor = mockk()
+        useCase = GetPartnershipLeadsUseCase(partnershipLeadAdaptor)
+    }
+
+    private fun lead(
+        id: Long = 1L,
+        status: PartnershipLeadStatus = PartnershipLeadStatus.NEW,
+    ) = PartnershipLead(
+        id = id,
+        academyName = "서울학원",
+        phone = "01012345678",
+        email = null,
+        message = null,
+        status = status,
+    )
+
+    @Nested
+    inner class Execute {
+        @Test
+        fun `status가 null이면 전체 조회한다`() {
+            val page: Page<PartnershipLead> = PageImpl(listOf(lead(1L), lead(2L)))
+            every { partnershipLeadAdaptor.findAll(Pageable.unpaged()) } returns page
+
+            val result = useCase.execute(null, Pageable.unpaged())
+
+            assertEquals(2, result.content.size)
+            verify(exactly = 1) { partnershipLeadAdaptor.findAll(any()) }
+            verify(exactly = 0) { partnershipLeadAdaptor.findAllByStatus(any(), any()) }
+        }
+
+        @Test
+        fun `status가 주어지면 해당 상태로 필터해서 조회한다`() {
+            val page: Page<PartnershipLead> = PageImpl(listOf(lead(1L, PartnershipLeadStatus.CONTACTED)))
+            every {
+                partnershipLeadAdaptor.findAllByStatus(PartnershipLeadStatus.CONTACTED, Pageable.unpaged())
+            } returns page
+
+            val result = useCase.execute(PartnershipLeadStatus.CONTACTED, Pageable.unpaged())
+
+            assertEquals(1, result.content.size)
+            assertEquals(PartnershipLeadStatus.CONTACTED, result.content.first().status)
+            verify(exactly = 0) { partnershipLeadAdaptor.findAll(any()) }
+            verify(exactly = 1) { partnershipLeadAdaptor.findAllByStatus(PartnershipLeadStatus.CONTACTED, any()) }
+        }
+
+        @Test
+        fun `엔티티를 PartnershipLeadDetailResponse로 변환한다`() {
+            val entity = lead(42L)
+            every { partnershipLeadAdaptor.findAll(any()) } returns PageImpl(listOf(entity))
+
+            val result = useCase.execute(null, Pageable.unpaged())
+
+            val dto = result.content.first()
+            assertEquals(42L, dto.id)
+            assertEquals("서울학원", dto.academyName)
+            assertEquals("01012345678", dto.phone)
+        }
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/partnership/usecase/UpdatePartnershipLeadStatusUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/partnership/usecase/UpdatePartnershipLeadStatusUseCaseTest.kt
@@ -1,0 +1,99 @@
+package com.sclass.backoffice.partnership.usecase
+
+import com.sclass.backoffice.partnership.dto.UpdatePartnershipLeadStatusRequest
+import com.sclass.domain.domains.partnership.adaptor.PartnershipLeadAdaptor
+import com.sclass.domain.domains.partnership.domain.PartnershipLead
+import com.sclass.domain.domains.partnership.domain.PartnershipLeadStatus
+import com.sclass.domain.domains.partnership.exception.PartnershipLeadNotFoundException
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class UpdatePartnershipLeadStatusUseCaseTest {
+    private lateinit var partnershipLeadAdaptor: PartnershipLeadAdaptor
+    private lateinit var useCase: UpdatePartnershipLeadStatusUseCase
+
+    @BeforeEach
+    fun setUp() {
+        partnershipLeadAdaptor = mockk()
+        useCase = UpdatePartnershipLeadStatusUseCase(partnershipLeadAdaptor)
+    }
+
+    private fun lead() =
+        PartnershipLead(
+            id = 1L,
+            academyName = "서울학원",
+            phone = "01012345678",
+            email = null,
+            message = null,
+            status = PartnershipLeadStatus.NEW,
+        )
+
+    @Nested
+    inner class Success {
+        @Test
+        fun `status와 note를 함께 업데이트한다`() {
+            val lead = lead()
+            every { partnershipLeadAdaptor.findById(1L) } returns lead
+
+            val result =
+                useCase.execute(
+                    1L,
+                    UpdatePartnershipLeadStatusRequest(
+                        status = PartnershipLeadStatus.CONTACTED,
+                        note = "통화 완료",
+                    ),
+                )
+
+            assertAll(
+                { assertEquals(PartnershipLeadStatus.CONTACTED, result.status) },
+                { assertEquals("통화 완료", result.note) },
+                { assertEquals(PartnershipLeadStatus.CONTACTED, lead.status) },
+                { assertEquals("통화 완료", lead.note) },
+            )
+        }
+
+        @Test
+        fun `note가 null이면 status만 변경되고 기존 note는 유지된다`() {
+            val lead = lead().apply { updateStatus(PartnershipLeadStatus.CONTACTED, "기존 메모") }
+            every { partnershipLeadAdaptor.findById(1L) } returns lead
+
+            val result =
+                useCase.execute(
+                    1L,
+                    UpdatePartnershipLeadStatusRequest(
+                        status = PartnershipLeadStatus.COMPLETED,
+                        note = null,
+                    ),
+                )
+
+            assertAll(
+                { assertEquals(PartnershipLeadStatus.COMPLETED, result.status) },
+                { assertEquals("기존 메모", result.note) },
+            )
+        }
+    }
+
+    @Nested
+    inner class Failure {
+        @Test
+        fun `존재하지 않는 id면 PartnershipLeadNotFoundException을 던진다`() {
+            every { partnershipLeadAdaptor.findById(99L) } throws PartnershipLeadNotFoundException()
+
+            assertThrows<PartnershipLeadNotFoundException> {
+                useCase.execute(
+                    99L,
+                    UpdatePartnershipLeadStatusRequest(
+                        status = PartnershipLeadStatus.CONTACTED,
+                        note = null,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/config/WebConfig.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/config/WebConfig.kt
@@ -23,6 +23,7 @@ class WebConfig(
                 "/api/v1/oauth/**",
                 "/api/v1/auth/phone/**",
                 "/api/v1/payments/nicepay",
+                "/api/v1/partnership-leads",
             )
     }
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/partnership/controller/PartnershipLeadController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/partnership/controller/PartnershipLeadController.kt
@@ -1,0 +1,22 @@
+package com.sclass.supporters.partnership.controller
+
+import com.sclass.common.dto.ApiResponse
+import com.sclass.supporters.partnership.dto.CreatePartnershipLeadRequest
+import com.sclass.supporters.partnership.dto.PartnershipLeadResponse
+import com.sclass.supporters.partnership.usecase.CreatePartnershipLeadUseCase
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/partnership-leads")
+class PartnershipLeadController(
+    private val createPartnershipLeadUseCase: CreatePartnershipLeadUseCase,
+) {
+    @PostMapping
+    fun create(
+        @Valid @RequestBody request: CreatePartnershipLeadRequest,
+    ): ApiResponse<PartnershipLeadResponse> = ApiResponse.success(createPartnershipLeadUseCase.execute(request))
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/partnership/dto/CreatePartnershipLeadRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/partnership/dto/CreatePartnershipLeadRequest.kt
@@ -1,0 +1,23 @@
+package com.sclass.supporters.partnership.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+data class CreatePartnershipLeadRequest(
+    @field:NotBlank
+    @field:Size(max = 100)
+    val academyName: String,
+
+    @field:NotBlank
+    @field:Pattern(regexp = "^01[0-9]-?\\d{3,4}-?\\d{4}$", message = "유효한 휴대폰 번호 형식이 아닙니다")
+    val phone: String,
+
+    @field:Email
+    @field:Size(max = 255)
+    val email: String?,
+
+    @field:Size(max = 2000)
+    val message: String?,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/partnership/dto/PartnershipLeadResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/partnership/dto/PartnershipLeadResponse.kt
@@ -1,0 +1,5 @@
+package com.sclass.supporters.partnership.dto
+
+data class PartnershipLeadResponse(
+    val id: Long,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/partnership/usecase/CreatePartnershipLeadUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/partnership/usecase/CreatePartnershipLeadUseCase.kt
@@ -1,0 +1,32 @@
+package com.sclass.supporters.partnership.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.partnership.adaptor.PartnershipLeadAdaptor
+import com.sclass.domain.domains.partnership.domain.PartnershipLead
+import com.sclass.domain.domains.partnership.exception.PartnershipLeadAlreadyExistsException
+import com.sclass.supporters.partnership.dto.CreatePartnershipLeadRequest
+import com.sclass.supporters.partnership.dto.PartnershipLeadResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class CreatePartnershipLeadUseCase(
+    private val partnershipLeadAdaptor: PartnershipLeadAdaptor,
+) {
+    @Transactional
+    fun execute(request: CreatePartnershipLeadRequest): PartnershipLeadResponse {
+        val normalizedPhone = request.phone.replace("-", "")
+        if (partnershipLeadAdaptor.existsByPhone(normalizedPhone)) {
+            throw PartnershipLeadAlreadyExistsException()
+        }
+        val lead =
+            partnershipLeadAdaptor.save(
+                PartnershipLead(
+                    academyName = request.academyName,
+                    phone = normalizedPhone,
+                    email = request.email,
+                    message = request.message,
+                ),
+            )
+        return PartnershipLeadResponse(id = lead.id)
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/partnership/usecase/CreatePartnershipLeadUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/partnership/usecase/CreatePartnershipLeadUseCaseTest.kt
@@ -1,0 +1,98 @@
+package com.sclass.supporters.partnership.usecase
+
+import com.sclass.domain.domains.partnership.adaptor.PartnershipLeadAdaptor
+import com.sclass.domain.domains.partnership.domain.PartnershipLead
+import com.sclass.domain.domains.partnership.exception.PartnershipLeadAlreadyExistsException
+import com.sclass.supporters.partnership.dto.CreatePartnershipLeadRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CreatePartnershipLeadUseCaseTest {
+    private lateinit var partnershipLeadAdaptor: PartnershipLeadAdaptor
+    private lateinit var useCase: CreatePartnershipLeadUseCase
+
+    @BeforeEach
+    fun setUp() {
+        partnershipLeadAdaptor = mockk()
+        useCase = CreatePartnershipLeadUseCase(partnershipLeadAdaptor)
+    }
+
+    private fun request(
+        phone: String = "010-1234-5678",
+        email: String? = "foo@example.com",
+        message: String? = "도입 문의",
+    ) = CreatePartnershipLeadRequest(
+        academyName = "서울학원",
+        phone = phone,
+        email = email,
+        message = message,
+    )
+
+    @Nested
+    inner class Success {
+        @Test
+        fun `하이픈이 포함된 전화번호는 하이픈을 제거하고 저장한다`() {
+            val savedSlot = slot<PartnershipLead>()
+            every { partnershipLeadAdaptor.existsByPhone("01012345678") } returns false
+            every { partnershipLeadAdaptor.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+            useCase.execute(request(phone = "010-1234-5678"))
+
+            verify { partnershipLeadAdaptor.existsByPhone("01012345678") }
+            assertEquals("01012345678", savedSlot.captured.phone)
+        }
+
+        @Test
+        fun `저장된 엔티티의 id를 응답으로 반환한다`() {
+            val lead =
+                PartnershipLead(
+                    id = 42L,
+                    academyName = "서울학원",
+                    phone = "01012345678",
+                    email = "foo@example.com",
+                    message = "도입 문의",
+                )
+            every { partnershipLeadAdaptor.existsByPhone(any()) } returns false
+            every { partnershipLeadAdaptor.save(any()) } returns lead
+
+            val result = useCase.execute(request())
+
+            assertEquals(42L, result.id)
+        }
+
+        @Test
+        fun `email과 message는 null 가능하다`() {
+            val savedSlot = slot<PartnershipLead>()
+            every { partnershipLeadAdaptor.existsByPhone(any()) } returns false
+            every { partnershipLeadAdaptor.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+            useCase.execute(request(email = null, message = null))
+
+            assertAll(
+                { assertEquals(null, savedSlot.captured.email) },
+                { assertEquals(null, savedSlot.captured.message) },
+            )
+        }
+    }
+
+    @Nested
+    inner class Failure {
+        @Test
+        fun `이미 접수된 번호면 PartnershipLeadAlreadyExistsException을 던진다`() {
+            every { partnershipLeadAdaptor.existsByPhone("01012345678") } returns true
+
+            assertThrows<PartnershipLeadAlreadyExistsException> {
+                useCase.execute(request(phone = "010-1234-5678"))
+            }
+            verify(exactly = 0) { partnershipLeadAdaptor.save(any()) }
+        }
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/adaptor/PartnershipLeadAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/adaptor/PartnershipLeadAdaptor.kt
@@ -1,0 +1,27 @@
+package com.sclass.domain.domains.partnership.adaptor
+
+import com.sclass.common.annotation.Adaptor
+import com.sclass.domain.domains.partnership.domain.PartnershipLead
+import com.sclass.domain.domains.partnership.domain.PartnershipLeadStatus
+import com.sclass.domain.domains.partnership.exception.PartnershipLeadNotFoundException
+import com.sclass.domain.domains.partnership.repository.PartnershipLeadRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+@Adaptor
+class PartnershipLeadAdaptor(
+    private val partnershipLeadRepository: PartnershipLeadRepository,
+) {
+    fun findById(id: Long): PartnershipLead = partnershipLeadRepository.findById(id).orElseThrow { PartnershipLeadNotFoundException() }
+
+    fun existsByPhone(phone: String): Boolean = partnershipLeadRepository.existsByPhone(phone)
+
+    fun findAll(pageable: Pageable): Page<PartnershipLead> = partnershipLeadRepository.findAll(pageable)
+
+    fun findAllByStatus(
+        status: PartnershipLeadStatus,
+        pageable: Pageable,
+    ): Page<PartnershipLead> = partnershipLeadRepository.findAllByStatus(status, pageable)
+
+    fun save(lead: PartnershipLead): PartnershipLead = partnershipLeadRepository.save(lead)
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/domain/PartnershipLead.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/domain/PartnershipLead.kt
@@ -1,0 +1,57 @@
+package com.sclass.domain.domains.partnership.domain
+
+import com.sclass.domain.common.model.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "partnership_leads",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_partnership_leads_phone", columnNames = ["phone"]),
+    ],
+    indexes = [
+        Index(name = "idx_partnership_leads_status", columnList = "status"),
+        Index(name = "idx_partnership_leads_created_at", columnList = "created_at"),
+    ],
+)
+class PartnershipLead(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(nullable = false, length = 100)
+    val academyName: String,
+
+    @Column(nullable = false, length = 20)
+    val phone: String,
+
+    @Column(length = 255)
+    val email: String?,
+
+    @Column(columnDefinition = "TEXT")
+    val message: String?,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: PartnershipLeadStatus = PartnershipLeadStatus.NEW,
+
+    @Column(columnDefinition = "TEXT")
+    var note: String? = null,
+) : BaseTimeEntity() {
+    fun updateStatus(
+        status: PartnershipLeadStatus,
+        note: String?,
+    ) {
+        this.status = status
+        if (note != null) this.note = note
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/domain/PartnershipLeadStatus.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/domain/PartnershipLeadStatus.kt
@@ -1,0 +1,8 @@
+package com.sclass.domain.domains.partnership.domain
+
+enum class PartnershipLeadStatus {
+    NEW,
+    CONTACTED,
+    COMPLETED,
+    REJECTED,
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/exception/PartnershipLeadAlreadyExistsException.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/exception/PartnershipLeadAlreadyExistsException.kt
@@ -1,0 +1,5 @@
+package com.sclass.domain.domains.partnership.exception
+
+import com.sclass.common.exception.BusinessException
+
+class PartnershipLeadAlreadyExistsException : BusinessException(PartnershipLeadErrorCode.PARTNERSHIP_LEAD_ALREADY_EXISTS)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/exception/PartnershipLeadErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/exception/PartnershipLeadErrorCode.kt
@@ -1,0 +1,12 @@
+package com.sclass.domain.domains.partnership.exception
+
+import com.sclass.common.exception.ErrorCode
+
+enum class PartnershipLeadErrorCode(
+    override val code: String,
+    override val message: String,
+    override val httpStatus: Int,
+) : ErrorCode {
+    PARTNERSHIP_LEAD_NOT_FOUND("PARTNERSHIP_001", "파트너십 문의를 찾을 수 없습니다", 404),
+    PARTNERSHIP_LEAD_ALREADY_EXISTS("PARTNERSHIP_002", "이미 접수된 연락처입니다. 곧 연락드리겠습니다", 409),
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/exception/PartnershipLeadNotFoundException.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/exception/PartnershipLeadNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.sclass.domain.domains.partnership.exception
+
+import com.sclass.common.exception.BusinessException
+
+class PartnershipLeadNotFoundException : BusinessException(PartnershipLeadErrorCode.PARTNERSHIP_LEAD_NOT_FOUND)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/repository/PartnershipLeadRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/partnership/repository/PartnershipLeadRepository.kt
@@ -1,0 +1,16 @@
+package com.sclass.domain.domains.partnership.repository
+
+import com.sclass.domain.domains.partnership.domain.PartnershipLead
+import com.sclass.domain.domains.partnership.domain.PartnershipLeadStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PartnershipLeadRepository : JpaRepository<PartnershipLead, Long> {
+    fun existsByPhone(phone: String): Boolean
+
+    fun findAllByStatus(
+        status: PartnershipLeadStatus,
+        pageable: Pageable,
+    ): Page<PartnershipLead>
+}

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/partnership/adaptor/PartnershipLeadAdaptorTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/partnership/adaptor/PartnershipLeadAdaptorTest.kt
@@ -1,0 +1,79 @@
+package com.sclass.domain.domains.partnership.adaptor
+
+import com.sclass.domain.domains.partnership.domain.PartnershipLead
+import com.sclass.domain.domains.partnership.domain.PartnershipLeadStatus
+import com.sclass.domain.domains.partnership.exception.PartnershipLeadNotFoundException
+import com.sclass.domain.domains.partnership.repository.PartnershipLeadRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import java.util.Optional
+
+class PartnershipLeadAdaptorTest {
+    private lateinit var repository: PartnershipLeadRepository
+    private lateinit var adaptor: PartnershipLeadAdaptor
+
+    @BeforeEach
+    fun setUp() {
+        repository = mockk()
+        adaptor = PartnershipLeadAdaptor(repository)
+    }
+
+    @Nested
+    inner class FindById {
+        @Test
+        fun `존재하는 id는 엔티티를 반환한다`() {
+            val lead = mockk<PartnershipLead>()
+            every { repository.findById(1L) } returns Optional.of(lead)
+
+            assertEquals(lead, adaptor.findById(1L))
+        }
+
+        @Test
+        fun `존재하지 않는 id는 PartnershipLeadNotFoundException을 던진다`() {
+            every { repository.findById(99L) } returns Optional.empty()
+
+            assertThrows<PartnershipLeadNotFoundException> { adaptor.findById(99L) }
+        }
+    }
+
+    @Nested
+    inner class ExistsByPhone {
+        @Test
+        fun `저장된 번호면 true를 반환한다`() {
+            every { repository.existsByPhone("01012345678") } returns true
+
+            assertTrue(adaptor.existsByPhone("01012345678"))
+        }
+
+        @Test
+        fun `저장되지 않은 번호면 false를 반환한다`() {
+            every { repository.existsByPhone("01099999999") } returns false
+
+            assertFalse(adaptor.existsByPhone("01099999999"))
+        }
+    }
+
+    @Nested
+    inner class FindAllByStatus {
+        @Test
+        fun `status로 필터한 Page를 반환한다`() {
+            val leads = listOf(mockk<PartnershipLead>(), mockk())
+            val page: Page<PartnershipLead> = PageImpl(leads)
+            every { repository.findAllByStatus(PartnershipLeadStatus.NEW, Pageable.unpaged()) } returns page
+
+            val result = adaptor.findAllByStatus(PartnershipLeadStatus.NEW, Pageable.unpaged())
+
+            assertEquals(2, result.content.size)
+        }
+    }
+}

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/partnership/domain/PartnershipLeadTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/partnership/domain/PartnershipLeadTest.kt
@@ -1,0 +1,60 @@
+package com.sclass.domain.domains.partnership.domain
+
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PartnershipLeadTest {
+    private fun lead(
+        status: PartnershipLeadStatus = PartnershipLeadStatus.NEW,
+        note: String? = null,
+    ) = PartnershipLead(
+        academyName = "서울학원",
+        phone = "01012345678",
+        email = "foo@example.com",
+        message = "도입 문의드립니다",
+        status = status,
+        note = note,
+    )
+
+    @Nested
+    inner class UpdateStatus {
+        @Test
+        fun `status를 변경하고 note를 함께 업데이트한다`() {
+            val lead = lead()
+
+            lead.updateStatus(PartnershipLeadStatus.CONTACTED, "2026-04-17 10:00 통화 완료")
+
+            assertAll(
+                { assertEquals(PartnershipLeadStatus.CONTACTED, lead.status) },
+                { assertEquals("2026-04-17 10:00 통화 완료", lead.note) },
+            )
+        }
+
+        @Test
+        fun `note가 null이면 기존 note는 유지된다`() {
+            val lead = lead(note = "기존 메모")
+
+            lead.updateStatus(PartnershipLeadStatus.COMPLETED, null)
+
+            assertAll(
+                { assertEquals(PartnershipLeadStatus.COMPLETED, lead.status) },
+                { assertEquals("기존 메모", lead.note) },
+            )
+        }
+
+        @Test
+        fun `note가 null이고 기존 note도 null이면 null을 유지한다`() {
+            val lead = lead()
+
+            lead.updateStatus(PartnershipLeadStatus.REJECTED, null)
+
+            assertAll(
+                { assertEquals(PartnershipLeadStatus.REJECTED, lead.status) },
+                { assertNull(lead.note) },
+            )
+        }
+    }
+}

--- a/infra/env/envs/prod.tfvars
+++ b/infra/env/envs/prod.tfvars
@@ -21,7 +21,7 @@ services = {
   }
 }
 
-cors_allow_origins    = "https://aura.co.kr,https://app.aura.co.kr,https://lms.aura.co.kr,https://backoffice.aura.co.kr,https://sclass.aura.co.kr"
+cors_allow_origins    = "https://aura.co.kr,https://app.aura.co.kr,https://lms.aura.co.kr,https://backoffice.aura.co.kr,https://sclass.aura.co.kr,https://academy.aura.co.kr"
 alimtalk_app_base_url = "https://sclass.aura.co.kr"
 frontend_url          = "https://sclass.aura.co.kr"
 report_service_base_url          = "https://report-service-452628026107.asia-northeast3.run.app"


### PR DESCRIPTION
## Summary
- 랜딩페이지 제휴문의 폼 수신용 `PartnershipLead` 도메인 추가 (Long id, phone UNIQUE, status 인덱스)
- Supporters 공개 POST API `/api/v1/partnership-leads` — 전화번호 하이픈 정규화, 중복 체크 (JWT 인터셉터 제외)
- Backoffice 관리 API — 목록 조회(status 필터 + 페이지네이션) + 상태/메모 업데이트
- prod CORS origin에 `https://academy.aura.co.kr` 추가 (terraform 로컬 apply + ECS 강제 재배포 완료)

## Test plan
- [x] `PartnershipLeadTest` — updateStatus 동작 (note null 유지 포함)
- [x] `PartnershipLeadAdaptorTest` — findById / existsByPhone / findAllByStatus
- [x] `CreatePartnershipLeadUseCaseTest` — 하이픈 제거, 중복 예외, null email/message
- [x] `GetPartnershipLeadsUseCaseTest` — status 필터 분기, DTO 변환
- [x] `UpdatePartnershipLeadStatusUseCaseTest` — status/note 업데이트, note null 유지, NotFound
- [x] ktlintFormat 통과
- [x] 전체 빌드 + 테스트 통과 (18 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)