### PR TITLE
refactor(backoffice): 어드민 카탈로그 토글 API 정리

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coinpackage/controller/CoinPackageController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coinpackage/controller/CoinPackageController.kt
@@ -3,9 +3,10 @@ package com.sclass.backoffice.coinpackage.controller
 import com.sclass.backoffice.coinpackage.dto.CoinPackageListResponse
 import com.sclass.backoffice.coinpackage.dto.CoinPackageResponse
 import com.sclass.backoffice.coinpackage.dto.CreateCoinPackageRequest
+import com.sclass.backoffice.coinpackage.dto.UpdateCoinPackageActiveRequest
 import com.sclass.backoffice.coinpackage.usecase.CreateCoinPackageUseCase
-import com.sclass.backoffice.coinpackage.usecase.DeactivateCoinPackageUseCase
 import com.sclass.backoffice.coinpackage.usecase.GetAdminCoinPackageListUseCase
+import com.sclass.backoffice.coinpackage.usecase.UpdateCoinPackageActiveUseCase
 import com.sclass.common.dto.ApiResponse
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController
 class CoinPackageController(
     private val createCoinPackageUseCase: CreateCoinPackageUseCase,
     private val getAdminCoinPackageListUseCase: GetAdminCoinPackageListUseCase,
-    private val deactivateCoinPackageUseCase: DeactivateCoinPackageUseCase,
+    private val updateCoinPackageActiveUseCase: UpdateCoinPackageActiveUseCase,
 ) {
     @GetMapping
     fun getCoinPackages(): ApiResponse<CoinPackageListResponse> = ApiResponse.success(getAdminCoinPackageListUseCase.execute())
@@ -31,11 +32,12 @@ class CoinPackageController(
         @RequestBody @Valid request: CreateCoinPackageRequest,
     ): ApiResponse<CoinPackageResponse> = ApiResponse.success(createCoinPackageUseCase.execute(request))
 
-    @PatchMapping("/{id}/deactivate")
-    fun deactivate(
+    @PatchMapping("/{id}")
+    fun updateActive(
         @PathVariable id: String,
+        @RequestBody @Valid request: UpdateCoinPackageActiveRequest,
     ): ApiResponse<Unit> {
-        deactivateCoinPackageUseCase.execute(id)
+        updateCoinPackageActiveUseCase.execute(id, request.active)
         return ApiResponse.success(Unit)
     }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coinpackage/dto/UpdateCoinPackageActiveRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coinpackage/dto/UpdateCoinPackageActiveRequest.kt
@@ -1,0 +1,7 @@
+package com.sclass.backoffice.coinpackage.dto
+
+import jakarta.validation.constraints.NotNull
+
+data class UpdateCoinPackageActiveRequest(
+    @field:NotNull val active: Boolean,
+)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coinpackage/usecase/UpdateCoinPackageActiveUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coinpackage/usecase/UpdateCoinPackageActiveUseCase.kt
@@ -5,12 +5,15 @@ import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-class DeactivateCoinPackageUseCase(
+class UpdateCoinPackageActiveUseCase(
     private val coinPackageAdaptor: CoinPackageAdaptor,
 ) {
     @Transactional
-    fun execute(id: String) {
+    fun execute(
+        id: String,
+        active: Boolean,
+    ) {
         val coinPackage = coinPackageAdaptor.findById(id)
-        coinPackage.active = false
+        coinPackage.active = active
     }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commissionpolicy/controller/CommissionPolicyController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commissionpolicy/controller/CommissionPolicyController.kt
@@ -1,10 +1,17 @@
 package com.sclass.backoffice.commissionpolicy.controller
 
+import com.sclass.backoffice.commissionpolicy.dto.CommissionPolicyListResponse
 import com.sclass.backoffice.commissionpolicy.dto.CommissionPolicyResponse
 import com.sclass.backoffice.commissionpolicy.dto.CreateCommissionPolicyRequest
+import com.sclass.backoffice.commissionpolicy.dto.UpdateCommissionPolicyActiveRequest
 import com.sclass.backoffice.commissionpolicy.usecase.CreateCommissionPolicyUseCase
+import com.sclass.backoffice.commissionpolicy.usecase.GetAdminCommissionPolicyListUseCase
+import com.sclass.backoffice.commissionpolicy.usecase.UpdateCommissionPolicyActiveUseCase
 import com.sclass.common.dto.ApiResponse
 import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,9 +21,24 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/commission-policies")
 class CommissionPolicyController(
     private val createCommissionPolicyUseCase: CreateCommissionPolicyUseCase,
+    private val getAdminCommissionPolicyListUseCase: GetAdminCommissionPolicyListUseCase,
+    private val updateCommissionPolicyActiveUseCase: UpdateCommissionPolicyActiveUseCase,
 ) {
+    @GetMapping
+    fun getCommissionPolicies(): ApiResponse<CommissionPolicyListResponse> =
+        ApiResponse.success(getAdminCommissionPolicyListUseCase.execute())
+
     @PostMapping
     fun createCommissionPolicy(
         @RequestBody @Valid request: CreateCommissionPolicyRequest,
     ): ApiResponse<CommissionPolicyResponse> = ApiResponse.success(createCommissionPolicyUseCase.execute(request))
+
+    @PatchMapping("/{id}")
+    fun updateActive(
+        @PathVariable id: String,
+        @RequestBody @Valid request: UpdateCommissionPolicyActiveRequest,
+    ): ApiResponse<Unit> {
+        updateCommissionPolicyActiveUseCase.execute(id, request.active)
+        return ApiResponse.success(Unit)
+    }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commissionpolicy/dto/CommissionPolicyListResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commissionpolicy/dto/CommissionPolicyListResponse.kt
@@ -1,0 +1,11 @@
+package com.sclass.backoffice.commissionpolicy.dto
+
+import com.sclass.domain.domains.commission.domain.CommissionPolicy
+
+data class CommissionPolicyListResponse(
+    val commissionPolicies: List<CommissionPolicyResponse>,
+) {
+    companion object {
+        fun from(policies: List<CommissionPolicy>) = CommissionPolicyListResponse(policies.map { CommissionPolicyResponse.from(it) })
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commissionpolicy/dto/UpdateCommissionPolicyActiveRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commissionpolicy/dto/UpdateCommissionPolicyActiveRequest.kt
@@ -1,0 +1,7 @@
+package com.sclass.backoffice.commissionpolicy.dto
+
+import jakarta.validation.constraints.NotNull
+
+data class UpdateCommissionPolicyActiveRequest(
+    @field:NotNull val active: Boolean,
+)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commissionpolicy/usecase/GetAdminCommissionPolicyListUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commissionpolicy/usecase/GetAdminCommissionPolicyListUseCase.kt
@@ -1,0 +1,14 @@
+package com.sclass.backoffice.commissionpolicy.usecase
+
+import com.sclass.backoffice.commissionpolicy.dto.CommissionPolicyListResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.commission.adaptor.CommissionPolicyAdaptor
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetAdminCommissionPolicyListUseCase(
+    private val commissionPolicyAdaptor: CommissionPolicyAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(): CommissionPolicyListResponse = CommissionPolicyListResponse.from(commissionPolicyAdaptor.findAll())
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commissionpolicy/usecase/UpdateCommissionPolicyActiveUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commissionpolicy/usecase/UpdateCommissionPolicyActiveUseCase.kt
@@ -1,0 +1,19 @@
+package com.sclass.backoffice.commissionpolicy.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.commission.adaptor.CommissionPolicyAdaptor
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class UpdateCommissionPolicyActiveUseCase(
+    private val commissionPolicyAdaptor: CommissionPolicyAdaptor,
+) {
+    @Transactional
+    fun execute(
+        id: String,
+        active: Boolean,
+    ) {
+        val policy = commissionPolicyAdaptor.findById(id)
+        policy.active = active
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/coinpackage/usecase/UpdateCoinPackageActiveUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/coinpackage/usecase/UpdateCoinPackageActiveUseCaseTest.kt
@@ -1,0 +1,57 @@
+package com.sclass.backoffice.coinpackage.usecase
+
+import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.coin.domain.CoinPackage
+import com.sclass.domain.domains.coin.exception.CoinPackageNotFoundException
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class UpdateCoinPackageActiveUseCaseTest {
+    private val coinPackageAdaptor = mockk<CoinPackageAdaptor>()
+    private val useCase = UpdateCoinPackageActiveUseCase(coinPackageAdaptor)
+
+    private fun coinPackage(active: Boolean) =
+        CoinPackage(
+            name = "10,000 코인",
+            priceWon = 10_000,
+            coinAmount = 10_000,
+            active = active,
+        )
+
+    @Nested
+    inner class Execute {
+        @Test
+        fun `active=false 로 호출하면 패키지를 비활성화한다`() {
+            val target = coinPackage(active = true)
+            every { coinPackageAdaptor.findById(target.id) } returns target
+
+            useCase.execute(target.id, active = false)
+
+            assertFalse(target.active)
+        }
+
+        @Test
+        fun `active=true 로 호출하면 비활성 패키지를 다시 활성화한다`() {
+            val target = coinPackage(active = false)
+            every { coinPackageAdaptor.findById(target.id) } returns target
+
+            useCase.execute(target.id, active = true)
+
+            assertTrue(target.active)
+        }
+
+        @Test
+        fun `존재하지 않는 패키지면 CoinPackageNotFoundException 을 던진다`() {
+            every { coinPackageAdaptor.findById(any()) } throws CoinPackageNotFoundException()
+
+            assertThrows(CoinPackageNotFoundException::class.java) {
+                useCase.execute("non-existent-id", active = false)
+            }
+        }
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/commissionpolicy/usecase/GetAdminCommissionPolicyListUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/commissionpolicy/usecase/GetAdminCommissionPolicyListUseCaseTest.kt
@@ -1,0 +1,43 @@
+package com.sclass.backoffice.commissionpolicy.usecase
+
+import com.sclass.domain.domains.commission.adaptor.CommissionPolicyAdaptor
+import com.sclass.domain.domains.commission.domain.CommissionPolicy
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class GetAdminCommissionPolicyListUseCaseTest {
+    private val commissionPolicyAdaptor = mockk<CommissionPolicyAdaptor>()
+    private val useCase = GetAdminCommissionPolicyListUseCase(commissionPolicyAdaptor)
+
+    @Nested
+    inner class Execute {
+        @Test
+        fun `활성, 비활성 정책을 모두 포함해 반환한다`() {
+            val active = CommissionPolicy(name = "현재 정책", coinCost = 100, active = true)
+            val inactive = CommissionPolicy(name = "이전 정책", coinCost = 80, active = false)
+            every { commissionPolicyAdaptor.findAll() } returns listOf(active, inactive)
+
+            val result = useCase.execute()
+
+            assertAll(
+                { assertEquals(2, result.commissionPolicies.size) },
+                { assertTrue(result.commissionPolicies.any { it.id == active.id && it.active }) },
+                { assertTrue(result.commissionPolicies.any { it.id == inactive.id && !it.active }) },
+            )
+        }
+
+        @Test
+        fun `정책이 없으면 빈 목록을 반환한다`() {
+            every { commissionPolicyAdaptor.findAll() } returns emptyList()
+
+            val result = useCase.execute()
+
+            assertEquals(0, result.commissionPolicies.size)
+        }
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/commissionpolicy/usecase/UpdateCommissionPolicyActiveUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/commissionpolicy/usecase/UpdateCommissionPolicyActiveUseCaseTest.kt
@@ -1,0 +1,56 @@
+package com.sclass.backoffice.commissionpolicy.usecase
+
+import com.sclass.domain.domains.commission.adaptor.CommissionPolicyAdaptor
+import com.sclass.domain.domains.commission.domain.CommissionPolicy
+import com.sclass.domain.domains.commission.exception.CommissionPolicyNotFoundException
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class UpdateCommissionPolicyActiveUseCaseTest {
+    private val commissionPolicyAdaptor = mockk<CommissionPolicyAdaptor>()
+    private val useCase = UpdateCommissionPolicyActiveUseCase(commissionPolicyAdaptor)
+
+    private fun policy(active: Boolean) =
+        CommissionPolicy(
+            name = "기본 의뢰 정책",
+            coinCost = 100,
+            active = active,
+        )
+
+    @Nested
+    inner class Execute {
+        @Test
+        fun `active=false 로 호출하면 정책을 비활성화한다`() {
+            val target = policy(active = true)
+            every { commissionPolicyAdaptor.findById(target.id) } returns target
+
+            useCase.execute(target.id, active = false)
+
+            assertFalse(target.active)
+        }
+
+        @Test
+        fun `active=true 로 호출하면 비활성 정책을 다시 활성화한다`() {
+            val target = policy(active = false)
+            every { commissionPolicyAdaptor.findById(target.id) } returns target
+
+            useCase.execute(target.id, active = true)
+
+            assertTrue(target.active)
+        }
+
+        @Test
+        fun `존재하지 않는 정책이면 CommissionPolicyNotFoundException 을 던진다`() {
+            every { commissionPolicyAdaptor.findById(any()) } throws CommissionPolicyNotFoundException()
+
+            assertThrows(CommissionPolicyNotFoundException::class.java) {
+                useCase.execute("non-existent-id", active = false)
+            }
+        }
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/adaptor/CommissionPolicyAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/adaptor/CommissionPolicyAdaptor.kt
@@ -3,17 +3,22 @@ package com.sclass.domain.domains.commission.adaptor
 import com.sclass.common.annotation.Adaptor
 import com.sclass.domain.domains.commission.domain.CommissionPolicy
 import com.sclass.domain.domains.commission.exception.CommissionPolicyNotConfiguredException
+import com.sclass.domain.domains.commission.exception.CommissionPolicyNotFoundException
 import com.sclass.domain.domains.commission.repository.CommissionPolicyRepository
 
 @Adaptor
 class CommissionPolicyAdaptor(
     private val commissionPolicyRepository: CommissionPolicyRepository,
 ) {
+    fun findById(id: String): CommissionPolicy = commissionPolicyRepository.findById(id).orElseThrow { CommissionPolicyNotFoundException() }
+
     fun findActive(): CommissionPolicy =
         commissionPolicyRepository.findFirstByActiveTrueOrderByCreatedAtDesc()
             ?: throw CommissionPolicyNotConfiguredException()
 
     fun findActiveOrNull(): CommissionPolicy? = commissionPolicyRepository.findFirstByActiveTrueOrderByCreatedAtDesc()
+
+    fun findAll(): List<CommissionPolicy> = commissionPolicyRepository.findAll()
 
     fun save(policy: CommissionPolicy): CommissionPolicy = commissionPolicyRepository.save(policy)
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/exception/CommissionErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/exception/CommissionErrorCode.kt
@@ -13,4 +13,5 @@ enum class CommissionErrorCode(
     COMMISSION_TOPIC_NOT_FOUND("COMMISSION_004", "추천 주제를 찾을 수 없습니다", 404),
     SUPPORT_TICKET_NOT_FOUND("COMMISSION_005", "지원 티켓을 찾을 수 없습니다", 404),
     COMMISSION_POLICY_NOT_CONFIGURED("COMMISSION_006", "활성화된 의뢰 정책이 없습니다", 500),
+    COMMISSION_POLICY_NOT_FOUND("COMMISSION_007", "의뢰 정책을 찾을 수 없습니다", 404),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/exception/CommissionPolicyNotFoundException.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/exception/CommissionPolicyNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.sclass.domain.domains.commission.exception
+
+import com.sclass.common.exception.BusinessException
+
+class CommissionPolicyNotFoundException : BusinessException(CommissionErrorCode.COMMISSION_POLICY_NOT_FOUND)


### PR DESCRIPTION
## Summary
- `GET /api/v1/commission-policies` 어드민 목록 조회 추가 (활성/비활성 모두)
- `/{id}/deactivate` 분리 엔드포인트 → `PATCH /{id}` body `{ "active": true|false }` 단일 엔드포인트로 통합
  - `coin-packages`, `commission-policies` 모두 동일 패턴
- `CommissionPolicyAdaptor`: `findById` / `findAll` 추가, `CommissionPolicyNotFoundException` 신규

## Why
PR #236 후속. 어드민 화면에서 commission policy 를 조회할 수단이 없어서 `GET /api/v1/commission-policies` 요청 시 `Method Not Supported` 발생. 더불어 coin-package 쪽의 `/deactivate` 전용 엔드포인트도 `active` 토글이 필요할 때 대칭되는 `/activate` 를 만들기보다 단일 PATCH body 로 통합하는 편이 RESTful 하고 FE 호출도 단순해져 함께 정리.

## API 변경사항 (FE)
| Before | After |
|---|---|
| `PATCH /api/v1/coin-packages/{id}/deactivate` | `PATCH /api/v1/coin-packages/{id}` body `{ "active": false }` |
| (없음) | `PATCH /api/v1/coin-packages/{id}` body `{ "active": true }` — 재활성화 |
| (없음) | `GET  /api/v1/commission-policies` — 어드민 목록 |
| (없음) | `PATCH /api/v1/commission-policies/{id}` body `{ "active": true|false }` |

## Test plan
- [x] `./gradlew ktlintFormat`
- [x] `UpdateCoinPackageActiveUseCaseTest` / `UpdateCommissionPolicyActiveUseCaseTest` / `GetAdminCommissionPolicyListUseCaseTest` 추가 및 통과
- [ ] FE 측 어드민 화면에서 엔드포인트 변경 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)