### PR TITLE
feat(backoffice): 코스 목록 응답에 priceWon 추가

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/CoursePageResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/CoursePageResponse.kt
@@ -22,6 +22,7 @@ data class CourseListResponse(
     val status: CourseStatus,
     val enrollmentCount: Long,
     val totalLessons: Int,
+    val priceWon: Int,
     val createdAt: LocalDateTime,
 ) {
     companion object {
@@ -37,6 +38,7 @@ data class CourseListResponse(
                 status = dto.course.status,
                 enrollmentCount = dto.enrollmentCount,
                 totalLessons = dto.courseProduct?.totalLessons ?: 0,
+                priceWon = dto.courseProduct?.priceWon ?: 0,
                 createdAt = dto.course.createdAt,
             )
     }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/course/usecase/GetCourseListUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/course/usecase/GetCourseListUseCaseTest.kt
@@ -24,6 +24,7 @@ class GetCourseListUseCaseTest {
         status: CourseStatus = CourseStatus.ACTIVE,
         enrollmentCount: Long = 5,
         totalLessons: Int = 12,
+        priceWon: Int = 300000,
     ) = CourseWithTeacherAndEnrollmentCountDto(
         course =
             Course(
@@ -35,7 +36,7 @@ class GetCourseListUseCaseTest {
         courseProduct =
             CourseProduct(
                 name = courseName,
-                priceWon = 300000,
+                priceWon = priceWon,
                 totalLessons = totalLessons,
                 description = "설명",
             ),
@@ -115,6 +116,17 @@ class GetCourseListUseCaseTest {
         val result = useCase.execute(null, null, pageable)
 
         assertEquals(8, result.content[0].totalLessons)
+    }
+
+    @Test
+    fun `priceWon이 응답에 포함된다`() {
+        val dto = createCourseDto(priceWon = 450000)
+        val pageable = PageRequest.of(0, 20)
+        every { courseAdaptor.searchCourses(null, null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, null, pageable)
+
+        assertEquals(450000, result.content[0].priceWon)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 관리자 코스 목록 응답(`CourseListResponse`)에 `priceWon` 필드 추가
- `CourseProduct.priceWon`을 매핑하여 응답 노출

## Why
- Backoffice 코스 목록에서 가격 표시가 필요
- CourseProduct에는 이미 가격이 있는데 응답에서 빠져 있었음

Closes #243

## Test plan
- [x] `GetCourseListUseCaseTest` — priceWon 매핑 테스트 추가
- [x] 기존 테스트 전체 통과
- [x] ktlintCheck 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)