### PR TITLE
feat(course,catalog): 카탈로그 필드 + 코스 수정 API + 카탈로그 상세 공개 API

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/controller/CourseController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/controller/CourseController.kt
@@ -4,9 +4,11 @@ import com.sclass.backoffice.course.dto.ChangeCourseStatusRequest
 import com.sclass.backoffice.course.dto.CoursePageResponse
 import com.sclass.backoffice.course.dto.CourseResponse
 import com.sclass.backoffice.course.dto.CreateCourseRequest
+import com.sclass.backoffice.course.dto.UpdateCourseRequest
 import com.sclass.backoffice.course.usecase.ChangeCourseStatusUseCase
 import com.sclass.backoffice.course.usecase.CreateCourseUseCase
 import com.sclass.backoffice.course.usecase.GetCourseListUseCase
+import com.sclass.backoffice.course.usecase.UpdateCourseUseCase
 import com.sclass.common.dto.ApiResponse
 import com.sclass.domain.domains.course.domain.CourseStatus
 import jakarta.validation.Valid
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -28,6 +31,7 @@ class CourseController(
     private val createCourseUseCase: CreateCourseUseCase,
     private val changeCourseStatusUseCase: ChangeCourseStatusUseCase,
     private val getCourseListUseCase: GetCourseListUseCase,
+    private val updateCourseUseCase: UpdateCourseUseCase,
 ) {
     @PostMapping
     fun createCourse(
@@ -46,4 +50,10 @@ class CourseController(
         @RequestParam(required = false) status: CourseStatus?,
         @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
     ): ApiResponse<CoursePageResponse> = ApiResponse.success(getCourseListUseCase.execute(teacherUserId, status, pageable))
+
+    @PutMapping("/{courseId}")
+    fun updateCourse(
+        @PathVariable courseId: Long,
+        @RequestBody @Valid request: UpdateCourseRequest,
+    ): ApiResponse<CourseResponse> = ApiResponse.success(updateCourseUseCase.execute(courseId, request))
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/CoursePageResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/CoursePageResponse.kt
@@ -19,10 +19,16 @@ data class CourseListResponse(
     val organizationId: String?,
     val name: String,
     val description: String?,
+    val thumbnailFileId: String?,
     val status: CourseStatus,
     val enrollmentCount: Long,
+    val maxEnrollments: Int,
     val totalLessons: Int,
     val priceWon: Int,
+    val enrollmentStartAt: LocalDateTime?,
+    val enrollmentDeadLine: LocalDateTime?,
+    val startAt: LocalDateTime?,
+    val endAt: LocalDateTime?,
     val createdAt: LocalDateTime,
 ) {
     companion object {
@@ -35,10 +41,16 @@ data class CourseListResponse(
                 organizationId = dto.course.organizationId,
                 name = dto.courseProduct?.name ?: "",
                 description = dto.courseProduct?.description,
+                thumbnailFileId = dto.courseProduct?.thumbnailFileId,
                 status = dto.course.status,
                 enrollmentCount = dto.enrollmentCount,
+                maxEnrollments = dto.course.maxEnrollments,
                 totalLessons = dto.courseProduct?.totalLessons ?: 0,
                 priceWon = dto.courseProduct?.priceWon ?: 0,
+                enrollmentStartAt = dto.course.enrollmentStartAt,
+                enrollmentDeadLine = dto.course.enrollmentDeadLine,
+                startAt = dto.course.startAt,
+                endAt = dto.course.endAt,
                 createdAt = dto.course.createdAt,
             )
     }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/CourseResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/CourseResponse.kt
@@ -3,6 +3,7 @@ package com.sclass.backoffice.course.dto
 import com.sclass.domain.domains.course.domain.Course
 import com.sclass.domain.domains.course.domain.CourseStatus
 import com.sclass.domain.domains.product.domain.CourseProduct
+import java.time.LocalDateTime
 
 data class CourseResponse(
     val id: Long,
@@ -11,7 +12,16 @@ data class CourseResponse(
     val organizationId: String?,
     val name: String,
     val description: String?,
+    val curriculum: String?,
+    val thumbnailFileId: String?,
+    val priceWon: Int,
+    val totalLessons: Int,
     val status: CourseStatus,
+    val maxEnrollments: Int,
+    val enrollmentStartAt: LocalDateTime?,
+    val enrollmentDeadLine: LocalDateTime?,
+    val startAt: LocalDateTime?,
+    val endAt: LocalDateTime?,
 ) {
     companion object {
         fun from(
@@ -24,7 +34,16 @@ data class CourseResponse(
             organizationId = course.organizationId,
             name = product.name,
             description = product.description,
+            curriculum = product.curriculum,
+            thumbnailFileId = product.thumbnailFileId,
+            priceWon = product.priceWon,
+            totalLessons = product.totalLessons,
             status = course.status,
+            maxEnrollments = course.maxEnrollments,
+            enrollmentStartAt = course.enrollmentStartAt,
+            enrollmentDeadLine = course.enrollmentDeadLine,
+            startAt = course.startAt,
+            endAt = course.endAt,
         )
     }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/CreateCourseRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/CreateCourseRequest.kt
@@ -3,12 +3,20 @@ package com.sclass.backoffice.course.dto
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
 
 data class CreateCourseRequest(
     @field:NotBlank val teacherUserId: String,
     val organizationId: String? = null,
     @field:NotBlank @field:Size(max = 200) val name: String,
     val description: String? = null,
+    val curriculum: String? = null,
+    val thumbnailFileId: String? = null,
     @field:Min(0) val priceWon: Int,
     @field:Min(1) val totalLessons: Int,
+    @field:Min(1) val maxEnrollments: Int = 1,
+    val enrollmentStartAt: LocalDateTime? = null,
+    val enrollmentDeadLine: LocalDateTime? = null,
+    val startAt: LocalDateTime? = null,
+    val endAt: LocalDateTime? = null,
 )

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/UpdateCourseRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/dto/UpdateCourseRequest.kt
@@ -1,0 +1,22 @@
+package com.sclass.backoffice.course.dto
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
+
+data class UpdateCourseRequest(
+    @field:Size(max = 200) val name: String? = null,
+    val description: String? = null,
+    val curriculum: String? = null,
+    val thumbnailFileId: String? = null,
+    @field:Min(0) val priceWon: Int? = null,
+    @field:Min(1) val maxEnrollments: Int? = null,
+    val enrollmentStartAt: LocalDateTime? = null,
+    val enrollmentDeadLine: LocalDateTime? = null,
+    val startAt: LocalDateTime? = null,
+    val endAt: LocalDateTime? = null,
+) {
+    fun hasEnrollmentConstraintChange() = maxEnrollments != null || enrollmentStartAt != null || enrollmentDeadLine != null
+
+    fun hasScheduleChange() = startAt != null || endAt != null
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/usecase/CreateCourseUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/usecase/CreateCourseUseCase.kt
@@ -23,6 +23,8 @@ class CreateCourseUseCase(
                     priceWon = request.priceWon,
                     totalLessons = request.totalLessons,
                     description = request.description,
+                    curriculum = request.curriculum,
+                    thumbnailFileId = request.thumbnailFileId,
                 ),
             ) as CourseProduct
         val course =
@@ -31,6 +33,11 @@ class CreateCourseUseCase(
                     productId = product.id,
                     teacherUserId = request.teacherUserId,
                     organizationId = request.organizationId,
+                    maxEnrollments = request.maxEnrollments,
+                    enrollmentStartAt = request.enrollmentStartAt,
+                    enrollmentDeadLine = request.enrollmentDeadLine,
+                    startAt = request.startAt,
+                    endAt = request.endAt,
                 ),
             )
         return CourseResponse.from(course, product)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/usecase/UpdateCourseUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/usecase/UpdateCourseUseCase.kt
@@ -1,0 +1,55 @@
+package com.sclass.backoffice.course.usecase
+
+import com.sclass.backoffice.course.dto.CourseResponse
+import com.sclass.backoffice.course.dto.UpdateCourseRequest
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@UseCase
+class UpdateCourseUseCase(
+    private val courseAdaptor: CourseAdaptor,
+    private val productAdaptor: ProductAdaptor,
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+) {
+    @Transactional
+    fun execute(
+        courseId: Long,
+        request: UpdateCourseRequest,
+    ): CourseResponse {
+        val course = courseAdaptor.findById(courseId)
+        val product =
+            productAdaptor.findById(course.productId) as? CourseProduct
+                ?: throw ProductTypeMismatchException()
+        val now = LocalDateTime.now()
+
+        product.updateCatalog(
+            newName = request.name,
+            newDescription = request.description,
+            newThumbnailFileId = request.thumbnailFileId,
+            newPriceWon = request.priceWon,
+        )
+        product.updateCurriculum(request.curriculum)
+
+        if (request.hasEnrollmentConstraintChange()) {
+            val liveCount = enrollmentAdaptor.countLiveEnrollments(courseId).toInt()
+            course.updateEnrollmentConstraints(
+                now = now,
+                newMaxEnrollments = request.maxEnrollments,
+                newEnrollmentStartAt = request.enrollmentStartAt,
+                newEnrollmentDeadLine = request.enrollmentDeadLine,
+                currentLiveCount = liveCount,
+            )
+        }
+        if (request.hasScheduleChange()) {
+            course.updateSchedule(now, request.startAt, request.endAt)
+        }
+
+        return CourseResponse.from(course, product)
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/course/usecase/CreateCourseUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/course/usecase/CreateCourseUseCaseTest.kt
@@ -14,6 +14,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
 
 class CreateCourseUseCaseTest {
     private lateinit var courseAdaptor: CourseAdaptor
@@ -80,6 +81,39 @@ class CreateCourseUseCaseTest {
             verify(exactly = 1) { productAdaptor.save(any()) }
             verify(exactly = 1) { courseAdaptor.save(any()) }
             assertThat(courseSlot.captured.productId).isNotBlank
+        }
+
+        @Test
+        fun `카탈로그 자산과 모집 제약 필드가 상품과 코스에 반영된다`() {
+            val productSlot = slot<CourseProduct>()
+            val courseSlot = slot<Course>()
+            every { productAdaptor.save(capture(productSlot)) } answers { productSlot.captured }
+            every { courseAdaptor.save(capture(courseSlot)) } answers { courseSlot.captured }
+
+            val enrollStart = LocalDateTime.of(2026, 5, 1, 0, 0)
+            val enrollEnd = LocalDateTime.of(2026, 5, 31, 23, 59)
+            val courseStart = LocalDateTime.of(2026, 6, 1, 0, 0)
+            val courseEnd = LocalDateTime.of(2026, 8, 31, 23, 59)
+
+            useCase.execute(
+                request().copy(
+                    curriculum = "1주차: 함수\n2주차: 극한",
+                    thumbnailFileId = "file-id-000000000001",
+                    maxEnrollments = 20,
+                    enrollmentStartAt = enrollStart,
+                    enrollmentDeadLine = enrollEnd,
+                    startAt = courseStart,
+                    endAt = courseEnd,
+                ),
+            )
+
+            assertThat(productSlot.captured.curriculum).isEqualTo("1주차: 함수\n2주차: 극한")
+            assertThat(productSlot.captured.thumbnailFileId).isEqualTo("file-id-000000000001")
+            assertThat(courseSlot.captured.maxEnrollments).isEqualTo(20)
+            assertThat(courseSlot.captured.enrollmentStartAt).isEqualTo(enrollStart)
+            assertThat(courseSlot.captured.enrollmentDeadLine).isEqualTo(enrollEnd)
+            assertThat(courseSlot.captured.startAt).isEqualTo(courseStart)
+            assertThat(courseSlot.captured.endAt).isEqualTo(courseEnd)
         }
     }
 }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/course/usecase/UpdateCourseUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/course/usecase/UpdateCourseUseCaseTest.kt
@@ -1,0 +1,149 @@
+package com.sclass.backoffice.course.usecase
+
+import com.sclass.backoffice.course.dto.UpdateCourseRequest
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.course.exception.CourseAlreadyStartedException
+import com.sclass.domain.domains.course.exception.CourseMaxEnrollmentsTooLowException
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.product.domain.Product
+import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class UpdateCourseUseCaseTest {
+    private lateinit var courseAdaptor: CourseAdaptor
+    private lateinit var productAdaptor: ProductAdaptor
+    private lateinit var enrollmentAdaptor: EnrollmentAdaptor
+    private lateinit var useCase: UpdateCourseUseCase
+
+    @BeforeEach
+    fun setUp() {
+        courseAdaptor = mockk()
+        productAdaptor = mockk()
+        enrollmentAdaptor = mockk()
+        useCase = UpdateCourseUseCase(courseAdaptor, productAdaptor, enrollmentAdaptor)
+    }
+
+    private fun listedCourse(startAt: LocalDateTime? = null) =
+        Course(
+            id = 1L,
+            productId = "product-id-00000000001",
+            teacherUserId = "teacher-id-00000000001",
+            status = CourseStatus.LISTED,
+            maxEnrollments = 10,
+            startAt = startAt,
+        )
+
+    private fun courseProduct() =
+        CourseProduct(
+            name = "수학 코스",
+            priceWon = 300000,
+            totalLessons = 12,
+        )
+
+    @Nested
+    inner class Success {
+        @Test
+        fun `마케팅 자산은 startAt과 무관하게 변경된다`() {
+            val course = listedCourse(startAt = LocalDateTime.now().minusDays(1))
+            val product = courseProduct()
+            every { courseAdaptor.findById(1L) } returns course
+            every { productAdaptor.findById("product-id-00000000001") } returns product
+
+            useCase.execute(
+                1L,
+                UpdateCourseRequest(
+                    name = "고급 수학 코스",
+                    description = "새 설명",
+                    curriculum = "1주차: 미분",
+                    thumbnailFileId = "file-id-000000000001",
+                    priceWon = 400000,
+                ),
+            )
+
+            assertAll(
+                { assertThat(product.name).isEqualTo("고급 수학 코스") },
+                { assertThat(product.description).isEqualTo("새 설명") },
+                { assertThat(product.curriculum).isEqualTo("1주차: 미분") },
+                { assertThat(product.thumbnailFileId).isEqualTo("file-id-000000000001") },
+                { assertThat(product.priceWon).isEqualTo(400000) },
+            )
+        }
+
+        @Test
+        fun `모집 제약 변경 시 현재 활성 등록자 수를 조회해 검증한다`() {
+            val course = listedCourse()
+            every { courseAdaptor.findById(1L) } returns course
+            every { productAdaptor.findById(any()) } returns courseProduct()
+            every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 2L
+
+            useCase.execute(1L, UpdateCourseRequest(maxEnrollments = 20))
+
+            assertThat(course.maxEnrollments).isEqualTo(20)
+        }
+
+        @Test
+        fun `일정 변경이 반영된다`() {
+            val course = listedCourse()
+            every { courseAdaptor.findById(1L) } returns course
+            every { productAdaptor.findById(any()) } returns courseProduct()
+
+            val newStart = LocalDateTime.now().plusDays(10)
+            val newEnd = LocalDateTime.now().plusDays(40)
+            useCase.execute(1L, UpdateCourseRequest(startAt = newStart, endAt = newEnd))
+
+            assertAll(
+                { assertThat(course.startAt).isEqualTo(newStart) },
+                { assertThat(course.endAt).isEqualTo(newEnd) },
+            )
+        }
+    }
+
+    @Nested
+    inner class Failure {
+        @Test
+        fun `CourseProduct가 아니면 ProductTypeMismatchException`() {
+            every { courseAdaptor.findById(1L) } returns listedCourse()
+            every { productAdaptor.findById(any()) } returns mockk<Product>()
+
+            assertThatThrownBy {
+                useCase.execute(1L, UpdateCourseRequest(maxEnrollments = 5))
+            }.isInstanceOf(ProductTypeMismatchException::class.java)
+        }
+
+        @Test
+        fun `이미 시작된 코스의 모집 제약 변경은 예외`() {
+            val course = listedCourse(startAt = LocalDateTime.now().minusDays(1))
+            every { courseAdaptor.findById(1L) } returns course
+            every { productAdaptor.findById(any()) } returns courseProduct()
+            every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 0L
+
+            assertThatThrownBy {
+                useCase.execute(1L, UpdateCourseRequest(maxEnrollments = 20))
+            }.isInstanceOf(CourseAlreadyStartedException::class.java)
+        }
+
+        @Test
+        fun `현재 활성 등록자보다 낮은 maxEnrollments는 예외`() {
+            val course = listedCourse()
+            every { courseAdaptor.findById(1L) } returns course
+            every { productAdaptor.findById(any()) } returns courseProduct()
+            every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 5L
+
+            assertThatThrownBy {
+                useCase.execute(1L, UpdateCourseRequest(maxEnrollments = 3))
+            }.isInstanceOf(CourseMaxEnrollmentsTooLowException::class.java)
+        }
+    }
+}

--- a/SClass-Api-Supporters/build.gradle.kts
+++ b/SClass-Api-Supporters/build.gradle.kts
@@ -12,4 +12,6 @@ dependencies {
     testImplementation("software.amazon.awssdk:s3")
     testImplementation(platform("com.google.cloud:libraries-bom:26.55.0"))
     testImplementation("com.google.cloud:google-cloud-storage")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter:1.20.4")
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/controller/CatalogController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/controller/CatalogController.kt
@@ -2,9 +2,12 @@ package com.sclass.supporters.catalog.controller
 
 import com.sclass.common.annotation.Public
 import com.sclass.common.dto.ApiResponse
+import com.sclass.supporters.catalog.dto.CatalogCourseDetailResponse
 import com.sclass.supporters.catalog.dto.CatalogCourseResponse
+import com.sclass.supporters.catalog.usecase.GetCatalogCourseDetailUseCase
 import com.sclass.supporters.catalog.usecase.GetCatalogCourseListUseCase
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -13,7 +16,13 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/catalog")
 class CatalogController(
     private val getCatalogCourseListUseCase: GetCatalogCourseListUseCase,
+    private val getCatalogCourseDetailUseCase: GetCatalogCourseDetailUseCase,
 ) {
     @GetMapping("/courses")
     fun getCourseList(): ApiResponse<List<CatalogCourseResponse>> = ApiResponse.success(getCatalogCourseListUseCase.execute())
+
+    @GetMapping("/courses/{courseId}")
+    fun getCourseDetail(
+        @PathVariable courseId: Long,
+    ): ApiResponse<CatalogCourseDetailResponse> = ApiResponse.success(getCatalogCourseDetailUseCase.execute(courseId))
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/dto/CatalogCourseDetailResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/dto/CatalogCourseDetailResponse.kt
@@ -4,16 +4,21 @@ import com.sclass.domain.domains.course.dto.CourseWithTeacherDto
 import com.sclass.domain.domains.teacher.domain.MajorCategory
 import java.time.LocalDateTime
 
-data class CatalogCourseResponse(
+data class CatalogCourseDetailResponse(
     val id: Long,
     val productId: String,
     val name: String,
     val description: String?,
+    val curriculum: String?,
     val thumbnailFileId: String?,
     val priceWon: Int,
     val totalLessons: Int,
+    val maxEnrollments: Int,
+    val remainingSeats: Long,
+    val enrollmentStartAt: LocalDateTime?,
     val enrollmentDeadLine: LocalDateTime?,
     val startAt: LocalDateTime?,
+    val endAt: LocalDateTime?,
     val teacher: TeacherSummary,
 ) {
     data class TeacherSummary(
@@ -26,17 +31,26 @@ data class CatalogCourseResponse(
     )
 
     companion object {
-        fun from(dto: CourseWithTeacherDto) =
-            CatalogCourseResponse(
+        fun from(
+            dto: CourseWithTeacherDto,
+            liveEnrollmentCount: Long,
+        ): CatalogCourseDetailResponse {
+            val remaining = (dto.course.maxEnrollments - liveEnrollmentCount).coerceAtLeast(0L)
+            return CatalogCourseDetailResponse(
                 id = dto.course.id,
                 productId = dto.course.productId,
                 name = dto.courseProduct?.name ?: "",
                 description = dto.courseProduct?.description,
+                curriculum = dto.courseProduct?.curriculum,
                 thumbnailFileId = dto.courseProduct?.thumbnailFileId,
                 priceWon = dto.courseProduct?.priceWon ?: 0,
                 totalLessons = dto.courseProduct?.totalLessons ?: 0,
+                maxEnrollments = dto.course.maxEnrollments,
+                remainingSeats = remaining,
+                enrollmentStartAt = dto.course.enrollmentStartAt,
                 enrollmentDeadLine = dto.course.enrollmentDeadLine,
                 startAt = dto.course.startAt,
+                endAt = dto.course.endAt,
                 teacher =
                     TeacherSummary(
                         userId = dto.course.teacherUserId,
@@ -48,5 +62,6 @@ data class CatalogCourseResponse(
                         major = dto.teacher?.education?.major,
                     ),
             )
+        }
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/usecase/GetCatalogCourseDetailUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/usecase/GetCatalogCourseDetailUseCase.kt
@@ -1,0 +1,20 @@
+package com.sclass.supporters.catalog.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.supporters.catalog.dto.CatalogCourseDetailResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetCatalogCourseDetailUseCase(
+    private val courseAdaptor: CourseAdaptor,
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(courseId: Long): CatalogCourseDetailResponse {
+        val dto = courseAdaptor.findCatalogCourseById(courseId)
+        val liveCount = enrollmentAdaptor.countLiveEnrollments(courseId)
+        return CatalogCourseDetailResponse.from(dto, liveCount)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/dto/MyCourseResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/course/dto/MyCourseResponse.kt
@@ -2,6 +2,7 @@ package com.sclass.supporters.course.dto
 
 import com.sclass.domain.domains.course.domain.CourseStatus
 import com.sclass.domain.domains.course.dto.CourseWithEnrollmentCountDto
+import java.time.LocalDateTime
 
 data class MyCourseResponse(
     val id: Long,
@@ -10,6 +11,10 @@ data class MyCourseResponse(
     val productId: String,
     val status: CourseStatus,
     val enrollmentCount: Long,
+    val maxEnrollments: Int,
+    val enrollmentDeadLine: LocalDateTime?,
+    val startAt: LocalDateTime?,
+    val endAt: LocalDateTime?,
 ) {
     companion object {
         fun from(dto: CourseWithEnrollmentCountDto) =
@@ -20,6 +25,10 @@ data class MyCourseResponse(
                 productId = dto.course.productId,
                 status = dto.course.status,
                 enrollmentCount = dto.enrollmentCount,
+                maxEnrollments = dto.course.maxEnrollments,
+                enrollmentDeadLine = dto.course.enrollmentDeadLine,
+                startAt = dto.course.startAt,
+                endAt = dto.course.endAt,
             )
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/MyEnrollmentResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/MyEnrollmentResponse.kt
@@ -1,8 +1,10 @@
 package com.sclass.supporters.enrollment.dto
 
-import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.course.domain.CourseStatus
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.enrollment.domain.EnrollmentType
+import com.sclass.domain.domains.enrollment.dto.EnrollmentWithCourseDto
+import java.time.LocalDateTime
 
 data class MyEnrollmentResponse(
     val id: Long,
@@ -10,15 +12,42 @@ data class MyEnrollmentResponse(
     val status: EnrollmentStatus,
     val enrollmentType: EnrollmentType,
     val tuitionAmountWon: Int,
+    val course: CourseSummary?,
 ) {
+    data class CourseSummary(
+        val name: String,
+        val description: String?,
+        val thumbnailFileId: String?,
+        val teacherName: String?,
+        val courseStatus: CourseStatus,
+        val enrollmentDeadLine: LocalDateTime?,
+        val startAt: LocalDateTime?,
+        val endAt: LocalDateTime?,
+    )
+
     companion object {
-        fun from(enrollment: Enrollment) =
-            MyEnrollmentResponse(
-                id = enrollment.id,
-                courseId = enrollment.courseId,
-                status = enrollment.status,
-                enrollmentType = enrollment.enrollmentType,
-                tuitionAmountWon = enrollment.tuitionAmountWon,
+        fun from(dto: EnrollmentWithCourseDto): MyEnrollmentResponse {
+            val summary =
+                dto.course?.let { course ->
+                    CourseSummary(
+                        name = dto.courseProduct?.name ?: "",
+                        description = dto.courseProduct?.description,
+                        thumbnailFileId = dto.courseProduct?.thumbnailFileId,
+                        teacherName = dto.teacherName,
+                        courseStatus = course.status,
+                        enrollmentDeadLine = course.enrollmentDeadLine,
+                        startAt = course.startAt,
+                        endAt = course.endAt,
+                    )
+                }
+            return MyEnrollmentResponse(
+                id = dto.enrollment.id,
+                courseId = dto.enrollment.courseId,
+                status = dto.enrollment.status,
+                enrollmentType = dto.enrollment.enrollmentType,
+                tuitionAmountWon = dto.enrollment.tuitionAmountWon,
+                course = summary,
             )
+        }
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/GetMyEnrollmentsUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/GetMyEnrollmentsUseCase.kt
@@ -11,5 +11,5 @@ class GetMyEnrollmentsUseCase(
 ) {
     @Transactional(readOnly = true)
     fun execute(studentUserId: String): List<MyEnrollmentResponse> =
-        enrollmentAdaptor.findAllByStudent(studentUserId).map { MyEnrollmentResponse.from(it) }
+        enrollmentAdaptor.findAllByStudentWithCourse(studentUserId).map { MyEnrollmentResponse.from(it) }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
@@ -3,8 +3,7 @@ package com.sclass.supporters.enrollment.usecase
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.common.vo.Ulid
 import com.sclass.domain.domains.course.adaptor.CourseAdaptor
-import com.sclass.domain.domains.course.domain.CourseStatus
-import com.sclass.domain.domains.course.exception.CourseNotListedException
+import com.sclass.domain.domains.course.exception.CourseNotEnrollableException
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.exception.EnrollmentAlreadyExistsException
@@ -19,6 +18,7 @@ import com.sclass.infrastructure.redis.DistributedLock
 import com.sclass.infrastructure.redis.LockKey
 import com.sclass.supporters.enrollment.dto.PrepareEnrollmentResponse
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @UseCase
 class PrepareEnrollmentUseCase(
@@ -30,12 +30,15 @@ class PrepareEnrollmentUseCase(
     @Transactional
     @DistributedLock(prefix = "enrollment")
     fun execute(
-        @LockKey studentUserId: String,
+        studentUserId: String,
         @LockKey courseId: Long,
         pgType: PgType,
     ): PrepareEnrollmentResponse {
         val course = courseAdaptor.findById(courseId)
-        if (course.status != CourseStatus.LISTED) throw CourseNotListedException()
+        val liveCount = enrollmentAdaptor.countLiveEnrollments(courseId)
+        if (!course.canEnroll(LocalDateTime.now(), liveCount.toInt())) {
+            throw CourseNotEnrollableException()
+        }
 
         val product =
             productAdaptor.findById(course.productId) as? CourseProduct

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
@@ -36,7 +36,7 @@ class PrepareEnrollmentUseCase(
     ): PrepareEnrollmentResponse {
         val course = courseAdaptor.findById(courseId)
         val liveCount = enrollmentAdaptor.countLiveEnrollments(courseId)
-        if (!course.canEnroll(LocalDateTime.now(), liveCount.toInt())) {
+        if (!course.canEnroll(LocalDateTime.now(), liveCount)) {
             throw CourseNotEnrollableException()
         }
 

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/catalog/usecase/GetCatalogCourseDetailUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/catalog/usecase/GetCatalogCourseDetailUseCaseTest.kt
@@ -1,0 +1,137 @@
+package com.sclass.supporters.catalog.usecase
+
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.course.dto.CourseWithTeacherDto
+import com.sclass.domain.domains.course.exception.CourseNotFoundException
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.teacher.domain.MajorCategory
+import com.sclass.domain.domains.teacher.domain.Teacher
+import com.sclass.domain.domains.teacher.domain.TeacherEducation
+import com.sclass.domain.domains.teacher.domain.TeacherProfile
+import com.sclass.domain.domains.user.domain.AuthProvider
+import com.sclass.domain.domains.user.domain.User
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class GetCatalogCourseDetailUseCaseTest {
+    private lateinit var courseAdaptor: CourseAdaptor
+    private lateinit var enrollmentAdaptor: EnrollmentAdaptor
+    private lateinit var useCase: GetCatalogCourseDetailUseCase
+
+    @BeforeEach
+    fun setUp() {
+        courseAdaptor = mockk()
+        enrollmentAdaptor = mockk()
+        useCase = GetCatalogCourseDetailUseCase(courseAdaptor, enrollmentAdaptor)
+    }
+
+    private fun makeDto(
+        courseId: Long = 1L,
+        maxEnrollments: Int = 10,
+        enrollmentStartAt: LocalDateTime? = LocalDateTime.of(2026, 4, 1, 0, 0),
+        enrollmentDeadLine: LocalDateTime? = LocalDateTime.of(2026, 4, 30, 0, 0),
+        startAt: LocalDateTime? = LocalDateTime.of(2026, 5, 1, 0, 0),
+        endAt: LocalDateTime? = LocalDateTime.of(2026, 6, 30, 0, 0),
+        curriculum: String? = "주 1회 12주 커리큘럼",
+        thumbnailFileId: String? = "file-id-00000000000000001",
+    ): CourseWithTeacherDto {
+        val user =
+            User(
+                email = "teacher@test.com",
+                name = "김선생",
+                authProvider = AuthProvider.EMAIL,
+            )
+        val teacher =
+            Teacher(
+                user = user,
+                profile = TeacherProfile(selfIntroduction = "안녕하세요"),
+                education =
+                    TeacherEducation(
+                        majorCategory = MajorCategory.ENGINEERING,
+                        university = "서울대학교",
+                        major = "컴퓨터공학",
+                    ),
+            )
+        return CourseWithTeacherDto(
+            course =
+                Course(
+                    id = courseId,
+                    productId = "product-id-0000000000000001",
+                    teacherUserId = user.id,
+                    status = CourseStatus.LISTED,
+                    maxEnrollments = maxEnrollments,
+                    enrollmentStartAt = enrollmentStartAt,
+                    enrollmentDeadLine = enrollmentDeadLine,
+                    startAt = startAt,
+                    endAt = endAt,
+                ),
+            courseProduct =
+                CourseProduct(
+                    name = "수학 기초",
+                    priceWon = 300000,
+                    totalLessons = 12,
+                    description = "수학 심화 과정",
+                    thumbnailFileId = thumbnailFileId,
+                    curriculum = curriculum,
+                ),
+            teacher = teacher,
+            teacherUser = user,
+        )
+    }
+
+    @Test
+    fun `카탈로그 코스 상세와 남은 좌석을 반환한다`() {
+        val dto = makeDto(maxEnrollments = 10)
+        every { courseAdaptor.findCatalogCourseById(1L) } returns dto
+        every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 3L
+
+        val result = useCase.execute(1L)
+
+        assertAll(
+            { assertEquals(1L, result.id) },
+            { assertEquals("수학 기초", result.name) },
+            { assertEquals("수학 심화 과정", result.description) },
+            { assertEquals("주 1회 12주 커리큘럼", result.curriculum) },
+            { assertEquals("file-id-00000000000000001", result.thumbnailFileId) },
+            { assertEquals(300000, result.priceWon) },
+            { assertEquals(12, result.totalLessons) },
+            { assertEquals(10, result.maxEnrollments) },
+            { assertEquals(7L, result.remainingSeats) },
+            { assertEquals(LocalDateTime.of(2026, 4, 1, 0, 0), result.enrollmentStartAt) },
+            { assertEquals(LocalDateTime.of(2026, 4, 30, 0, 0), result.enrollmentDeadLine) },
+            { assertEquals(LocalDateTime.of(2026, 5, 1, 0, 0), result.startAt) },
+            { assertEquals(LocalDateTime.of(2026, 6, 30, 0, 0), result.endAt) },
+            { assertEquals("김선생", result.teacher.name) },
+            { assertEquals(MajorCategory.ENGINEERING, result.teacher.majorCategory) },
+        )
+    }
+
+    @Test
+    fun `활성 등록 수가 정원을 넘으면 남은 좌석은 0이다`() {
+        val dto = makeDto(maxEnrollments = 5)
+        every { courseAdaptor.findCatalogCourseById(1L) } returns dto
+        every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 10L
+
+        val result = useCase.execute(1L)
+
+        assertEquals(0L, result.remainingSeats)
+    }
+
+    @Test
+    fun `코스가 카탈로그에 없으면 CourseNotFoundException 을 던진다`() {
+        every { courseAdaptor.findCatalogCourseById(999L) } throws CourseNotFoundException()
+
+        assertThrows(CourseNotFoundException::class.java) {
+            useCase.execute(999L)
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/GetMyEnrollmentsUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/GetMyEnrollmentsUseCaseTest.kt
@@ -1,0 +1,106 @@
+package com.sclass.supporters.enrollment.usecase
+
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.enrollment.dto.EnrollmentWithCourseDto
+import com.sclass.domain.domains.product.domain.CourseProduct
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class GetMyEnrollmentsUseCaseTest {
+    private lateinit var enrollmentAdaptor: EnrollmentAdaptor
+    private lateinit var useCase: GetMyEnrollmentsUseCase
+
+    @BeforeEach
+    fun setUp() {
+        enrollmentAdaptor = mockk()
+        useCase = GetMyEnrollmentsUseCase(enrollmentAdaptor)
+    }
+
+    private fun makeDto(
+        course: Course? =
+            Course(
+                id = 1L,
+                productId = "product-id-0000000000000001",
+                teacherUserId = "teacher-id-0000000000000001",
+                status = CourseStatus.LISTED,
+                maxEnrollments = 10,
+                enrollmentDeadLine = LocalDateTime.of(2026, 4, 30, 0, 0),
+                startAt = LocalDateTime.of(2026, 5, 1, 0, 0),
+                endAt = LocalDateTime.of(2026, 6, 30, 0, 0),
+            ),
+        courseProduct: CourseProduct? =
+            CourseProduct(
+                name = "수학 기초",
+                priceWon = 300000,
+                totalLessons = 12,
+                description = "수학 심화",
+                thumbnailFileId = "file-id-00000000000000001",
+            ),
+        teacherName: String? = "김선생",
+    ): EnrollmentWithCourseDto {
+        val enrollment =
+            Enrollment.createForPurchase(
+                courseId = 1L,
+                studentUserId = "student-id-0000000000000001",
+                tuitionAmountWon = 300000,
+                paymentId = "payment-id-00000000000000",
+            )
+        return EnrollmentWithCourseDto(
+            enrollment = enrollment,
+            course = course,
+            courseProduct = courseProduct,
+            teacherName = teacherName,
+        )
+    }
+
+    @Test
+    fun `학생의 등록 목록과 코스 요약을 반환한다`() {
+        every { enrollmentAdaptor.findAllByStudentWithCourse("student-id-0000000000000001") } returns listOf(makeDto())
+
+        val result = useCase.execute("student-id-0000000000000001")
+
+        val summary = result[0].course!!
+        assertAll(
+            { assertEquals(1, result.size) },
+            { assertEquals(1L, result[0].courseId) },
+            { assertEquals(EnrollmentStatus.PENDING_PAYMENT, result[0].status) },
+            { assertEquals(300000, result[0].tuitionAmountWon) },
+            { assertEquals("수학 기초", summary.name) },
+            { assertEquals("수학 심화", summary.description) },
+            { assertEquals("file-id-00000000000000001", summary.thumbnailFileId) },
+            { assertEquals("김선생", summary.teacherName) },
+            { assertEquals(CourseStatus.LISTED, summary.courseStatus) },
+            { assertEquals(LocalDateTime.of(2026, 4, 30, 0, 0), summary.enrollmentDeadLine) },
+            { assertEquals(LocalDateTime.of(2026, 5, 1, 0, 0), summary.startAt) },
+            { assertEquals(LocalDateTime.of(2026, 6, 30, 0, 0), summary.endAt) },
+        )
+    }
+
+    @Test
+    fun `코스가 삭제되어 join 결과가 null 이면 course 요약은 null 이다`() {
+        every { enrollmentAdaptor.findAllByStudentWithCourse("student-id-0000000000000001") } returns
+            listOf(makeDto(course = null, courseProduct = null, teacherName = null))
+
+        val result = useCase.execute("student-id-0000000000000001")
+
+        assertNull(result[0].course)
+    }
+
+    @Test
+    fun `등록 내역이 없으면 빈 리스트를 반환한다`() {
+        every { enrollmentAdaptor.findAllByStudentWithCourse("student-id-0000000000000001") } returns emptyList()
+
+        assertTrue(useCase.execute("student-id-0000000000000001").isEmpty())
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentConcurrencyTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentConcurrencyTest.kt
@@ -1,0 +1,135 @@
+package com.sclass.supporters.enrollment.usecase
+
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.course.exception.CourseNotEnrollableException
+import com.sclass.domain.domains.course.repository.CourseRepository
+import com.sclass.domain.domains.enrollment.repository.EnrollmentRepository
+import com.sclass.domain.domains.payment.domain.PgType
+import com.sclass.domain.domains.payment.repository.PaymentRepository
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.product.repository.ProductRepository
+import com.sclass.supporters.config.ApiIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@ApiIntegrationTest
+@Testcontainers
+class PrepareEnrollmentConcurrencyTest {
+    companion object {
+        @Container
+        @JvmStatic
+        val redis: GenericContainer<*> =
+            GenericContainer("redis:7-alpine").withExposedPorts(6379)
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun redisProps(registry: DynamicPropertyRegistry) {
+            registry.add("spring.data.redis.host") { redis.host }
+            registry.add("spring.data.redis.port") { redis.firstMappedPort }
+        }
+    }
+
+    @Autowired
+    private lateinit var prepareEnrollmentUseCase: PrepareEnrollmentUseCase
+
+    @Autowired
+    private lateinit var courseRepository: CourseRepository
+
+    @Autowired
+    private lateinit var productRepository: ProductRepository
+
+    @Autowired
+    private lateinit var enrollmentRepository: EnrollmentRepository
+
+    @Autowired
+    private lateinit var paymentRepository: PaymentRepository
+
+    @Test
+    fun `정원 3명 코스에 10명이 동시 등록 요청하면 3명만 성공한다`() {
+        val product =
+            productRepository.save(
+                CourseProduct(
+                    name = "테스트 코스",
+                    priceWon = 10_000,
+                    totalLessons = 10,
+                ),
+            )
+        val course =
+            courseRepository.save(
+                Course(
+                    productId = product.id,
+                    teacherUserId = "teacher-01",
+                    status = CourseStatus.LISTED,
+                    maxEnrollments = 3,
+                ),
+            )
+
+        val threadCount = 10
+        val readyLatch = CountDownLatch(threadCount)
+        val startLatch = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val successes = ConcurrentLinkedQueue<Int>()
+        val enrollableFailures = ConcurrentLinkedQueue<Int>()
+        val otherFailures = ConcurrentLinkedQueue<Exception>()
+
+        try {
+            repeat(threadCount) { i ->
+                executor.submit {
+                    readyLatch.countDown()
+                    startLatch.await()
+                    try {
+                        prepareEnrollmentUseCase.execute(
+                            studentUserId = "student-$i",
+                            courseId = course.id,
+                            pgType = PgType.NICEPAY,
+                        )
+                        successes.add(i)
+                    } catch (e: CourseNotEnrollableException) {
+                        enrollableFailures.add(i)
+                    } catch (e: Exception) {
+                        otherFailures.add(e)
+                    }
+                }
+            }
+
+            readyLatch.await()
+            startLatch.countDown()
+            executor.shutdown()
+            executor.awaitTermination(60, TimeUnit.SECONDS)
+
+            assertThat(otherFailures)
+                .describedAs("예상하지 못한 예외가 발생했습니다: %s", otherFailures)
+                .isEmpty()
+            assertThat(successes.size)
+                .describedAs("정원을 초과해 등록되었습니다")
+                .isEqualTo(3)
+            assertThat(enrollableFailures.size).isEqualTo(7)
+
+            val liveCount =
+                enrollmentRepository.countByCourseIdAndStatusIn(
+                    course.id,
+                    setOf(
+                        com.sclass.domain.domains.enrollment.domain.EnrollmentStatus.PENDING_PAYMENT,
+                        com.sclass.domain.domains.enrollment.domain.EnrollmentStatus.ACTIVE,
+                    ),
+                )
+            assertThat(liveCount).isEqualTo(3L)
+        } finally {
+            enrollmentRepository.deleteAll()
+            paymentRepository.deleteAll()
+            courseRepository.deleteAll()
+            productRepository.deleteAll()
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
@@ -3,7 +3,7 @@ package com.sclass.supporters.enrollment.usecase
 import com.sclass.domain.domains.course.adaptor.CourseAdaptor
 import com.sclass.domain.domains.course.domain.Course
 import com.sclass.domain.domains.course.domain.CourseStatus
-import com.sclass.domain.domains.course.exception.CourseNotListedException
+import com.sclass.domain.domains.course.exception.CourseNotEnrollableException
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
@@ -81,6 +81,7 @@ class PrepareEnrollmentUseCaseTest {
         fun `결제 준비 시 Payment와 Enrollment가 생성된다`() {
             val enrollmentSlot = slot<Enrollment>()
             every { courseAdaptor.findById(1L) } returns listedCourse()
+            every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 0L
             every { productAdaptor.findById("product-id-00000000001") } returns courseProduct()
             every { enrollmentAdaptor.findLiveEnrollment(1L, "student-id-00000000001") } returns null
             every { paymentAdaptor.save(any()) } returns pendingPayment()
@@ -99,12 +100,13 @@ class PrepareEnrollmentUseCaseTest {
     @Nested
     inner class Failure {
         @Test
-        fun `코스가 LISTED가 아니면 CourseNotListedException이 발생한다`() {
+        fun `코스가 등록 불가능하면 CourseNotEnrollableException이 발생한다`() {
             every { courseAdaptor.findById(1L) } returns draftCourse()
+            every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 0L
 
             assertThatThrownBy {
                 useCase.execute("student-id-00000000001", 1L, PgType.NICEPAY)
-            }.isInstanceOf(CourseNotListedException::class.java)
+            }.isInstanceOf(CourseNotEnrollableException::class.java)
         }
 
         @Test
@@ -117,6 +119,7 @@ class PrepareEnrollmentUseCaseTest {
                     paymentId = "payment-id-000000000001",
                 )
             every { courseAdaptor.findById(1L) } returns listedCourse()
+            every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 0L
             every { productAdaptor.findById(any()) } returns courseProduct()
             every { enrollmentAdaptor.findLiveEnrollment(1L, "student-id-00000000001") } returns existingEnrollment
 
@@ -128,6 +131,7 @@ class PrepareEnrollmentUseCaseTest {
         @Test
         fun `CourseProduct가 아닌 상품이면 ProductTypeMismatchException이 발생한다`() {
             every { courseAdaptor.findById(1L) } returns listedCourse()
+            every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 0L
             every { productAdaptor.findById(any()) } returns mockk<Product>()
             every { enrollmentAdaptor.findLiveEnrollment(any(), any()) } returns null
 
@@ -139,6 +143,7 @@ class PrepareEnrollmentUseCaseTest {
         @Test
         fun `결제 준비 시 paymentAdaptor와 enrollmentAdaptor save를 각각 호출한다`() {
             every { courseAdaptor.findById(1L) } returns listedCourse()
+            every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 0L
             every { productAdaptor.findById(any()) } returns courseProduct()
             every { enrollmentAdaptor.findLiveEnrollment(any(), any()) } returns null
             every { paymentAdaptor.save(any()) } returns pendingPayment()

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/adaptor/CourseAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/adaptor/CourseAdaptor.kt
@@ -25,6 +25,8 @@ class CourseAdaptor(
 
     fun findAllCatalogCourses() = courseRepository.findAllCatalogCourses()
 
+    fun findCatalogCourseById(id: Long) = courseRepository.findCatalogCourseById(id) ?: throw CourseNotFoundException()
+
     fun findAllByTeacherUserIdWithEnrollmentCount(teacherUserId: String): List<CourseWithEnrollmentCountDto> =
         courseRepository.findAllByTeacherUserIdWithEnrollmentCount(teacherUserId)
 

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/domain/Course.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/domain/Course.kt
@@ -75,11 +75,11 @@ class Course(
 
     fun canEnroll(
         now: LocalDateTime,
-        currentCount: Int,
+        currentCount: Long,
     ): Boolean {
-        if (status !== CourseStatus.LISTED)return false
-        if (enrollmentStartAt !== null && now.isBefore(enrollmentStartAt))return false
-        if (enrollmentDeadLine !== null && now.isAfter(enrollmentDeadLine))return false
+        if (status != CourseStatus.LISTED) return false
+        if (enrollmentStartAt != null && now.isBefore(enrollmentStartAt)) return false
+        if (enrollmentDeadLine != null && now.isAfter(enrollmentDeadLine)) return false
         if (currentCount >= maxEnrollments) return false
         return true
     }
@@ -96,7 +96,7 @@ class Course(
         if (status !in allowed) throw CourseInvalidStatusTransitionException()
     }
 
-    fun hasStarted(now: LocalDateTime): Boolean = startAt !== null && !now.isBefore(startAt)
+    fun hasStarted(now: LocalDateTime): Boolean = startAt != null && !now.isBefore(startAt)
 
     fun updateEnrollmentConstraints(
         now: LocalDateTime,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/domain/Course.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/domain/Course.kt
@@ -1,7 +1,10 @@
 package com.sclass.domain.domains.course.domain
 
 import com.sclass.domain.common.model.BaseTimeEntity
+import com.sclass.domain.domains.course.exception.CourseAlreadyStartedException
+import com.sclass.domain.domains.course.exception.CourseInvalidScheduleException
 import com.sclass.domain.domains.course.exception.CourseInvalidStatusTransitionException
+import com.sclass.domain.domains.course.exception.CourseMaxEnrollmentsTooLowException
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -91,5 +94,60 @@ class Course(
                     setOf(CourseStatus.DRAFT, CourseStatus.LISTED, CourseStatus.UNLISTED, CourseStatus.ARCHIVED)
             }
         if (status !in allowed) throw CourseInvalidStatusTransitionException()
+    }
+
+    fun hasStarted(now: LocalDateTime): Boolean = startAt !== null && !now.isBefore(startAt)
+
+    fun updateEnrollmentConstraints(
+        now: LocalDateTime,
+        newMaxEnrollments: Int?,
+        newEnrollmentStartAt: LocalDateTime?,
+        newEnrollmentDeadLine: LocalDateTime?,
+        currentLiveCount: Int,
+    ) {
+        if (hasStarted(now)) throw CourseAlreadyStartedException()
+
+        val nextMax = newMaxEnrollments ?: maxEnrollments
+        val nextStart = newEnrollmentStartAt ?: enrollmentStartAt
+        val nextDeadLine = newEnrollmentDeadLine ?: enrollmentDeadLine
+
+        if (nextMax < currentLiveCount)throw CourseMaxEnrollmentsTooLowException()
+        validateSchedule(nextStart, nextDeadLine, startAt, endAt)
+
+        maxEnrollments = nextMax
+        enrollmentStartAt = nextStart
+        enrollmentDeadLine = nextDeadLine
+    }
+
+    fun updateSchedule(
+        now: LocalDateTime,
+        newStartTime: LocalDateTime?,
+        newEndAt: LocalDateTime?,
+    ) {
+        if (hasStarted(now)) throw CourseAlreadyStartedException()
+
+        val nextStart = newStartTime ?: startAt
+        val nextEnd = newEndAt ?: endAt
+        validateSchedule(enrollmentStartAt, enrollmentDeadLine, nextStart, nextEnd)
+
+        startAt = nextStart
+        endAt = nextEnd
+    }
+
+    private fun validateSchedule(
+        enrollStart: LocalDateTime?,
+        enrollDeadline: LocalDateTime?,
+        courseStart: LocalDateTime?,
+        courseEnd: LocalDateTime?,
+    ) {
+        if (enrollStart != null && enrollDeadline != null && !enrollStart.isBefore(enrollDeadline)) {
+            throw CourseInvalidScheduleException()
+        }
+        if (enrollDeadline != null && courseStart != null && enrollDeadline.isAfter(courseStart)) {
+            throw CourseInvalidScheduleException()
+        }
+        if (courseStart != null && courseEnd != null && !courseStart.isBefore(courseEnd)) {
+            throw CourseInvalidScheduleException()
+        }
     }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/domain/Course.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/domain/Course.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Index
 import jakarta.persistence.Table
+import java.time.LocalDateTime
 
 @Entity
 @Table(
@@ -38,6 +39,21 @@ class Course(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     var status: CourseStatus = CourseStatus.DRAFT,
+
+    @Column(name = "max_enrollments", nullable = false)
+    var maxEnrollments: Int = 1,
+
+    @Column(name = "enrollment_start_at")
+    var enrollmentStartAt: LocalDateTime? = null,
+
+    @Column(name = "enrollment_deadline")
+    var enrollmentDeadLine: LocalDateTime? = null,
+
+    @Column(name = "start_at")
+    var startAt: LocalDateTime? = null,
+
+    @Column(name = "end_at")
+    var endAt: LocalDateTime? = null,
 ) : BaseTimeEntity() {
     fun list() {
         validateTransition(CourseStatus.LISTED)
@@ -52,6 +68,17 @@ class Course(
     fun archive() {
         validateTransition(CourseStatus.ARCHIVED)
         this.status = CourseStatus.ARCHIVED
+    }
+
+    fun canEnroll(
+        now: LocalDateTime,
+        currentCount: Int,
+    ): Boolean {
+        if (status !== CourseStatus.LISTED)return false
+        if (enrollmentStartAt !== null && now.isBefore(enrollmentStartAt))return false
+        if (enrollmentDeadLine !== null && now.isAfter(enrollmentDeadLine))return false
+        if (currentCount >= maxEnrollments) return false
+        return true
     }
 
     private fun validateTransition(target: CourseStatus) {

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/exception/CourseErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/exception/CourseErrorCode.kt
@@ -12,4 +12,7 @@ enum class CourseErrorCode(
     COURSE_INVALID_STATUS_TRANSITION("COURSE_003", "잘못된 코스 상태 전이입니다", 400),
     COURSE_PRODUCT_NOT_FOUND("COURSE_004", "코스에 연결된 상품을 찾을 수 없습니다", 404),
     COURSE_NOT_ENROLLABLE("COURSE_005", "등록할 수 없는 코스입니다", 400),
+    COURSE_ALREADY_STARTED("COURSE_006", "이미 시작된 코스는 일정/모집 조건을 변경할 수 없습니다", 400),
+    COURSE_MAX_ENROLLMENTS_TOO_LOW("COURSE_007", "최대 정원은 현재 등록자 수보다 작을 수 없습니다", 400),
+    COURSE_INVALID_SCHEDULE("COURSE_008", "모집 시작 < 모집 마감 ≤ 개강 < 종강 순이어야 합니다", 400),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/exception/CourseErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/exception/CourseErrorCode.kt
@@ -11,4 +11,5 @@ enum class CourseErrorCode(
     COURSE_NOT_LISTED("COURSE_002", "판매 중인 코스가 아닙니다", 400),
     COURSE_INVALID_STATUS_TRANSITION("COURSE_003", "잘못된 코스 상태 전이입니다", 400),
     COURSE_PRODUCT_NOT_FOUND("COURSE_004", "코스에 연결된 상품을 찾을 수 없습니다", 404),
+    COURSE_NOT_ENROLLABLE("COURSE_005", "등록할 수 없는 코스입니다", 400),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/exception/CourseExceptions.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/exception/CourseExceptions.kt
@@ -11,3 +11,9 @@ class CourseInvalidStatusTransitionException : BusinessException(CourseErrorCode
 class CourseProductNotFoundException : BusinessException(CourseErrorCode.COURSE_PRODUCT_NOT_FOUND)
 
 class CourseNotEnrollableException : BusinessException(CourseErrorCode.COURSE_NOT_ENROLLABLE)
+
+class CourseAlreadyStartedException : BusinessException(CourseErrorCode.COURSE_ALREADY_STARTED)
+
+class CourseMaxEnrollmentsTooLowException : BusinessException(CourseErrorCode.COURSE_MAX_ENROLLMENTS_TOO_LOW)
+
+class CourseInvalidScheduleException : BusinessException(CourseErrorCode.COURSE_INVALID_SCHEDULE)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/exception/CourseExceptions.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/exception/CourseExceptions.kt
@@ -9,3 +9,5 @@ class CourseNotListedException : BusinessException(CourseErrorCode.COURSE_NOT_LI
 class CourseInvalidStatusTransitionException : BusinessException(CourseErrorCode.COURSE_INVALID_STATUS_TRANSITION)
 
 class CourseProductNotFoundException : BusinessException(CourseErrorCode.COURSE_PRODUCT_NOT_FOUND)
+
+class CourseNotEnrollableException : BusinessException(CourseErrorCode.COURSE_NOT_ENROLLABLE)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepository.kt
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Pageable
 interface CourseCustomRepository {
     fun findAllCatalogCourses(): List<CourseWithTeacherDto>
 
+    fun findCatalogCourseById(id: Long): CourseWithTeacherDto?
+
     fun findAllByTeacherUserIdWithEnrollmentCount(teacherUserId: String): List<CourseWithEnrollmentCountDto>
 
     fun searchCourses(

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/repository/CourseCustomRepositoryImpl.kt
@@ -115,6 +115,30 @@ class CourseCustomRepositoryImpl(
                 )
             }
 
+    override fun findCatalogCourseById(id: Long): CourseWithTeacherDto? =
+        queryFactory
+            .select(course, courseProduct, teacher, user)
+            .from(course)
+            .leftJoin(courseProduct)
+            .on(courseProduct.id.eq(course.productId))
+            .leftJoin(teacher)
+            .on(teacher.user.id.eq(course.teacherUserId))
+            .leftJoin(user)
+            .on(user.id.eq(course.teacherUserId))
+            .where(
+                course.id.eq(id),
+                course.status.eq(CourseStatus.LISTED),
+                courseProduct.visible.isTrue,
+            ).fetchOne()
+            ?.let { tuple ->
+                CourseWithTeacherDto(
+                    course = tuple[course]!!,
+                    courseProduct = tuple[courseProduct],
+                    teacher = tuple[teacher],
+                    teacherUser = tuple[user],
+                )
+            }
+
     private fun Sort.toOrderSpecifiers(): Array<OrderSpecifier<*>> {
         if (isUnsorted) return arrayOf(course.createdAt.desc())
         val coursePath = PathBuilder(Course::class.java, "course")

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
@@ -60,4 +60,10 @@ class EnrollmentAdaptor(
         enrollmentRepository.findByPaymentId(paymentId) ?: throw EnrollmentNotFoundException()
 
     fun findByPaymentIdOrNull(paymentId: String): Enrollment? = enrollmentRepository.findByPaymentId(paymentId)
+
+    fun countLiveEnrollments(courseId: Long): Long =
+        enrollmentRepository.countByCourseIdAndStatusIn(
+            courseId,
+            setOf(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.ACTIVE),
+        )
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
@@ -4,6 +4,7 @@ import com.sclass.common.annotation.Adaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.enrollment.domain.EnrollmentType
+import com.sclass.domain.domains.enrollment.dto.EnrollmentWithCourseDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithStudentDto
 import com.sclass.domain.domains.enrollment.exception.EnrollmentNotFoundException
@@ -23,6 +24,9 @@ class EnrollmentAdaptor(
     fun findByIdOrNull(id: Long): Enrollment? = enrollmentRepository.findByIdOrNull(id)
 
     fun findAllByStudent(studentUserId: String): List<Enrollment> = enrollmentRepository.findAllByStudentUserId(studentUserId)
+
+    fun findAllByStudentWithCourse(studentUserId: String): List<EnrollmentWithCourseDto> =
+        enrollmentRepository.findAllByStudentUserIdWithCourse(studentUserId)
 
     fun findAllByCourseWithStudent(courseId: Long): List<EnrollmentWithStudentDto> =
         enrollmentRepository.findAllByCourseIdWithStudent(courseId)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/dto/EnrollmentWithCourseDto.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/dto/EnrollmentWithCourseDto.kt
@@ -1,0 +1,12 @@
+package com.sclass.domain.domains.enrollment.dto
+
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.product.domain.CourseProduct
+
+data class EnrollmentWithCourseDto(
+    val enrollment: Enrollment,
+    val course: Course?,
+    val courseProduct: CourseProduct?,
+    val teacherName: String?,
+)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepository.kt
@@ -1,6 +1,7 @@
 package com.sclass.domain.domains.enrollment.repository
 
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.enrollment.dto.EnrollmentWithCourseDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithStudentDto
 import org.springframework.data.domain.Page
@@ -8,6 +9,8 @@ import org.springframework.data.domain.Pageable
 
 interface EnrollmentCustomRepository {
     fun findAllByCourseIdWithStudent(courseId: Long): List<EnrollmentWithStudentDto>
+
+    fun findAllByStudentUserIdWithCourse(studentUserId: String): List<EnrollmentWithCourseDto>
 
     fun searchEnrollments(
         studentUserId: String?,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.sclass.domain.domains.course.domain.QCourse.course
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.enrollment.domain.QEnrollment.enrollment
+import com.sclass.domain.domains.enrollment.dto.EnrollmentWithCourseDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithStudentDto
 import com.sclass.domain.domains.product.domain.QCourseProduct.courseProduct
@@ -22,6 +23,28 @@ import org.springframework.data.domain.Sort
 class EnrollmentCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : EnrollmentCustomRepository {
+    override fun findAllByStudentUserIdWithCourse(studentUserId: String): List<EnrollmentWithCourseDto> =
+        queryFactory
+            .select(enrollment, course, courseProduct, user.name)
+            .from(enrollment)
+            .leftJoin(course)
+            .on(course.id.eq(enrollment.courseId))
+            .leftJoin(courseProduct)
+            .on(courseProduct.id.eq(course.productId))
+            .leftJoin(user)
+            .on(user.id.eq(course.teacherUserId))
+            .where(enrollment.studentUserId.eq(studentUserId))
+            .orderBy(enrollment.createdAt.desc())
+            .fetch()
+            .map { tuple ->
+                EnrollmentWithCourseDto(
+                    enrollment = tuple[enrollment]!!,
+                    course = tuple[course],
+                    courseProduct = tuple[courseProduct],
+                    teacherName = tuple[user.name],
+                )
+            }
+
     override fun findAllByCourseIdWithStudent(courseId: Long): List<EnrollmentWithStudentDto> =
         queryFactory
             .select(enrollment, user)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentRepository.kt
@@ -30,4 +30,9 @@ interface EnrollmentRepository :
 
     // Payment → Enrollment 역조회 (콜백 처리용)
     fun findByPaymentId(paymentId: String): Enrollment?
+
+    fun countByCourseIdAndStatusIn(
+        courseId: Long,
+        statuses: Collection<EnrollmentStatus>,
+    ): Long
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/file/domain/FileType.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/file/domain/FileType.kt
@@ -31,4 +31,7 @@ enum class FileType {
 
     // 과제
     TASK_SUBMISSION,
+
+    // 카탈로그 자산
+    COURSE_THUMBNAIL,
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
@@ -15,4 +15,10 @@ class CourseProduct(
 
     @Column(columnDefinition = "TEXT")
     var description: String? = null,
+
+    @Column(columnDefinition = "TEXT")
+    var curriculum: String? = null,
+
+    @Column(name = "thumbnail_file_id", length = 26)
+    var thumbnailFileId: String? = null,
 ) : Product(name = name, priceWon = priceWon)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
@@ -22,4 +22,8 @@ class CourseProduct(
         priceWon = priceWon,
         description = description,
         thumbnailFileId = thumbnailFileId,
-    )
+    ) {
+    fun updateCurriculum(newCurriculum: String?) {
+        newCurriculum?.let { curriculum = it }
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
@@ -9,16 +9,17 @@ import jakarta.persistence.Entity
 class CourseProduct(
     name: String,
     priceWon: Int,
+    description: String? = null,
+    thumbnailFileId: String? = null,
 
     @Column(name = "total_lessons", nullable = true)
     val totalLessons: Int,
 
     @Column(columnDefinition = "TEXT")
-    var description: String? = null,
-
-    @Column(columnDefinition = "TEXT")
     var curriculum: String? = null,
-
-    @Column(name = "thumbnail_file_id", length = 26)
-    var thumbnailFileId: String? = null,
-) : Product(name = name, priceWon = priceWon)
+) : Product(
+        name = name,
+        priceWon = priceWon,
+        description = description,
+        thumbnailFileId = thumbnailFileId,
+    )

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/Product.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/Product.kt
@@ -36,4 +36,16 @@ abstract class Product(
     fun hide() {
         visible = false
     }
+
+    fun updateCatalog(
+        newName: String?,
+        newDescription: String?,
+        newThumbnailFileId: String?,
+        newPriceWon: Int?,
+    ) {
+        newName?.let { name = it }
+        newDescription?.let { description = it }
+        newThumbnailFileId?.let { thumbnailFileId = it }
+        newPriceWon?.let { priceWon = it }
+    }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/Product.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/Product.kt
@@ -15,10 +15,16 @@ abstract class Product(
     val id: String = Ulid.generate(),
 
     @Column(nullable = false)
-    val name: String,
+    var name: String,
 
     @Column(nullable = false)
-    val priceWon: Int,
+    var priceWon: Int,
+
+    @Column(columnDefinition = "TEXT")
+    var description: String? = null,
+
+    @Column(name = "thumbnail_file_id", length = 26)
+    var thumbnailFileId: String? = null,
 
     @Column(nullable = false)
     var visible: Boolean = false,

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/course/domain/CourseTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/course/domain/CourseTest.kt
@@ -1,0 +1,98 @@
+package com.sclass.domain.domains.course.domain
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class CourseTest {
+    private fun newListedCourse(
+        maxEnrollments: Int = 1,
+        enrollmentStartAt: LocalDateTime? = null,
+        enrollmentDeadLine: LocalDateTime? = null,
+    ) = Course(
+        productId = "PRD",
+        teacherUserId = "TCH",
+        status = CourseStatus.LISTED,
+        maxEnrollments = maxEnrollments,
+        enrollmentStartAt = enrollmentStartAt,
+        enrollmentDeadLine = enrollmentDeadLine,
+    )
+
+    @Test
+    fun `LISTED 상태에 정원이 남고 기간 제약이 없으면 등록 가능하다`() {
+        assertTrue(newListedCourse().canEnroll(LocalDateTime.now(), currentCount = 0))
+    }
+
+    @Test
+    fun `DRAFT 상태면 등록 불가능하다`() {
+        val course =
+            Course(
+                productId = "PRD",
+                teacherUserId = "TCH",
+                status = CourseStatus.DRAFT,
+            )
+
+        assertFalse(course.canEnroll(LocalDateTime.now(), currentCount = 0))
+    }
+
+    @Test
+    fun `UNLISTED 상태면 등록 불가능하다`() {
+        val course = newListedCourse().also { it.unlist() }
+
+        assertFalse(course.canEnroll(LocalDateTime.now(), currentCount = 0))
+    }
+
+    @Test
+    fun `ARCHIVED 상태면 등록 불가능하다`() {
+        val course = newListedCourse().also { it.archive() }
+
+        assertFalse(course.canEnroll(LocalDateTime.now(), currentCount = 0))
+    }
+
+    @Test
+    fun `enrollmentStartAt 이전이면 등록 불가능하다`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course = newListedCourse(enrollmentStartAt = now.plusDays(1))
+
+        assertFalse(course.canEnroll(now, currentCount = 0))
+    }
+
+    @Test
+    fun `enrollmentStartAt 이후면 등록 가능하다`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course = newListedCourse(enrollmentStartAt = now.minusDays(1))
+
+        assertTrue(course.canEnroll(now, currentCount = 0))
+    }
+
+    @Test
+    fun `enrollmentDeadLine 이후면 등록 불가능하다`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course = newListedCourse(enrollmentDeadLine = now.minusDays(1))
+
+        assertFalse(course.canEnroll(now, currentCount = 0))
+    }
+
+    @Test
+    fun `enrollmentDeadLine 이전이면 등록 가능하다`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course = newListedCourse(enrollmentDeadLine = now.plusDays(1))
+
+        assertTrue(course.canEnroll(now, currentCount = 0))
+    }
+
+    @Test
+    fun `정원이 가득 차면 등록 불가능하다`() {
+        val course = newListedCourse(maxEnrollments = 3)
+
+        assertFalse(course.canEnroll(LocalDateTime.now(), currentCount = 3))
+    }
+
+    @Test
+    fun `정원이 남아있으면 등록 가능하다`() {
+        val course = newListedCourse(maxEnrollments = 3)
+
+        assertTrue(course.canEnroll(LocalDateTime.now(), currentCount = 2))
+    }
+}

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/course/domain/CourseTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/course/domain/CourseTest.kt
@@ -1,6 +1,10 @@
 package com.sclass.domain.domains.course.domain
 
+import com.sclass.domain.domains.course.exception.CourseAlreadyStartedException
+import com.sclass.domain.domains.course.exception.CourseInvalidScheduleException
+import com.sclass.domain.domains.course.exception.CourseMaxEnrollmentsTooLowException
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
@@ -94,5 +98,132 @@ class CourseTest {
         val course = newListedCourse(maxEnrollments = 3)
 
         assertTrue(course.canEnroll(LocalDateTime.now(), currentCount = 2))
+    }
+
+    @Test
+    fun `startAt 이전이면 hasStarted는 false`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course = newListedCourse().also { it.startAt = now.plusDays(1) }
+
+        assertFalse(course.hasStarted(now))
+    }
+
+    @Test
+    fun `startAt과 같거나 이후면 hasStarted는 true`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course = newListedCourse().also { it.startAt = now }
+
+        assertTrue(course.hasStarted(now))
+    }
+
+    @Test
+    fun `startAt이 null이면 hasStarted는 false`() {
+        val course = newListedCourse()
+
+        assertFalse(course.hasStarted(LocalDateTime.now()))
+    }
+
+    @Test
+    fun `이미 시작된 코스는 모집 조건을 변경할 수 없다`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course = newListedCourse().also { it.startAt = now.minusDays(1) }
+
+        assertThrows(CourseAlreadyStartedException::class.java) {
+            course.updateEnrollmentConstraints(now, newMaxEnrollments = 10, null, null, currentLiveCount = 0)
+        }
+    }
+
+    @Test
+    fun `maxEnrollments를 현재 등록자 수보다 낮추면 예외`() {
+        val course = newListedCourse(maxEnrollments = 10)
+
+        assertThrows(CourseMaxEnrollmentsTooLowException::class.java) {
+            course.updateEnrollmentConstraints(
+                now = LocalDateTime.of(2026, 4, 1, 0, 0),
+                newMaxEnrollments = 2,
+                newEnrollmentStartAt = null,
+                newEnrollmentDeadLine = null,
+                currentLiveCount = 3,
+            )
+        }
+    }
+
+    @Test
+    fun `모집 시작이 모집 마감보다 뒤면 예외`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course = newListedCourse()
+
+        assertThrows(CourseInvalidScheduleException::class.java) {
+            course.updateEnrollmentConstraints(
+                now = now,
+                newMaxEnrollments = null,
+                newEnrollmentStartAt = now.plusDays(10),
+                newEnrollmentDeadLine = now.plusDays(5),
+                currentLiveCount = 0,
+            )
+        }
+    }
+
+    @Test
+    fun `정상 입력이면 모집 조건이 반영된다`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course = newListedCourse()
+
+        course.updateEnrollmentConstraints(
+            now = now,
+            newMaxEnrollments = 20,
+            newEnrollmentStartAt = now.plusDays(1),
+            newEnrollmentDeadLine = now.plusDays(5),
+            currentLiveCount = 0,
+        )
+
+        assertTrue(course.maxEnrollments == 20)
+        assertTrue(course.enrollmentStartAt == now.plusDays(1))
+        assertTrue(course.enrollmentDeadLine == now.plusDays(5))
+    }
+
+    @Test
+    fun `이미 시작된 코스는 일정을 변경할 수 없다`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course = newListedCourse().also { it.startAt = now.minusDays(1) }
+
+        assertThrows(CourseAlreadyStartedException::class.java) {
+            course.updateSchedule(now, newStartTime = now.plusDays(1), newEndAt = now.plusDays(5))
+        }
+    }
+
+    @Test
+    fun `startAt이 endAt보다 뒤면 예외`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course = newListedCourse()
+
+        assertThrows(CourseInvalidScheduleException::class.java) {
+            course.updateSchedule(now, newStartTime = now.plusDays(10), newEndAt = now.plusDays(5))
+        }
+    }
+
+    @Test
+    fun `모집 마감이 개강보다 뒤면 예외`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course =
+            newListedCourse(
+                enrollmentStartAt = now.plusDays(1),
+                enrollmentDeadLine = now.plusDays(10),
+            )
+
+        assertThrows(CourseInvalidScheduleException::class.java) {
+            course.updateSchedule(now, newStartTime = now.plusDays(5), newEndAt = now.plusDays(30))
+        }
+    }
+
+    @Test
+    fun `정상 입력이면 일정이 반영된다`() {
+        val now = LocalDateTime.of(2026, 4, 1, 0, 0)
+        val course = newListedCourse()
+
+        course.updateSchedule(now, newStartTime = now.plusDays(10), newEndAt = now.plusDays(40))
+
+        assertTrue(course.startAt == now.plusDays(10))
+        assertTrue(course.endAt == now.plusDays(40))
     }
 }

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/course/domain/CourseTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/course/domain/CourseTest.kt
@@ -25,7 +25,7 @@ class CourseTest {
 
     @Test
     fun `LISTED 상태에 정원이 남고 기간 제약이 없으면 등록 가능하다`() {
-        assertTrue(newListedCourse().canEnroll(LocalDateTime.now(), currentCount = 0))
+        assertTrue(newListedCourse().canEnroll(LocalDateTime.now(), currentCount = 0L))
     }
 
     @Test
@@ -37,21 +37,21 @@ class CourseTest {
                 status = CourseStatus.DRAFT,
             )
 
-        assertFalse(course.canEnroll(LocalDateTime.now(), currentCount = 0))
+        assertFalse(course.canEnroll(LocalDateTime.now(), currentCount = 0L))
     }
 
     @Test
     fun `UNLISTED 상태면 등록 불가능하다`() {
         val course = newListedCourse().also { it.unlist() }
 
-        assertFalse(course.canEnroll(LocalDateTime.now(), currentCount = 0))
+        assertFalse(course.canEnroll(LocalDateTime.now(), currentCount = 0L))
     }
 
     @Test
     fun `ARCHIVED 상태면 등록 불가능하다`() {
         val course = newListedCourse().also { it.archive() }
 
-        assertFalse(course.canEnroll(LocalDateTime.now(), currentCount = 0))
+        assertFalse(course.canEnroll(LocalDateTime.now(), currentCount = 0L))
     }
 
     @Test
@@ -59,7 +59,7 @@ class CourseTest {
         val now = LocalDateTime.of(2026, 4, 1, 0, 0)
         val course = newListedCourse(enrollmentStartAt = now.plusDays(1))
 
-        assertFalse(course.canEnroll(now, currentCount = 0))
+        assertFalse(course.canEnroll(now, currentCount = 0L))
     }
 
     @Test
@@ -67,7 +67,7 @@ class CourseTest {
         val now = LocalDateTime.of(2026, 4, 1, 0, 0)
         val course = newListedCourse(enrollmentStartAt = now.minusDays(1))
 
-        assertTrue(course.canEnroll(now, currentCount = 0))
+        assertTrue(course.canEnroll(now, currentCount = 0L))
     }
 
     @Test
@@ -75,7 +75,7 @@ class CourseTest {
         val now = LocalDateTime.of(2026, 4, 1, 0, 0)
         val course = newListedCourse(enrollmentDeadLine = now.minusDays(1))
 
-        assertFalse(course.canEnroll(now, currentCount = 0))
+        assertFalse(course.canEnroll(now, currentCount = 0L))
     }
 
     @Test
@@ -83,21 +83,21 @@ class CourseTest {
         val now = LocalDateTime.of(2026, 4, 1, 0, 0)
         val course = newListedCourse(enrollmentDeadLine = now.plusDays(1))
 
-        assertTrue(course.canEnroll(now, currentCount = 0))
+        assertTrue(course.canEnroll(now, currentCount = 0L))
     }
 
     @Test
     fun `정원이 가득 차면 등록 불가능하다`() {
         val course = newListedCourse(maxEnrollments = 3)
 
-        assertFalse(course.canEnroll(LocalDateTime.now(), currentCount = 3))
+        assertFalse(course.canEnroll(LocalDateTime.now(), currentCount = 3L))
     }
 
     @Test
     fun `정원이 남아있으면 등록 가능하다`() {
         val course = newListedCourse(maxEnrollments = 3)
 
-        assertTrue(course.canEnroll(LocalDateTime.now(), currentCount = 2))
+        assertTrue(course.canEnroll(LocalDateTime.now(), currentCount = 2L))
     }
 
     @Test


### PR DESCRIPTION
## Summary
Course/CourseProduct에 카탈로그 자산·모집 제약·일정 필드를 추가하고 도메인 메서드로 등록/수정 가능 여부를 판단한다. Backoffice에 코스 수정 API, Supporters에 비로그인 카탈로그 상세 API를 추가하고 `GET /enrollments/me` 응답에 코스 요약을 얹는다.

## Changes

### 도메인
- **Course**: `maxEnrollments`, `enrollmentStartAt`, `enrollmentDeadLine`, `startAt`, `endAt` 필드
- **Course.canEnroll(now, currentCount)**: LISTED + 기간 + 정원 단일 게이트
- **Course.updateEnrollmentConstraints / updateSchedule**: `hasStarted` 이후 변경 차단 + 일관성 검증 (`enrollStart < enrollDeadline ≤ startAt < endAt`)
- **Product(공통)**: `description`, `thumbnailFileId` 를 부모 `Product`로 승격 + `updateCatalog(...)`
- **CourseProduct**: `curriculum`(TEXT) 추가 + `updateCurriculum`
- **CourseNotEnrollableException / CourseAlreadyStartedException / CourseMaxEnrollmentsTooLowException / CourseInvalidScheduleException**: 도메인 예외 정리
- **FileType.COURSE_THUMBNAIL** 추가
- **EnrollmentAdaptor.countLiveEnrollments**: PENDING_PAYMENT + ACTIVE 카운트
- **CourseCustomRepository.findCatalogCourseById**: 카탈로그 단건 (LISTED + visible) 쿼리
- **EnrollmentWithCourseDto + findAllByStudentUserIdWithCourse**: 학생의 등록 목록 + 코스/상품/교사명 조인

### API
- **Backoffice `POST /api/v1/courses`**: `description`/`curriculum`/`thumbnailFileId`/`maxEnrollments`/`enrollmentStartAt`/`enrollmentDeadLine`/`startAt`/`endAt` 수용
- **Backoffice `PUT /api/v1/courses/{courseId}`** (신규): 마케팅 자산(언제든) / 모집 제약·일정(startAt 이전) 분리 수정. null 필드는 변경 없음
- **Backoffice CourseResponse / CourseListResponse**: 신규 필드 노출
- **Supporters `GET /api/v1/catalog/courses`**: `thumbnailFileId`, `enrollmentDeadLine`, `startAt` 추가 (학생 관점)
- **Supporters `GET /api/v1/catalog/courses/{courseId}`** (신규, `@Public`): 상세 응답 = 커리큘럼/썸네일/정원/남은 좌석(`max - liveCount`, 음수 0 보정)/전체 일정 + 교사 요약
- **Supporters `GET /api/v1/courses/me`** (Role.TEACHER 전용): `maxEnrollments`, `enrollmentDeadLine`, `startAt`, `endAt` 추가
- **Supporters `GET /api/v1/enrollments/me`**: 응답에 `course` 요약 추가 (이름/설명/썸네일/교사명/상태/모집마감/수업 시작·종료). 코스 미존재 시 `course=null`

### 동시성
- **PrepareEnrollmentUseCase**: `@DistributedLock` 키를 `courseId` 단독으로 변경 (기존 courseId+studentUserId는 서로 다른 학생 동시 요청 시 정원 초과 허용)

### 테스트
- **CourseTest**: `canEnroll` 단위 테스트 10건 (상태/기간/정원)
- **UpdateCourseUseCaseTest**: 마케팅 변경 / 모집 제약 / 일정 수정 + startAt 이후 거부 + 현재 등록자 수 미만 거부
- **GetCatalogCourseDetailUseCaseTest**: 정상 + remainingSeats 음수 0 보정 + 미공개 404
- **GetMyEnrollmentsUseCaseTest**: 정상 매핑 + 코스 join null 케이스 + 빈 리스트
- **PrepareEnrollmentConcurrencyTest**: Redis testcontainer + 10 스레드 경쟁 → 정원 3명 코스에 정확히 3명만 성공

## Follow-up (별도 이슈로 분리 예정)
- 카탈로그 썸네일을 public CDN URL로 분리 — 현재 응답은 `thumbnailFileId`만 내려줘 프론트에서 `/api/v1/files/{id}/download-url` 추가 호출이 필요함. bucket policy + CloudFront + 업로드 경로 분기까지 필요한 작업이라 별도 PR로 뺀다

## Affected Modules
- [ ] SClass-Common
- [x] SClass-Domain
- [ ] SClass-Infrastructure
- [x] SClass-Api-Supporters
- [x] SClass-Api-Backoffice
- [ ] SClass-Batch

## Test Plan
- [x] `./gradlew clean build` 빌드 성공
- [x] `./gradlew ktlintCheck` 통과
- [x] `PrepareEnrollmentConcurrencyTest` 통과 (정원 3 / 동시 10 → 3명 성공)
- [x] `CourseTest` 10건 통과
- [x] `UpdateCourseUseCaseTest` 통과
- [x] `GetCatalogCourseDetailUseCaseTest` 통과
- [x] `GetMyEnrollmentsUseCaseTest` 통과

## Checklist
- [x] CLAUDE.md 컨벤션 준수
- [x] 불필요한 파일 미포함

Closes #241