### PR TITLE
feat(common): @Public 어노테이션 도입 — 선언적 비로그인 엔드포인트

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/config/SwaggerConfig.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/config/SwaggerConfig.kt
@@ -1,10 +1,12 @@
 package com.sclass.backoffice.config
 
+import com.sclass.common.annotation.Public
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -28,4 +30,14 @@ class SwaggerConfig {
             ).addSecurityItem(SecurityRequirement().addList(securitySchemeName))
             .components(Components().addSecuritySchemes(securitySchemeName, securityScheme))
     }
+
+    @Bean
+    fun publicEndpointCustomizer(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            val isPublic =
+                handlerMethod.hasMethodAnnotation(Public::class.java) ||
+                    handlerMethod.beanType.isAnnotationPresent(Public::class.java)
+            if (isPublic) operation.security = emptyList()
+            operation
+        }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/config/SwaggerConfig.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/config/SwaggerConfig.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.AnnotatedElementUtils
 
 @Configuration
 class SwaggerConfig {
@@ -35,8 +36,8 @@ class SwaggerConfig {
     fun publicEndpointCustomizer(): OperationCustomizer =
         OperationCustomizer { operation, handlerMethod ->
             val isPublic =
-                handlerMethod.hasMethodAnnotation(Public::class.java) ||
-                    handlerMethod.beanType.isAnnotationPresent(Public::class.java)
+                AnnotatedElementUtils.hasAnnotation(handlerMethod.method, Public::class.java) ||
+                    AnnotatedElementUtils.hasAnnotation(handlerMethod.beanType, Public::class.java)
             if (isPublic) operation.security = emptyList()
             operation
         }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/config/WebConfig.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/config/WebConfig.kt
@@ -16,7 +16,7 @@ class WebConfig(
         registry
             .addInterceptor(jwtAuthInterceptor)
             .addPathPatterns("/api/**")
-            .excludePathPatterns("/api/v1/auth/**", "/api/v1/oauth/**", "/api/report-webhooks/**")
+            .excludePathPatterns("/api/v1/auth/**", "/api/v1/oauth/**")
     }
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/webhook/controller/ReportWebhookController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/webhook/controller/ReportWebhookController.kt
@@ -1,6 +1,7 @@
 package com.sclass.backoffice.webhook.controller
 
 import com.sclass.backoffice.webhook.usecase.ReceiveReportWebhookUseCase
+import com.sclass.common.annotation.Public
 import com.sclass.common.dto.ApiResponse
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Public
 @RestController
 @RequestMapping("/api/report-webhooks")
 class ReportWebhookController(

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/controller/CatalogController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/controller/CatalogController.kt
@@ -1,5 +1,6 @@
 package com.sclass.supporters.catalog.controller
 
+import com.sclass.common.annotation.Public
 import com.sclass.common.dto.ApiResponse
 import com.sclass.supporters.catalog.dto.CatalogCourseResponse
 import com.sclass.supporters.catalog.usecase.GetCatalogCourseListUseCase
@@ -7,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Public
 @RestController
 @RequestMapping("/api/v1/catalog")
 class CatalogController(

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/config/SwaggerConfig.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/config/SwaggerConfig.kt
@@ -1,10 +1,12 @@
 package com.sclass.supporters.config
 
+import com.sclass.common.annotation.Public
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -28,4 +30,14 @@ class SwaggerConfig {
             ).addSecurityItem(SecurityRequirement().addList(securitySchemeName))
             .components(Components().addSecuritySchemes(securitySchemeName, securityScheme))
     }
+
+    @Bean
+    fun publicEndpointCustomizer(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            val isPublic =
+                handlerMethod.hasMethodAnnotation(Public::class.java) ||
+                    handlerMethod.beanType.isAnnotationPresent(Public::class.java)
+            if (isPublic) operation.security = emptyList()
+            operation
+        }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/config/SwaggerConfig.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/config/SwaggerConfig.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.AnnotatedElementUtils
 
 @Configuration
 class SwaggerConfig {
@@ -35,8 +36,8 @@ class SwaggerConfig {
     fun publicEndpointCustomizer(): OperationCustomizer =
         OperationCustomizer { operation, handlerMethod ->
             val isPublic =
-                handlerMethod.hasMethodAnnotation(Public::class.java) ||
-                    handlerMethod.beanType.isAnnotationPresent(Public::class.java)
+                AnnotatedElementUtils.hasAnnotation(handlerMethod.method, Public::class.java) ||
+                    AnnotatedElementUtils.hasAnnotation(handlerMethod.beanType, Public::class.java)
             if (isPublic) operation.security = emptyList()
             operation
         }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/config/WebConfig.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/config/WebConfig.kt
@@ -22,9 +22,6 @@ class WebConfig(
                 "/api/v1/auth/**",
                 "/api/v1/oauth/**",
                 "/api/v1/auth/phone/**",
-                "/api/v1/payments/nicepay",
-                "/api/v1/partnership-leads",
-                "/api/v1/catalog/**",
             )
     }
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/partnership/controller/PartnershipLeadController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/partnership/controller/PartnershipLeadController.kt
@@ -1,5 +1,6 @@
 package com.sclass.supporters.partnership.controller
 
+import com.sclass.common.annotation.Public
 import com.sclass.common.dto.ApiResponse
 import com.sclass.supporters.partnership.dto.CreatePartnershipLeadRequest
 import com.sclass.supporters.partnership.dto.PartnershipLeadResponse
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 class PartnershipLeadController(
     private val createPartnershipLeadUseCase: CreatePartnershipLeadUseCase,
 ) {
+    @Public
     @PostMapping
     fun create(
         @Valid @RequestBody request: CreatePartnershipLeadRequest,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/controller/PaymentController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/controller/PaymentController.kt
@@ -1,6 +1,7 @@
 package com.sclass.supporters.payment.controller
 
 import com.sclass.common.annotation.CurrentUserId
+import com.sclass.common.annotation.Public
 import com.sclass.common.dto.ApiResponse
 import com.sclass.infrastructure.nicepay.dto.NicePayWebhookPayload
 import com.sclass.supporters.payment.dto.PreparePaymentRequest
@@ -32,6 +33,7 @@ class PaymentController(
         @Valid @RequestBody request: PreparePaymentRequest,
     ): ApiResponse<PreparePaymentResponse> = ApiResponse.success(preparePaymentUseCase.execute(userId, request))
 
+    @Public
     @PostMapping("/nicepay/webhook", produces = [MediaType.TEXT_HTML_VALUE])
     fun handleNicepayWebhook(
         @RequestBody request: NicePayWebhookPayload,
@@ -40,6 +42,7 @@ class PaymentController(
         return "OK"
     }
 
+    @Public
     @PostMapping("/nicepay")
     fun handleNicePayReturn(
         @RequestParam authResultCode: String,

--- a/SClass-Common/src/main/kotlin/com/sclass/common/annotation/Public.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/annotation/Public.kt
@@ -1,0 +1,5 @@
+package com.sclass.common.annotation
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Public

--- a/SClass-Common/src/main/kotlin/com/sclass/common/jwt/JwtAuthInterceptor.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/jwt/JwtAuthInterceptor.kt
@@ -1,9 +1,11 @@
 package com.sclass.common.jwt
 
+import com.sclass.common.annotation.Public
 import com.sclass.common.exception.UnauthorizedException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
 import org.springframework.web.servlet.HandlerInterceptor
 
 @Component
@@ -29,6 +31,8 @@ class JwtAuthInterceptor(
             return true
         }
 
+        if (handler is HandlerMethod && handler.isPublic()) return true
+
         val authHeader = request.getHeader("Authorization") ?: throw UnauthorizedException()
         if (!authHeader.startsWith("Bearer ")) throw UnauthorizedException()
 
@@ -40,4 +44,8 @@ class JwtAuthInterceptor(
         request.setAttribute(USER_ROLE_ATTRIBUTE, tokenInfo.role)
         return true
     }
+
+    private fun HandlerMethod.isPublic(): Boolean =
+        hasMethodAnnotation(Public::class.java) ||
+            beanType.isAnnotationPresent(Public::class.java)
 }

--- a/SClass-Common/src/main/kotlin/com/sclass/common/jwt/JwtAuthInterceptor.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/jwt/JwtAuthInterceptor.kt
@@ -4,6 +4,7 @@ import com.sclass.common.annotation.Public
 import com.sclass.common.exception.UnauthorizedException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.annotation.AnnotatedElementUtils
 import org.springframework.stereotype.Component
 import org.springframework.web.method.HandlerMethod
 import org.springframework.web.servlet.HandlerInterceptor
@@ -46,6 +47,6 @@ class JwtAuthInterceptor(
     }
 
     private fun HandlerMethod.isPublic(): Boolean =
-        hasMethodAnnotation(Public::class.java) ||
-            beanType.isAnnotationPresent(Public::class.java)
+        AnnotatedElementUtils.hasAnnotation(method, Public::class.java) ||
+            AnnotatedElementUtils.hasAnnotation(beanType, Public::class.java)
 }

--- a/SClass-Common/src/test/kotlin/com/sclass/common/jwt/JwtAuthInterceptorTest.kt
+++ b/SClass-Common/src/test/kotlin/com/sclass/common/jwt/JwtAuthInterceptorTest.kt
@@ -1,5 +1,6 @@
 package com.sclass.common.jwt
 
+import com.sclass.common.annotation.Public
 import com.sclass.common.exception.UnauthorizedException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.web.method.HandlerMethod
 
 class JwtAuthInterceptorTest {
     private lateinit var jwtTokenProvider: JwtTokenProvider
@@ -16,6 +18,23 @@ class JwtAuthInterceptorTest {
 
     private val jwtSecretKey = "test-secret-key-that-is-at-least-32-bytes-long!!"
     private val aesSecretKey = "test-aes-secret-key-32-bytes-ok!"
+
+    private class SecuredController {
+        fun secured() = Unit
+
+        @Public
+        fun publicMethod() = Unit
+    }
+
+    @Public
+    private class PublicController {
+        fun anyMethod() = Unit
+    }
+
+    private fun handlerMethod(
+        bean: Any,
+        methodName: String,
+    ): HandlerMethod = HandlerMethod(bean, bean::class.java.getDeclaredMethod(methodName))
 
     @BeforeEach
     fun setUp() {
@@ -58,6 +77,39 @@ class JwtAuthInterceptorTest {
 
         assertThrows<UnauthorizedException> {
             interceptor.preHandle(request, response, Any())
+        }
+    }
+
+    @Test
+    fun `@Public 메서드면 Authorization 헤더 없이도 통과한다`() {
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val handler = handlerMethod(SecuredController(), "publicMethod")
+
+        val result = interceptor.preHandle(request, response, handler)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `@Public 클래스의 모든 메서드는 Authorization 헤더 없이도 통과한다`() {
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val handler = handlerMethod(PublicController(), "anyMethod")
+
+        val result = interceptor.preHandle(request, response, handler)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `@Public 이 없는 메서드는 Authorization 헤더가 없으면 UnauthorizedException 이 발생한다`() {
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val handler = handlerMethod(SecuredController(), "secured")
+
+        assertThrows<UnauthorizedException> {
+            interceptor.preHandle(request, response, handler)
         }
     }
 }


### PR DESCRIPTION
## Summary
`@Public` 어노테이션을 도입해 비로그인 엔드포인트를 선언적으로 지정합니다. 기존 `WebConfig.excludePathPatterns` 기반의 path 화이트리스트를 컨트롤러/메서드 단위 어노테이션으로 이관하고, Swagger UI 에서도 해당 엔드포인트는 인증 락 아이콘이 표시되지 않도록 `OperationCustomizer` 를 추가합니다.

Closes #239

## Changes
- `@Public` 어노테이션 추가 (`SClass-Common` — FUNCTION, CLASS 타겟)
- `JwtAuthInterceptor` 가 `HandlerMethod` 의 `@Public` 여부를 확인하여 인증 skip
- 기존 path 화이트리스트를 `@Public` 으로 이관:
  - `/api/v1/catalog/**` → `CatalogController` 클래스 레벨
  - `/api/v1/partnership-leads` → `PartnershipLeadController.create` 메서드
  - `/api/v1/payments/nicepay` → `PaymentController.handleNicepayWebhook` + `handleNicePayReturn` 메서드
  - `/api/report-webhooks/**` → `ReportWebhookController` 클래스 레벨
- Swagger `OperationCustomizer` 추가 — `@Public` 엔드포인트의 `operation.security` 를 비워 UI 락 아이콘 미표시 (Supporters / Backoffice 양쪽 `SwaggerConfig` 에 Bean 등록)
- `/api/v1/auth/**` 와 `/api/v1/oauth/**` 는 path 기반 유지 — 컨트롤러 전체가 공개인 인프라성 진입점이라 `WebConfig` 에 선언된 의도가 더 명확

## Affected Modules
- [x] SClass-Common
- [ ] SClass-Domain
- [ ] SClass-Infrastructure
- [x] SClass-Api-Supporters
- [x] SClass-Api-Backoffice
- [ ] SClass-Batch

## Test Plan
- [x] `./gradlew clean build` 빌드 성공
- [x] `./gradlew ktlintCheck` 통과
- [x] `JwtAuthInterceptorTest` — `@Public` 메서드 / `@Public` 클래스 / 미부착 401 3 케이스 추가
- [ ] Swagger UI 에서 `/api/v1/catalog/courses` 락 아이콘 미표시 확인 (deploy 후)
- [ ] 비인증 `curl https://supporters-api.dev.sclass.click/api/v1/catalog/courses` → 200 확인 (deploy 후)

## Checklist
- [x] CLAUDE.md 컨벤션을 준수했는지 확인
- [x] 불필요한 파일이 포함되지 않았는지 확인

## Follow-up
- #241 Course/CourseProduct 확장 필드 (카탈로그 자산 + 모집 제약) — 이번 PR 머지 후 착수

🤖 Generated with [Claude Code](https://claude.com/claude-code)