### PR TITLE
fix(ci): dev EC2(Graviton) 대응 — CD에서 linux/arm64 이미지 빌드

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -140,20 +140,34 @@ jobs:
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve build platform
+        id: platform
+        run: |
+          if [[ "${{ needs.setup.outputs.env }}" == "dev" ]]; then
+            echo "platform=linux/arm64" >> "$GITHUB_OUTPUT"
+          else
+            echo "platform=linux/amd64" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push Docker image
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           ECR_REPOSITORY: sclass-${{ needs.setup.outputs.env }}-${{ matrix.target.service }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build \
+          docker buildx build \
+            --platform ${{ steps.platform.outputs.platform }} \
             --build-arg MODULE=${{ matrix.target.module }} \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            --push \
             .
-
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
       # ── Prod: ECS force new deployment ──
       - name: Deploy to ECS (prod)


### PR DESCRIPTION
## Summary
- 서울 이전(2026-04-16)으로 dev EC2가 aarch64 Graviton으로 바뀌었는데, CD는 계속 amd64 이미지를 빌드해 컨테이너가 `exec format error`로 재시작 루프에 빠짐
- `docker buildx` + QEMU 셋업을 추가하고, `needs.setup.outputs.env` 기준으로 platform을 분기 (dev=arm64, prod=amd64)
- `--push` 플래그로 빌드/푸시 단계 단일화

## 증상 (before)
```
docker logs backoffice-api
  exec /opt/java/openjdk/bin/java: exec format error
  ...
docker ps
  backoffice-api   Restarting (255) ...
  supporters-api   Restarting (255) ...
```
- EC2: `uname -m` → `aarch64`
- 이미지: `docker image inspect ...` → `amd64/linux`

## 영향 범위
- dev: 배포되는 이미지가 arm64로 변경 → 정상 기동
- prod: 기존과 동일 (amd64, ECS Fargate x86_64 task definition)

## Test plan
- [ ] PR 머지 후 develop CD가 green으로 끝나는지 확인
- [ ] SSM으로 dev EC2 접속 → `docker ps`에서 supporters-api/backoffice-api가 `Up` 상태인지 확인
- [ ] `curl https://supporters-api.dev.sclass.click/actuator/health` → 200
- [ ] `curl https://backoffice-api.dev.sclass.click/actuator/health` → 200
- [ ] prod는 영향 없음 확인 (다음 main CD 성공)

🤖 Generated with [Claude Code](https://claude.com/claude-code)