### PR TITLE
feat(membership): MembershipProduct 도입 + 구매 플로우 + 카탈로그/백오피스 (#255)

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/EnrollmentPageResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/EnrollmentPageResponse.kt
@@ -14,7 +14,7 @@ data class EnrollmentPageResponse(
 
 data class EnrollmentListResponse(
     val id: Long,
-    val courseId: Long,
+    val courseId: Long?,
     val courseName: String,
     val studentUserId: String,
     val studentName: String,

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/EnrollmentResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/EnrollmentResponse.kt
@@ -6,7 +6,7 @@ import com.sclass.domain.domains.enrollment.domain.EnrollmentType
 
 data class EnrollmentResponse(
     val id: Long,
-    val courseId: Long,
+    val courseId: Long?,
     val studentUserId: String,
     val enrollmentType: EnrollmentType,
     val tuitionAmountWon: Int,

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/controller/MembershipProductController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/controller/MembershipProductController.kt
@@ -1,0 +1,52 @@
+package com.sclass.backoffice.membershipproduct.controller
+
+import com.sclass.backoffice.membershipproduct.dto.CreateMembershipProductRequest
+import com.sclass.backoffice.membershipproduct.dto.MembershipProductPageResponse
+import com.sclass.backoffice.membershipproduct.dto.MembershipProductResponse
+import com.sclass.backoffice.membershipproduct.dto.UpdateMembershipProductRequest
+import com.sclass.backoffice.membershipproduct.usecase.CreateMembershipProductUseCase
+import com.sclass.backoffice.membershipproduct.usecase.GetMembershipProductDetailUseCase
+import com.sclass.backoffice.membershipproduct.usecase.GetMembershipProductListUseCase
+import com.sclass.backoffice.membershipproduct.usecase.UpdateMembershipProductUseCase
+import com.sclass.common.dto.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/membership-products")
+class MembershipProductController(
+    private val createMembershipProductUseCase: CreateMembershipProductUseCase,
+    private val updateMembershipProductUseCase: UpdateMembershipProductUseCase,
+    private val getMembershipProductListUseCase: GetMembershipProductListUseCase,
+    private val getMembershipProductDetailUseCase: GetMembershipProductDetailUseCase,
+) {
+    @PostMapping
+    fun create(
+        @Valid @RequestBody request: CreateMembershipProductRequest,
+    ): ApiResponse<MembershipProductResponse> = ApiResponse.success(createMembershipProductUseCase.execute(request))
+
+    @GetMapping
+    fun getList(
+        @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
+    ): ApiResponse<MembershipProductPageResponse> = ApiResponse.success(getMembershipProductListUseCase.execute(pageable))
+
+    @GetMapping("/{productId}")
+    fun getDetail(
+        @PathVariable productId: String,
+    ): ApiResponse<MembershipProductResponse> = ApiResponse.success(getMembershipProductDetailUseCase.execute(productId))
+
+    @PutMapping("/{productId}")
+    fun update(
+        @PathVariable productId: String,
+        @Valid @RequestBody request: UpdateMembershipProductRequest,
+    ): ApiResponse<MembershipProductResponse> = ApiResponse.success(updateMembershipProductUseCase.execute(productId, request))
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/dto/CreateMembershipProductRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/dto/CreateMembershipProductRequest.kt
@@ -1,0 +1,15 @@
+package com.sclass.backoffice.membershipproduct.dto
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CreateMembershipProductRequest(
+    @field:NotBlank @field:Size(max = 200) val name: String,
+    val description: String? = null,
+    val thumbnailFileId: String? = null,
+    @field:Min(0) val priceWon: Int,
+    @field:Min(1) val periodDays: Int,
+    @field:Min(1) val maxEnrollments: Int? = null,
+    @field:NotBlank val coinPackageId: String,
+)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/dto/MembershipProductPageResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/dto/MembershipProductPageResponse.kt
@@ -1,0 +1,8 @@
+package com.sclass.backoffice.membershipproduct.dto
+
+data class MembershipProductPageResponse(
+    val content: List<MembershipProductResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/dto/MembershipProductResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/dto/MembershipProductResponse.kt
@@ -1,0 +1,37 @@
+package com.sclass.backoffice.membershipproduct.dto
+
+import com.sclass.domain.domains.product.domain.MembershipProduct
+
+data class MembershipProductResponse(
+    val productId: String,
+    val name: String,
+    val description: String?,
+    val thumbnailFileId: String?,
+    val thumbnailUrl: String?,
+    val priceWon: Int,
+    val periodDays: Int,
+    val maxEnrollments: Int?,
+    val coinPackageId: String,
+    val coinAmount: Int,
+    val visible: Boolean,
+) {
+    companion object {
+        fun from(
+            product: MembershipProduct,
+            thumbnailUrl: String?,
+            coinAmount: Int,
+        ) = MembershipProductResponse(
+            productId = product.id,
+            name = product.name,
+            description = product.description,
+            thumbnailFileId = product.thumbnailFileId,
+            thumbnailUrl = thumbnailUrl,
+            priceWon = product.priceWon,
+            periodDays = product.periodDays,
+            maxEnrollments = product.maxEnrollments,
+            coinPackageId = product.coinPackageId,
+            coinAmount = coinAmount,
+            visible = product.visible,
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/dto/UpdateMembershipProductRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/dto/UpdateMembershipProductRequest.kt
@@ -1,0 +1,14 @@
+package com.sclass.backoffice.membershipproduct.dto
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Size
+
+data class UpdateMembershipProductRequest(
+    @field:Size(max = 200) val name: String? = null,
+    val description: String? = null,
+    val thumbnailFileId: String? = null,
+    @field:Min(0) val priceWon: Int? = null,
+    @field:Min(1) val periodDays: Int? = null,
+    @field:Min(1) val maxEnrollments: Int? = null,
+    val coinPackageId: String? = null,
+)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/usecase/CreateMembershipProductUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/usecase/CreateMembershipProductUseCase.kt
@@ -1,0 +1,39 @@
+package com.sclass.backoffice.membershipproduct.usecase
+
+import com.sclass.backoffice.membershipproduct.dto.CreateMembershipProductRequest
+import com.sclass.backoffice.membershipproduct.dto.MembershipProductResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.MembershipProduct
+import com.sclass.infrastructure.s3.ThumbnailUrlResolver
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class CreateMembershipProductUseCase(
+    private val productAdaptor: ProductAdaptor,
+    private val coinPackageAdaptor: CoinPackageAdaptor,
+    private val thumbnailUrlResolver: ThumbnailUrlResolver,
+) {
+    @Transactional
+    fun execute(request: CreateMembershipProductRequest): MembershipProductResponse {
+        val coinPackage = coinPackageAdaptor.findById(request.coinPackageId)
+        val product =
+            productAdaptor.save(
+                MembershipProduct(
+                    name = request.name,
+                    priceWon = request.priceWon,
+                    description = request.description,
+                    thumbnailFileId = request.thumbnailFileId,
+                    periodDays = request.periodDays,
+                    maxEnrollments = request.maxEnrollments,
+                    coinPackageId = request.coinPackageId,
+                ),
+            ) as MembershipProduct
+        return MembershipProductResponse.from(
+            product = product,
+            thumbnailUrl = thumbnailUrlResolver.resolve(product.thumbnailFileId),
+            coinAmount = coinPackage.coinAmount,
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/usecase/GetMembershipProductDetailUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/usecase/GetMembershipProductDetailUseCase.kt
@@ -1,0 +1,30 @@
+package com.sclass.backoffice.membershipproduct.usecase
+
+import com.sclass.backoffice.membershipproduct.dto.MembershipProductResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.MembershipProduct
+import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
+import com.sclass.infrastructure.s3.ThumbnailUrlResolver
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetMembershipProductDetailUseCase(
+    private val productAdaptor: ProductAdaptor,
+    private val coinPackageAdaptor: CoinPackageAdaptor,
+    private val thumbnailUrlResolver: ThumbnailUrlResolver,
+) {
+    @Transactional(readOnly = true)
+    fun execute(productId: String): MembershipProductResponse {
+        val product =
+            productAdaptor.findById(productId) as? MembershipProduct
+                ?: throw ProductTypeMismatchException()
+        val coinPackage = coinPackageAdaptor.findById(product.coinPackageId)
+        return MembershipProductResponse.from(
+            product = product,
+            thumbnailUrl = thumbnailUrlResolver.resolve(product.thumbnailFileId),
+            coinAmount = coinPackage.coinAmount,
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/usecase/GetMembershipProductListUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/usecase/GetMembershipProductListUseCase.kt
@@ -1,0 +1,37 @@
+package com.sclass.backoffice.membershipproduct.usecase
+
+import com.sclass.backoffice.membershipproduct.dto.MembershipProductPageResponse
+import com.sclass.backoffice.membershipproduct.dto.MembershipProductResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.infrastructure.s3.ThumbnailUrlResolver
+import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetMembershipProductListUseCase(
+    private val productAdaptor: ProductAdaptor,
+    private val coinPackageAdaptor: CoinPackageAdaptor,
+    private val thumbnailUrlResolver: ThumbnailUrlResolver,
+) {
+    @Transactional(readOnly = true)
+    fun execute(pageable: Pageable): MembershipProductPageResponse {
+        val page = productAdaptor.findAllMemberships(pageable)
+        val content =
+            page.content.map { product ->
+                val coinPackage = coinPackageAdaptor.findById(product.coinPackageId)
+                MembershipProductResponse.from(
+                    product = product,
+                    thumbnailUrl = thumbnailUrlResolver.resolve(product.thumbnailFileId),
+                    coinAmount = coinPackage.coinAmount,
+                )
+            }
+        return MembershipProductPageResponse(
+            content = content,
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+            currentPage = page.number,
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/usecase/GetMembershipProductListUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/usecase/GetMembershipProductListUseCase.kt
@@ -3,7 +3,6 @@ package com.sclass.backoffice.membershipproduct.usecase
 import com.sclass.backoffice.membershipproduct.dto.MembershipProductPageResponse
 import com.sclass.backoffice.membershipproduct.dto.MembershipProductResponse
 import com.sclass.common.annotation.UseCase
-import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
 import com.sclass.infrastructure.s3.ThumbnailUrlResolver
 import org.springframework.data.domain.Pageable
@@ -12,19 +11,17 @@ import org.springframework.transaction.annotation.Transactional
 @UseCase
 class GetMembershipProductListUseCase(
     private val productAdaptor: ProductAdaptor,
-    private val coinPackageAdaptor: CoinPackageAdaptor,
     private val thumbnailUrlResolver: ThumbnailUrlResolver,
 ) {
     @Transactional(readOnly = true)
     fun execute(pageable: Pageable): MembershipProductPageResponse {
-        val page = productAdaptor.findAllMemberships(pageable)
+        val page = productAdaptor.findMembershipsWithCoinPackage(visibleOnly = false, pageable = pageable)
         val content =
-            page.content.map { product ->
-                val coinPackage = coinPackageAdaptor.findById(product.coinPackageId)
+            page.content.map { row ->
                 MembershipProductResponse.from(
-                    product = product,
-                    thumbnailUrl = thumbnailUrlResolver.resolve(product.thumbnailFileId),
-                    coinAmount = coinPackage.coinAmount,
+                    product = row.product,
+                    thumbnailUrl = thumbnailUrlResolver.resolve(row.product.thumbnailFileId),
+                    coinAmount = row.coinPackage?.coinAmount ?: 0,
                 )
             }
         return MembershipProductPageResponse(

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/usecase/UpdateMembershipProductUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/usecase/UpdateMembershipProductUseCase.kt
@@ -25,7 +25,7 @@ class UpdateMembershipProductUseCase(
             productAdaptor.findById(productId) as? MembershipProduct
                 ?: throw ProductTypeMismatchException()
 
-        request.coinPackageId?.let { coinPackageAdaptor.findById(it) }
+        val newCoinPackage = request.coinPackageId?.let { coinPackageAdaptor.findById(it) }
 
         product.updateCatalog(
             newName = request.name,
@@ -39,7 +39,7 @@ class UpdateMembershipProductUseCase(
             newCoinPackageId = request.coinPackageId,
         )
 
-        val coinPackage = coinPackageAdaptor.findById(product.coinPackageId)
+        val coinPackage = newCoinPackage ?: coinPackageAdaptor.findById(product.coinPackageId)
         return MembershipProductResponse.from(
             product = product,
             thumbnailUrl = thumbnailUrlResolver.resolve(product.thumbnailFileId),

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/usecase/UpdateMembershipProductUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/membershipproduct/usecase/UpdateMembershipProductUseCase.kt
@@ -1,0 +1,49 @@
+package com.sclass.backoffice.membershipproduct.usecase
+
+import com.sclass.backoffice.membershipproduct.dto.MembershipProductResponse
+import com.sclass.backoffice.membershipproduct.dto.UpdateMembershipProductRequest
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.MembershipProduct
+import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
+import com.sclass.infrastructure.s3.ThumbnailUrlResolver
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class UpdateMembershipProductUseCase(
+    private val productAdaptor: ProductAdaptor,
+    private val coinPackageAdaptor: CoinPackageAdaptor,
+    private val thumbnailUrlResolver: ThumbnailUrlResolver,
+) {
+    @Transactional
+    fun execute(
+        productId: String,
+        request: UpdateMembershipProductRequest,
+    ): MembershipProductResponse {
+        val product =
+            productAdaptor.findById(productId) as? MembershipProduct
+                ?: throw ProductTypeMismatchException()
+
+        request.coinPackageId?.let { coinPackageAdaptor.findById(it) }
+
+        product.updateCatalog(
+            newName = request.name,
+            newDescription = request.description,
+            newThumbnailFileId = request.thumbnailFileId,
+            newPriceWon = request.priceWon,
+        )
+        product.updateMembership(
+            newPeriodDays = request.periodDays,
+            newMaxEnrollments = request.maxEnrollments,
+            newCoinPackageId = request.coinPackageId,
+        )
+
+        val coinPackage = coinPackageAdaptor.findById(product.coinPackageId)
+        return MembershipProductResponse.from(
+            product = product,
+            thumbnailUrl = thumbnailUrlResolver.resolve(product.thumbnailFileId),
+            coinAmount = coinPackage.coinAmount,
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/membershipproduct/usecase/CreateMembershipProductUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/membershipproduct/usecase/CreateMembershipProductUseCaseTest.kt
@@ -1,0 +1,74 @@
+package com.sclass.backoffice.membershipproduct.usecase
+
+import com.sclass.backoffice.membershipproduct.dto.CreateMembershipProductRequest
+import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.coin.domain.CoinPackage
+import com.sclass.domain.domains.coin.exception.CoinPackageNotFoundException
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.MembershipProduct
+import com.sclass.infrastructure.s3.ThumbnailUrlResolver
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CreateMembershipProductUseCaseTest {
+    private lateinit var productAdaptor: ProductAdaptor
+    private lateinit var coinPackageAdaptor: CoinPackageAdaptor
+    private lateinit var thumbnailUrlResolver: ThumbnailUrlResolver
+    private lateinit var useCase: CreateMembershipProductUseCase
+
+    @BeforeEach
+    fun setUp() {
+        productAdaptor = mockk()
+        coinPackageAdaptor = mockk()
+        thumbnailUrlResolver = mockk()
+        useCase = CreateMembershipProductUseCase(productAdaptor, coinPackageAdaptor, thumbnailUrlResolver)
+    }
+
+    @Test
+    fun `MembershipProduct가 생성되고 coinAmount가 응답에 포함된다`() {
+        val coinPackage = CoinPackage(name = "코인 1000", priceWon = 10000, coinAmount = 1000)
+        val captured = slot<MembershipProduct>()
+        every { coinPackageAdaptor.findById("cp-001") } returns coinPackage
+        every { productAdaptor.save(capture(captured)) } answers { captured.captured }
+        every { thumbnailUrlResolver.resolve(any()) } returns null
+
+        val result =
+            useCase.execute(
+                CreateMembershipProductRequest(
+                    name = "프리미엄",
+                    priceWon = 10000,
+                    periodDays = 30,
+                    maxEnrollments = 100,
+                    coinPackageId = "cp-001",
+                ),
+            )
+
+        assertThat(result.name).isEqualTo("프리미엄")
+        assertThat(result.periodDays).isEqualTo(30)
+        assertThat(result.maxEnrollments).isEqualTo(100)
+        assertThat(result.coinPackageId).isEqualTo("cp-001")
+        assertThat(result.coinAmount).isEqualTo(1000)
+        assertThat(captured.captured.priceWon).isEqualTo(10000)
+    }
+
+    @Test
+    fun `coinPackageId가 존재하지 않으면 CoinPackageNotFoundException이 발생한다`() {
+        every { coinPackageAdaptor.findById("cp-missing") } throws CoinPackageNotFoundException()
+
+        assertThatThrownBy {
+            useCase.execute(
+                CreateMembershipProductRequest(
+                    name = "프리미엄",
+                    priceWon = 10000,
+                    periodDays = 30,
+                    coinPackageId = "cp-missing",
+                ),
+            )
+        }.isInstanceOf(CoinPackageNotFoundException::class.java)
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/membershipproduct/usecase/GetMembershipProductDetailUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/membershipproduct/usecase/GetMembershipProductDetailUseCaseTest.kt
@@ -1,0 +1,60 @@
+package com.sclass.backoffice.membershipproduct.usecase
+
+import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.coin.domain.CoinPackage
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.product.domain.MembershipProduct
+import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
+import com.sclass.infrastructure.s3.ThumbnailUrlResolver
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GetMembershipProductDetailUseCaseTest {
+    private lateinit var productAdaptor: ProductAdaptor
+    private lateinit var coinPackageAdaptor: CoinPackageAdaptor
+    private lateinit var thumbnailUrlResolver: ThumbnailUrlResolver
+    private lateinit var useCase: GetMembershipProductDetailUseCase
+
+    @BeforeEach
+    fun setUp() {
+        productAdaptor = mockk()
+        coinPackageAdaptor = mockk()
+        thumbnailUrlResolver = mockk()
+        useCase = GetMembershipProductDetailUseCase(productAdaptor, coinPackageAdaptor, thumbnailUrlResolver)
+    }
+
+    @Test
+    fun `비공개 상태라도 admin은 상세를 조회할 수 있다`() {
+        val product =
+            MembershipProduct(
+                name = "프리미엄",
+                priceWon = 10000,
+                periodDays = 30,
+                coinPackageId = "cp-001",
+            )
+        val coinPackage = CoinPackage(name = "코인 1000", priceWon = 10000, coinAmount = 1000)
+        every { productAdaptor.findById(product.id) } returns product
+        every { coinPackageAdaptor.findById("cp-001") } returns coinPackage
+        every { thumbnailUrlResolver.resolve(any()) } returns null
+
+        val result = useCase.execute(product.id)
+
+        assertThat(result.productId).isEqualTo(product.id)
+        assertThat(result.visible).isFalse()
+        assertThat(result.coinAmount).isEqualTo(1000)
+    }
+
+    @Test
+    fun `MembershipProduct가 아니면 ProductTypeMismatchException이 발생한다`() {
+        val courseProduct = CourseProduct(name = "수학", priceWon = 10000, totalLessons = 12)
+        every { productAdaptor.findById(any()) } returns courseProduct
+
+        assertThatThrownBy { useCase.execute("some-id") }
+            .isInstanceOf(ProductTypeMismatchException::class.java)
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/membershipproduct/usecase/GetMembershipProductListUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/membershipproduct/usecase/GetMembershipProductListUseCaseTest.kt
@@ -1,9 +1,9 @@
 package com.sclass.backoffice.membershipproduct.usecase
 
-import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
 import com.sclass.domain.domains.coin.domain.CoinPackage
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
 import com.sclass.domain.domains.product.domain.MembershipProduct
+import com.sclass.domain.domains.product.dto.MembershipProductWithCoinPackageDto
 import com.sclass.infrastructure.s3.ThumbnailUrlResolver
 import io.mockk.every
 import io.mockk.mockk
@@ -15,16 +15,14 @@ import org.springframework.data.domain.PageRequest
 
 class GetMembershipProductListUseCaseTest {
     private lateinit var productAdaptor: ProductAdaptor
-    private lateinit var coinPackageAdaptor: CoinPackageAdaptor
     private lateinit var thumbnailUrlResolver: ThumbnailUrlResolver
     private lateinit var useCase: GetMembershipProductListUseCase
 
     @BeforeEach
     fun setUp() {
         productAdaptor = mockk()
-        coinPackageAdaptor = mockk()
         thumbnailUrlResolver = mockk()
-        useCase = GetMembershipProductListUseCase(productAdaptor, coinPackageAdaptor, thumbnailUrlResolver)
+        useCase = GetMembershipProductListUseCase(productAdaptor, thumbnailUrlResolver)
     }
 
     @Test
@@ -34,9 +32,20 @@ class GetMembershipProductListUseCaseTest {
         val hidden =
             MembershipProduct(name = "B", priceWon = 20000, periodDays = 60, coinPackageId = "cp-2")
         val pageable = PageRequest.of(0, 20)
-        every { productAdaptor.findAllMemberships(pageable) } returns PageImpl(listOf(visible, hidden), pageable, 2)
-        every { coinPackageAdaptor.findById("cp-1") } returns CoinPackage(name = "1", priceWon = 10000, coinAmount = 1000)
-        every { coinPackageAdaptor.findById("cp-2") } returns CoinPackage(name = "2", priceWon = 20000, coinAmount = 2000)
+        val rows =
+            listOf(
+                MembershipProductWithCoinPackageDto(
+                    product = visible,
+                    coinPackage = CoinPackage(name = "1", priceWon = 10000, coinAmount = 1000),
+                ),
+                MembershipProductWithCoinPackageDto(
+                    product = hidden,
+                    coinPackage = CoinPackage(name = "2", priceWon = 20000, coinAmount = 2000),
+                ),
+            )
+        every {
+            productAdaptor.findMembershipsWithCoinPackage(visibleOnly = false, pageable = pageable)
+        } returns PageImpl(rows, pageable, 2)
         every { thumbnailUrlResolver.resolve(any()) } returns null
 
         val result = useCase.execute(pageable)

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/membershipproduct/usecase/GetMembershipProductListUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/membershipproduct/usecase/GetMembershipProductListUseCaseTest.kt
@@ -1,0 +1,51 @@
+package com.sclass.backoffice.membershipproduct.usecase
+
+import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.coin.domain.CoinPackage
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.MembershipProduct
+import com.sclass.infrastructure.s3.ThumbnailUrlResolver
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+class GetMembershipProductListUseCaseTest {
+    private lateinit var productAdaptor: ProductAdaptor
+    private lateinit var coinPackageAdaptor: CoinPackageAdaptor
+    private lateinit var thumbnailUrlResolver: ThumbnailUrlResolver
+    private lateinit var useCase: GetMembershipProductListUseCase
+
+    @BeforeEach
+    fun setUp() {
+        productAdaptor = mockk()
+        coinPackageAdaptor = mockk()
+        thumbnailUrlResolver = mockk()
+        useCase = GetMembershipProductListUseCase(productAdaptor, coinPackageAdaptor, thumbnailUrlResolver)
+    }
+
+    @Test
+    fun `페이지 내용과 각 항목의 coinAmount가 매핑된다`() {
+        val visible =
+            MembershipProduct(name = "A", priceWon = 10000, periodDays = 30, coinPackageId = "cp-1").also { it.show() }
+        val hidden =
+            MembershipProduct(name = "B", priceWon = 20000, periodDays = 60, coinPackageId = "cp-2")
+        val pageable = PageRequest.of(0, 20)
+        every { productAdaptor.findAllMemberships(pageable) } returns PageImpl(listOf(visible, hidden), pageable, 2)
+        every { coinPackageAdaptor.findById("cp-1") } returns CoinPackage(name = "1", priceWon = 10000, coinAmount = 1000)
+        every { coinPackageAdaptor.findById("cp-2") } returns CoinPackage(name = "2", priceWon = 20000, coinAmount = 2000)
+        every { thumbnailUrlResolver.resolve(any()) } returns null
+
+        val result = useCase.execute(pageable)
+
+        assertThat(result.content).hasSize(2)
+        assertThat(result.totalElements).isEqualTo(2)
+        assertThat(result.content[0].coinAmount).isEqualTo(1000)
+        assertThat(result.content[0].visible).isTrue()
+        assertThat(result.content[1].coinAmount).isEqualTo(2000)
+        assertThat(result.content[1].visible).isFalse()
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/membershipproduct/usecase/UpdateMembershipProductUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/membershipproduct/usecase/UpdateMembershipProductUseCaseTest.kt
@@ -1,0 +1,110 @@
+package com.sclass.backoffice.membershipproduct.usecase
+
+import com.sclass.backoffice.membershipproduct.dto.UpdateMembershipProductRequest
+import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.coin.domain.CoinPackage
+import com.sclass.domain.domains.coin.exception.CoinPackageNotFoundException
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.product.domain.MembershipProduct
+import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
+import com.sclass.infrastructure.s3.ThumbnailUrlResolver
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UpdateMembershipProductUseCaseTest {
+    private lateinit var productAdaptor: ProductAdaptor
+    private lateinit var coinPackageAdaptor: CoinPackageAdaptor
+    private lateinit var thumbnailUrlResolver: ThumbnailUrlResolver
+    private lateinit var useCase: UpdateMembershipProductUseCase
+
+    @BeforeEach
+    fun setUp() {
+        productAdaptor = mockk()
+        coinPackageAdaptor = mockk()
+        thumbnailUrlResolver = mockk()
+        useCase = UpdateMembershipProductUseCase(productAdaptor, coinPackageAdaptor, thumbnailUrlResolver)
+    }
+
+    private fun existing() =
+        MembershipProduct(
+            name = "기존",
+            priceWon = 5000,
+            periodDays = 30,
+            maxEnrollments = 50,
+            coinPackageId = "cp-old",
+        )
+
+    @Test
+    fun `부분 업데이트가 반영된다`() {
+        val product = existing()
+        val coinPackage = CoinPackage(name = "코인 1000", priceWon = 10000, coinAmount = 1000)
+        every { productAdaptor.findById(product.id) } returns product
+        every { coinPackageAdaptor.findById("cp-old") } returns coinPackage
+        every { thumbnailUrlResolver.resolve(any()) } returns null
+
+        val result =
+            useCase.execute(
+                product.id,
+                UpdateMembershipProductRequest(
+                    name = "업데이트",
+                    priceWon = 15000,
+                    periodDays = 60,
+                ),
+            )
+
+        assertThat(result.name).isEqualTo("업데이트")
+        assertThat(result.priceWon).isEqualTo(15000)
+        assertThat(result.periodDays).isEqualTo(60)
+        assertThat(result.maxEnrollments).isEqualTo(50)
+        assertThat(result.coinPackageId).isEqualTo("cp-old")
+    }
+
+    @Test
+    fun `coinPackageId 변경 시 새 coinPackage 존재 여부를 검증한다`() {
+        val product = existing()
+        val newCoinPackage = CoinPackage(name = "코인 2000", priceWon = 20000, coinAmount = 2000)
+        every { productAdaptor.findById(product.id) } returns product
+        every { coinPackageAdaptor.findById("cp-new") } returns newCoinPackage
+        every { thumbnailUrlResolver.resolve(any()) } returns null
+
+        val result =
+            useCase.execute(
+                product.id,
+                UpdateMembershipProductRequest(coinPackageId = "cp-new"),
+            )
+
+        assertThat(result.coinPackageId).isEqualTo("cp-new")
+        assertThat(result.coinAmount).isEqualTo(2000)
+        verify(atLeast = 1) { coinPackageAdaptor.findById("cp-new") }
+    }
+
+    @Test
+    fun `새 coinPackage가 없으면 CoinPackageNotFoundException이 발생한다`() {
+        val product = existing()
+        every { productAdaptor.findById(product.id) } returns product
+        every { coinPackageAdaptor.findById("cp-missing") } throws CoinPackageNotFoundException()
+
+        assertThatThrownBy {
+            useCase.execute(
+                product.id,
+                UpdateMembershipProductRequest(coinPackageId = "cp-missing"),
+            )
+        }.isInstanceOf(CoinPackageNotFoundException::class.java)
+    }
+
+    @Test
+    fun `MembershipProduct가 아니면 ProductTypeMismatchException이 발생한다`() {
+        val courseProduct = CourseProduct(name = "수학", priceWon = 10000, totalLessons = 12)
+        every { productAdaptor.findById(any()) } returns courseProduct
+
+        assertThatThrownBy {
+            useCase.execute("some-id", UpdateMembershipProductRequest(name = "x"))
+        }.isInstanceOf(ProductTypeMismatchException::class.java)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/controller/CatalogController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/controller/CatalogController.kt
@@ -4,8 +4,12 @@ import com.sclass.common.annotation.Public
 import com.sclass.common.dto.ApiResponse
 import com.sclass.supporters.catalog.dto.CatalogCourseDetailResponse
 import com.sclass.supporters.catalog.dto.CatalogCoursePageResponse
+import com.sclass.supporters.catalog.dto.CatalogMembershipPageResponse
+import com.sclass.supporters.catalog.dto.CatalogMembershipResponse
 import com.sclass.supporters.catalog.usecase.GetCatalogCourseDetailUseCase
 import com.sclass.supporters.catalog.usecase.GetCatalogCourseListUseCase
+import com.sclass.supporters.catalog.usecase.GetCatalogMembershipDetailUseCase
+import com.sclass.supporters.catalog.usecase.GetCatalogMembershipListUseCase
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
@@ -20,6 +24,8 @@ import org.springframework.web.bind.annotation.RestController
 class CatalogController(
     private val getCatalogCourseListUseCase: GetCatalogCourseListUseCase,
     private val getCatalogCourseDetailUseCase: GetCatalogCourseDetailUseCase,
+    private val getCatalogMembershipListUseCase: GetCatalogMembershipListUseCase,
+    private val getCatalogMembershipDetailUseCase: GetCatalogMembershipDetailUseCase,
 ) {
     @GetMapping("/courses")
     fun getCourseList(
@@ -30,4 +36,14 @@ class CatalogController(
     fun getCourseDetail(
         @PathVariable courseId: Long,
     ): ApiResponse<CatalogCourseDetailResponse> = ApiResponse.success(getCatalogCourseDetailUseCase.execute(courseId))
+
+    @GetMapping("/memberships")
+    fun getMembershipList(
+        @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
+    ): ApiResponse<CatalogMembershipPageResponse> = ApiResponse.success(getCatalogMembershipListUseCase.execute(pageable))
+
+    @GetMapping("/memberships/{productId}")
+    fun getMembershipDetail(
+        @PathVariable productId: String,
+    ): ApiResponse<CatalogMembershipResponse> = ApiResponse.success(getCatalogMembershipDetailUseCase.execute(productId))
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/dto/CatalogMembershipPageResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/dto/CatalogMembershipPageResponse.kt
@@ -1,0 +1,8 @@
+package com.sclass.supporters.catalog.dto
+
+data class CatalogMembershipPageResponse(
+    val content: List<CatalogMembershipResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/dto/CatalogMembershipResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/dto/CatalogMembershipResponse.kt
@@ -1,0 +1,13 @@
+package com.sclass.supporters.catalog.dto
+
+data class CatalogMembershipResponse(
+    val productId: String,
+    val name: String,
+    val description: String?,
+    val thumbnailUrl: String?,
+    val priceWon: Int,
+    val periodDays: Int,
+    val maxEnrollments: Int?,
+    val remainingSeats: Long?,
+    val coinAmount: Int,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/usecase/GetCatalogMembershipDetailUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/usecase/GetCatalogMembershipDetailUseCase.kt
@@ -1,0 +1,46 @@
+package com.sclass.supporters.catalog.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.MembershipProduct
+import com.sclass.domain.domains.product.exception.ProductNotFoundException
+import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
+import com.sclass.infrastructure.s3.ThumbnailUrlResolver
+import com.sclass.supporters.catalog.dto.CatalogMembershipResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetCatalogMembershipDetailUseCase(
+    private val productAdaptor: ProductAdaptor,
+    private val coinPackageAdaptor: CoinPackageAdaptor,
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val thumbnailUrlResolver: ThumbnailUrlResolver,
+) {
+    @Transactional(readOnly = true)
+    fun execute(productId: String): CatalogMembershipResponse {
+        val product =
+            productAdaptor.findById(productId) as? MembershipProduct
+                ?: throw ProductTypeMismatchException()
+        if (!product.visible) throw ProductNotFoundException()
+
+        val coinPackage = coinPackageAdaptor.findById(product.coinPackageId)
+        val remaining =
+            product.maxEnrollments?.let { cap ->
+                val live = enrollmentAdaptor.countLiveMembershipEnrollments(product.id)
+                (cap - live).coerceAtLeast(0L)
+            }
+        return CatalogMembershipResponse(
+            productId = product.id,
+            name = product.name,
+            description = product.description,
+            thumbnailUrl = thumbnailUrlResolver.resolve(product.thumbnailFileId),
+            priceWon = product.priceWon,
+            periodDays = product.periodDays,
+            maxEnrollments = product.maxEnrollments,
+            remainingSeats = remaining,
+            coinAmount = coinPackage.coinAmount,
+        )
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/usecase/GetCatalogMembershipListUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/usecase/GetCatalogMembershipListUseCase.kt
@@ -1,7 +1,6 @@
 package com.sclass.supporters.catalog.usecase
 
 import com.sclass.common.annotation.UseCase
-import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
 import com.sclass.infrastructure.s3.ThumbnailUrlResolver
@@ -13,19 +12,27 @@ import org.springframework.transaction.annotation.Transactional
 @UseCase
 class GetCatalogMembershipListUseCase(
     private val productAdaptor: ProductAdaptor,
-    private val coinPackageAdaptor: CoinPackageAdaptor,
     private val enrollmentAdaptor: EnrollmentAdaptor,
     private val thumbnailUrlResolver: ThumbnailUrlResolver,
 ) {
     @Transactional(readOnly = true)
     fun execute(pageable: Pageable): CatalogMembershipPageResponse {
-        val page = productAdaptor.findVisibleMemberships(pageable)
+        val page = productAdaptor.findMembershipsWithCoinPackage(visibleOnly = true, pageable = pageable)
+
+        val productIdsWithCap = page.content.filter { it.product.maxEnrollments != null }.map { it.product.id }
+        val liveCounts =
+            if (productIdsWithCap.isNotEmpty()) {
+                enrollmentAdaptor.countLiveMembershipEnrollmentsByProductIds(productIdsWithCap)
+            } else {
+                emptyMap()
+            }
+
         val content =
-            page.content.map { product ->
-                val coinPackage = coinPackageAdaptor.findById(product.coinPackageId)
+            page.content.map { row ->
+                val product = row.product
                 val remaining =
                     product.maxEnrollments?.let { cap ->
-                        val live = enrollmentAdaptor.countLiveMembershipEnrollments(product.id)
+                        val live = liveCounts[product.id] ?: 0L
                         (cap - live).coerceAtLeast(0L)
                     }
                 CatalogMembershipResponse(
@@ -37,7 +44,7 @@ class GetCatalogMembershipListUseCase(
                     periodDays = product.periodDays,
                     maxEnrollments = product.maxEnrollments,
                     remainingSeats = remaining,
-                    coinAmount = coinPackage.coinAmount,
+                    coinAmount = row.coinPackage?.coinAmount ?: 0,
                 )
             }
         return CatalogMembershipPageResponse(

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/usecase/GetCatalogMembershipListUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/catalog/usecase/GetCatalogMembershipListUseCase.kt
@@ -1,0 +1,50 @@
+package com.sclass.supporters.catalog.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.infrastructure.s3.ThumbnailUrlResolver
+import com.sclass.supporters.catalog.dto.CatalogMembershipPageResponse
+import com.sclass.supporters.catalog.dto.CatalogMembershipResponse
+import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetCatalogMembershipListUseCase(
+    private val productAdaptor: ProductAdaptor,
+    private val coinPackageAdaptor: CoinPackageAdaptor,
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val thumbnailUrlResolver: ThumbnailUrlResolver,
+) {
+    @Transactional(readOnly = true)
+    fun execute(pageable: Pageable): CatalogMembershipPageResponse {
+        val page = productAdaptor.findVisibleMemberships(pageable)
+        val content =
+            page.content.map { product ->
+                val coinPackage = coinPackageAdaptor.findById(product.coinPackageId)
+                val remaining =
+                    product.maxEnrollments?.let { cap ->
+                        val live = enrollmentAdaptor.countLiveMembershipEnrollments(product.id)
+                        (cap - live).coerceAtLeast(0L)
+                    }
+                CatalogMembershipResponse(
+                    productId = product.id,
+                    name = product.name,
+                    description = product.description,
+                    thumbnailUrl = thumbnailUrlResolver.resolve(product.thumbnailFileId),
+                    priceWon = product.priceWon,
+                    periodDays = product.periodDays,
+                    maxEnrollments = product.maxEnrollments,
+                    remainingSeats = remaining,
+                    coinAmount = coinPackage.coinAmount,
+                )
+            }
+        return CatalogMembershipPageResponse(
+            content = content,
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+            currentPage = page.number,
+        )
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/EnrollmentWithStudentResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/EnrollmentWithStudentResponse.kt
@@ -6,7 +6,7 @@ import com.sclass.domain.domains.enrollment.dto.EnrollmentWithStudentDto
 
 data class EnrollmentWithStudentResponse(
     val id: Long,
-    val courseId: Long,
+    val courseId: Long?,
     val status: EnrollmentStatus,
     val enrollmentType: EnrollmentType,
     val tuitionAmountWon: Int,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/MyEnrollmentResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/MyEnrollmentResponse.kt
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 
 data class MyEnrollmentResponse(
     val id: Long,
-    val courseId: Long,
+    val courseId: Long?,
     val status: EnrollmentStatus,
     val enrollmentType: EnrollmentType,
     val tuitionAmountWon: Int,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/GetEnrollmentLessonsUseCase.kt
@@ -20,7 +20,8 @@ class GetEnrollmentLessonsUseCase(
         enrollmentId: Long,
     ): List<LessonResponse> {
         val enrollment = enrollmentAdaptor.findById(enrollmentId)
-        val course = courseAdaptor.findById(enrollment.courseId)
+        val courseId = enrollment.courseId ?: throw EnrollmentUnauthorizedAccessException()
+        val course = courseAdaptor.findById(courseId)
 
         val isStudent = enrollment.studentUserId == userId
         val isTeacher = course.teacherUserId == userId

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/membership/controller/MembershipPurchaseController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/membership/controller/MembershipPurchaseController.kt
@@ -1,0 +1,28 @@
+package com.sclass.supporters.membership.controller
+
+import com.sclass.common.annotation.CurrentUserId
+import com.sclass.common.dto.ApiResponse
+import com.sclass.common.dto.ApiResponse.Companion.success
+import com.sclass.supporters.membership.dto.PrepareMembershipPurchaseRequest
+import com.sclass.supporters.membership.dto.PrepareMembershipPurchaseResponse
+import com.sclass.supporters.membership.usecase.PrepareMembershipPurchaseUseCase
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/memberships")
+class MembershipPurchaseController(
+    private val prepareMembershipPurchaseUseCase: PrepareMembershipPurchaseUseCase,
+) {
+    @PostMapping("/purchase")
+    fun prepare(
+        @CurrentUserId userId: String,
+        @RequestBody @Valid request: PrepareMembershipPurchaseRequest,
+    ): ApiResponse<PrepareMembershipPurchaseResponse> =
+        success(
+            prepareMembershipPurchaseUseCase.execute(userId, request.membershipProductId, request.pgType),
+        )
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/membership/dto/PrepareMembershipPurchaseRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/membership/dto/PrepareMembershipPurchaseRequest.kt
@@ -1,0 +1,10 @@
+package com.sclass.supporters.membership.dto
+
+import com.sclass.domain.domains.payment.domain.PgType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+data class PrepareMembershipPurchaseRequest(
+    @field:NotBlank val membershipProductId: String,
+    @field:NotNull val pgType: PgType,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/membership/dto/PrepareMembershipPurchaseResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/membership/dto/PrepareMembershipPurchaseResponse.kt
@@ -1,0 +1,9 @@
+package com.sclass.supporters.membership.dto
+
+data class PrepareMembershipPurchaseResponse(
+    val paymentId: String,
+    val pgOrderId: String,
+    val amount: Int,
+    val productId: String,
+    val productName: String,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/membership/usecase/PrepareMembershipPurchaseUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/membership/usecase/PrepareMembershipPurchaseUseCase.kt
@@ -1,0 +1,76 @@
+package com.sclass.supporters.membership.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.common.vo.Ulid
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.exception.EnrollmentAlreadyExistsException
+import com.sclass.domain.domains.enrollment.exception.MembershipCapacityExceededException
+import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.Payment
+import com.sclass.domain.domains.payment.domain.PaymentTargetType
+import com.sclass.domain.domains.payment.domain.PgType
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.MembershipProduct
+import com.sclass.domain.domains.product.exception.ProductNotPurchasableException
+import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import com.sclass.supporters.membership.dto.PrepareMembershipPurchaseResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class PrepareMembershipPurchaseUseCase(
+    private val productAdaptor: ProductAdaptor,
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val paymentAdaptor: PaymentAdaptor,
+) {
+    @Transactional
+    @DistributedLock(prefix = "membership-purchase")
+    fun execute(
+        studentUserId: String,
+        @LockKey membershipProductId: String,
+        pgType: PgType,
+    ): PrepareMembershipPurchaseResponse {
+        val product =
+            productAdaptor.findById(membershipProductId) as? MembershipProduct
+                ?: throw ProductTypeMismatchException()
+        if (!product.visible) throw ProductNotPurchasableException()
+
+        product.maxEnrollments?.let { cap ->
+            val live = enrollmentAdaptor.countLiveMembershipEnrollments(product.id)
+            if (live >= cap) throw MembershipCapacityExceededException()
+        }
+        if (enrollmentAdaptor.findLiveMembershipEnrollment(product.id, studentUserId) != null) {
+            throw EnrollmentAlreadyExistsException()
+        }
+
+        val payment =
+            paymentAdaptor.save(
+                Payment(
+                    userId = studentUserId,
+                    targetType = PaymentTargetType.MEMBERSHIP_PRODUCT,
+                    targetId = product.id,
+                    amount = product.priceWon,
+                    pgType = pgType,
+                    pgOrderId = Ulid.generate(),
+                ),
+            )
+        enrollmentAdaptor.save(
+            Enrollment.createForMembershipPurchase(
+                productId = product.id,
+                studentUserId = studentUserId,
+                tuitionAmountWon = product.priceWon,
+                paymentId = payment.id,
+            ),
+        )
+
+        return PrepareMembershipPurchaseResponse(
+            paymentId = payment.id,
+            pgOrderId = payment.pgOrderId,
+            amount = payment.amount,
+            productId = product.id,
+            productName = product.name,
+        )
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
@@ -2,11 +2,15 @@ package com.sclass.supporters.payment.usecase
 
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.coin.domain.CoinLotSourceType
 import com.sclass.domain.domains.coin.service.CoinDomainService
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.MembershipProduct
+import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
 import com.sclass.infrastructure.nicepay.PgGateway
 import com.sclass.infrastructure.nicepay.exception.NicePayException
 import com.sclass.infrastructure.redis.DistributedLock
@@ -14,10 +18,12 @@ import com.sclass.infrastructure.redis.LockKey
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.transaction.support.TransactionTemplate
+import java.time.LocalDateTime
 
 @UseCase
 class HandleNicePayReturnUseCase(
     private val paymentAdaptor: PaymentAdaptor,
+    private val productAdaptor: ProductAdaptor,
     private val coinPackageAdaptor: CoinPackageAdaptor,
     private val coinDomainService: CoinDomainService,
     private val enrollmentAdaptor: EnrollmentAdaptor,
@@ -123,6 +129,35 @@ class HandleNicePayReturnUseCase(
                     }
                     log.info("결제 완료(수강): paymentId={}", payment.id)
                     successUrl(null)
+                }
+                PaymentTargetType.MEMBERSHIP_PRODUCT -> {
+                    val product =
+                        productAdaptor.findById(payment.targetId) as? MembershipProduct
+                            ?: throw ProductTypeMismatchException()
+                    val coinPackage = coinPackageAdaptor.findById(product.coinPackageId)
+                    txTemplate.execute {
+                        val fresh = paymentAdaptor.findById(payment.id)
+                        val enrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
+                        val now = LocalDateTime.now()
+                        val endAt = now.plusDays(product.periodDays.toLong())
+                        enrollment.markPaid(startAt = now, endAt = endAt)
+                        enrollmentAdaptor.save(enrollment)
+
+                        coinDomainService.issue(
+                            userId = fresh.userId,
+                            amount = coinPackage.coinAmount,
+                            referenceId = fresh.id,
+                            description = "멤버십 가입 - ${product.name}",
+                            enrollmentId = enrollment.id,
+                            expireAt = endAt,
+                            sourceType = CoinLotSourceType.PURCHASE,
+                            sourceMeta = """{"membershipProductId":"${product.id}"}""",
+                        )
+                        fresh.markCompleted()
+                        paymentAdaptor.save(fresh)
+                    }
+                    log.info("결제 완료(멤버십): paymentId={}", payment.id)
+                    successUrl(coinPackage.coinAmount)
                 }
             }
         } catch (e: Exception) {

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -2,6 +2,7 @@ package com.sclass.supporters.payment.usecase
 
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
+import com.sclass.domain.domains.coin.domain.CoinLotSourceType
 import com.sclass.domain.domains.coin.service.CoinDomainService
 import com.sclass.domain.domains.course.adaptor.CourseAdaptor
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
@@ -11,6 +12,7 @@ import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
 import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.product.domain.MembershipProduct
 import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
 import com.sclass.infrastructure.nicepay.PgGateway
 import com.sclass.infrastructure.nicepay.dto.NicePayWebhookPayload
@@ -18,6 +20,7 @@ import com.sclass.infrastructure.redis.DistributedLock
 import com.sclass.infrastructure.redis.LockKey
 import org.slf4j.LoggerFactory
 import org.springframework.transaction.support.TransactionTemplate
+import java.time.LocalDateTime
 
 @UseCase
 class HandleNicePayWebhookUseCase(
@@ -123,13 +126,62 @@ class HandleNicePayWebhookUseCase(
                     fresh.markCompleted()
                     paymentAdaptor.save(fresh)
 
-                    val course = courseAdaptor.findById(freshEnrollment.courseId)
+                    val courseId =
+                        freshEnrollment.courseId
+                            ?: error("COURSE_PRODUCT enrollment must have courseId")
+                    val course = courseAdaptor.findById(courseId)
                     lessonService.createLessonsForEnrollment(
                         freshEnrollment,
                         teacherUserId = course.teacherUserId,
                         courseName = product.name,
                         totalLessons = product.totalLessons,
                     )
+                }
+            }
+            PaymentTargetType.MEMBERSHIP_PRODUCT -> {
+                val product =
+                    productAdaptor.findById(payment.targetId) as? MembershipProduct
+                        ?: throw ProductTypeMismatchException()
+                val coinPackage = coinPackageAdaptor.findById(product.coinPackageId)
+                txTemplate.execute {
+                    val fresh = paymentAdaptor.findById(payment.id)
+                    fresh.markPgApproved(payload.tid)
+                    paymentAdaptor.save(fresh)
+                }
+                val enrollment = enrollmentAdaptor.findByPaymentIdOrNull(payment.id)
+                if (enrollment == null) {
+                    log.warn("웹훅 수신: enrollment 없음 paymentId={}", payment.id)
+                    return
+                }
+                try {
+                    txTemplate.execute {
+                        val fresh = paymentAdaptor.findById(payment.id)
+                        val freshEnrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
+                        val now = LocalDateTime.now()
+                        val endAt = now.plusDays(product.periodDays.toLong())
+                        freshEnrollment.markPaid(startAt = now, endAt = endAt)
+                        enrollmentAdaptor.save(freshEnrollment)
+
+                        coinDomainService.issue(
+                            userId = fresh.userId,
+                            amount = coinPackage.coinAmount,
+                            referenceId = fresh.id,
+                            description = "멤버십 가입 (웹훅) - ${product.name}",
+                            enrollmentId = freshEnrollment.id,
+                            expireAt = endAt,
+                            sourceType = CoinLotSourceType.PURCHASE,
+                            sourceMeta = """{"membershipProductId":"${product.id}"}""",
+                        )
+                        fresh.markCompleted()
+                        paymentAdaptor.save(fresh)
+                    }
+                } catch (e: Exception) {
+                    log.error("웹훅 수신: 멤버십 발급 실패 paymentId={}", payment.id, e)
+                    txTemplate.execute {
+                        val fresh = paymentAdaptor.findById(payment.id)
+                        fresh.markIssueCoinFailed()
+                        paymentAdaptor.save(fresh)
+                    }
                 }
             }
         }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/membership/usecase/PrepareMembershipPurchaseUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/membership/usecase/PrepareMembershipPurchaseUseCaseTest.kt
@@ -1,0 +1,176 @@
+package com.sclass.supporters.membership.usecase
+
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.enrollment.exception.EnrollmentAlreadyExistsException
+import com.sclass.domain.domains.enrollment.exception.MembershipCapacityExceededException
+import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.Payment
+import com.sclass.domain.domains.payment.domain.PaymentTargetType
+import com.sclass.domain.domains.payment.domain.PgType
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.product.domain.MembershipProduct
+import com.sclass.domain.domains.product.exception.ProductNotPurchasableException
+import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PrepareMembershipPurchaseUseCaseTest {
+    private lateinit var productAdaptor: ProductAdaptor
+    private lateinit var enrollmentAdaptor: EnrollmentAdaptor
+    private lateinit var paymentAdaptor: PaymentAdaptor
+    private lateinit var useCase: PrepareMembershipPurchaseUseCase
+
+    private val studentUserId = "student-id-00000000001"
+    private val membershipProductId = "mp-0000000000000000000000001"
+
+    @BeforeEach
+    fun setUp() {
+        productAdaptor = mockk()
+        enrollmentAdaptor = mockk()
+        paymentAdaptor = mockk()
+        useCase = PrepareMembershipPurchaseUseCase(productAdaptor, enrollmentAdaptor, paymentAdaptor)
+    }
+
+    private fun visibleMembership(maxEnrollments: Int? = null): MembershipProduct {
+        val product =
+            MembershipProduct(
+                name = "프리미엄 멤버십",
+                priceWon = 10000,
+                periodDays = 30,
+                maxEnrollments = maxEnrollments,
+                coinPackageId = "cp-0000000000000000000000001",
+            )
+        product.show()
+        return product
+    }
+
+    private fun hiddenMembership(): MembershipProduct =
+        MembershipProduct(
+            name = "비공개 멤버십",
+            priceWon = 10000,
+            periodDays = 30,
+            coinPackageId = "cp-0000000000000000000000001",
+        )
+
+    private fun pendingPayment() =
+        Payment(
+            userId = studentUserId,
+            targetType = PaymentTargetType.MEMBERSHIP_PRODUCT,
+            targetId = membershipProductId,
+            amount = 10000,
+            pgType = PgType.NICEPAY,
+            pgOrderId = "order-id-000000000001",
+        )
+
+    @Nested
+    inner class Success {
+        @Test
+        fun `멤버십 구매 준비 시 Payment와 Enrollment가 생성된다`() {
+            val product = visibleMembership()
+            val enrollmentSlot = slot<Enrollment>()
+            every { productAdaptor.findById(membershipProductId) } returns product
+            every { enrollmentAdaptor.findLiveMembershipEnrollment(product.id, studentUserId) } returns null
+            every { paymentAdaptor.save(any()) } returns pendingPayment()
+            every { enrollmentAdaptor.save(capture(enrollmentSlot)) } answers { enrollmentSlot.captured }
+
+            val result = useCase.execute(studentUserId, membershipProductId, PgType.NICEPAY)
+
+            assertThat(result.productId).isEqualTo(product.id)
+            assertThat(result.productName).isEqualTo("프리미엄 멤버십")
+            assertThat(result.amount).isEqualTo(10000)
+            assertThat(enrollmentSlot.captured.status).isEqualTo(EnrollmentStatus.PENDING_PAYMENT)
+            assertThat(enrollmentSlot.captured.productId).isEqualTo(product.id)
+            assertThat(enrollmentSlot.captured.courseId).isNull()
+            verify(exactly = 1) { paymentAdaptor.save(any()) }
+            verify(exactly = 1) { enrollmentAdaptor.save(any()) }
+        }
+
+        @Test
+        fun `maxEnrollments null이면 정원 검증을 건너뛴다`() {
+            val product = visibleMembership(maxEnrollments = null)
+            every { productAdaptor.findById(membershipProductId) } returns product
+            every { enrollmentAdaptor.findLiveMembershipEnrollment(product.id, studentUserId) } returns null
+            every { paymentAdaptor.save(any()) } returns pendingPayment()
+            every { enrollmentAdaptor.save(any()) } answers { firstArg() }
+
+            useCase.execute(studentUserId, membershipProductId, PgType.NICEPAY)
+
+            verify(exactly = 0) { enrollmentAdaptor.countLiveMembershipEnrollments(any()) }
+        }
+
+        @Test
+        fun `maxEnrollments가 있으면 live 수보다 클 때 통과한다`() {
+            val product = visibleMembership(maxEnrollments = 10)
+            every { productAdaptor.findById(membershipProductId) } returns product
+            every { enrollmentAdaptor.countLiveMembershipEnrollments(product.id) } returns 5L
+            every { enrollmentAdaptor.findLiveMembershipEnrollment(product.id, studentUserId) } returns null
+            every { paymentAdaptor.save(any()) } returns pendingPayment()
+            every { enrollmentAdaptor.save(any()) } answers { firstArg() }
+
+            useCase.execute(studentUserId, membershipProductId, PgType.NICEPAY)
+
+            verify(exactly = 1) { enrollmentAdaptor.countLiveMembershipEnrollments(product.id) }
+        }
+    }
+
+    @Nested
+    inner class Failure {
+        @Test
+        fun `MembershipProduct가 아니면 ProductTypeMismatchException이 발생한다`() {
+            val courseProduct = CourseProduct(name = "수학", priceWon = 10000, totalLessons = 12)
+            every { productAdaptor.findById(membershipProductId) } returns courseProduct
+
+            assertThatThrownBy {
+                useCase.execute(studentUserId, membershipProductId, PgType.NICEPAY)
+            }.isInstanceOf(ProductTypeMismatchException::class.java)
+        }
+
+        @Test
+        fun `상품이 비공개이면 ProductNotPurchasableException이 발생한다`() {
+            every { productAdaptor.findById(membershipProductId) } returns hiddenMembership()
+
+            assertThatThrownBy {
+                useCase.execute(studentUserId, membershipProductId, PgType.NICEPAY)
+            }.isInstanceOf(ProductNotPurchasableException::class.java)
+        }
+
+        @Test
+        fun `정원 초과 시 MembershipCapacityExceededException이 발생한다`() {
+            val product = visibleMembership(maxEnrollments = 10)
+            every { productAdaptor.findById(membershipProductId) } returns product
+            every { enrollmentAdaptor.countLiveMembershipEnrollments(product.id) } returns 10L
+
+            assertThatThrownBy {
+                useCase.execute(studentUserId, membershipProductId, PgType.NICEPAY)
+            }.isInstanceOf(MembershipCapacityExceededException::class.java)
+        }
+
+        @Test
+        fun `활성 멤버십이 이미 있으면 EnrollmentAlreadyExistsException이 발생한다`() {
+            val product = visibleMembership()
+            val existing =
+                Enrollment.createForMembershipPurchase(
+                    productId = product.id,
+                    studentUserId = studentUserId,
+                    tuitionAmountWon = 10000,
+                    paymentId = "payment-id-000000000001",
+                )
+            every { productAdaptor.findById(membershipProductId) } returns product
+            every { enrollmentAdaptor.findLiveMembershipEnrollment(product.id, studentUserId) } returns existing
+
+            assertThatThrownBy {
+                useCase.execute(studentUserId, membershipProductId, PgType.NICEPAY)
+            }.isInstanceOf(EnrollmentAlreadyExistsException::class.java)
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCaseTest.kt
@@ -5,11 +5,14 @@ import com.sclass.domain.domains.coin.domain.CoinLot
 import com.sclass.domain.domains.coin.domain.CoinPackage
 import com.sclass.domain.domains.coin.service.CoinDomainService
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.Payment
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
 import com.sclass.domain.domains.payment.domain.PgType
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.MembershipProduct
 import com.sclass.infrastructure.nicepay.PgGateway
 import com.sclass.infrastructure.nicepay.dto.PgApproveResult
 import com.sclass.infrastructure.nicepay.exception.NicePayException
@@ -25,6 +28,7 @@ import org.springframework.transaction.support.TransactionTemplate
 
 class HandleNicePayReturnUseCaseTest {
     private lateinit var paymentAdaptor: PaymentAdaptor
+    private lateinit var productAdaptor: ProductAdaptor
     private lateinit var coinPackageAdaptor: CoinPackageAdaptor
     private lateinit var coinDomainService: CoinDomainService
     private lateinit var enrollmentAdaptor: EnrollmentAdaptor
@@ -37,6 +41,7 @@ class HandleNicePayReturnUseCaseTest {
     @BeforeEach
     fun setUp() {
         paymentAdaptor = mockk()
+        productAdaptor = mockk()
         coinPackageAdaptor = mockk()
         coinDomainService = mockk()
         pgGateway = mockk()
@@ -50,6 +55,7 @@ class HandleNicePayReturnUseCaseTest {
         useCase =
             HandleNicePayReturnUseCase(
                 paymentAdaptor,
+                productAdaptor,
                 coinPackageAdaptor,
                 coinDomainService,
                 enrollmentAdaptor,
@@ -240,6 +246,95 @@ class HandleNicePayReturnUseCaseTest {
         assertTrue(result.contains("status=FAILED"))
     }
 
+    @Test
+    fun `멤버십 결제 성공 시 enrollment가 ACTIVE로 전환되고 멤버십 코인이 발급된다`() {
+        val payment = membershipPayment(amount = 10000)
+        val product =
+            MembershipProduct(
+                name = "프리미엄 멤버십",
+                priceWon = 10000,
+                periodDays = 30,
+                coinPackageId = "cp-000000000000000000000000001",
+            )
+        val coinPackage = CoinPackage(name = "코인 1000", priceWon = 10000, coinAmount = 1000)
+        val enrollment =
+            Enrollment.createForMembershipPurchase(
+                productId = product.id,
+                studentUserId = payment.userId,
+                tuitionAmountWon = 10000,
+                paymentId = payment.id,
+            )
+
+        every { pgGateway.verifyReturnSignature(any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(payment.pgOrderId) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { productAdaptor.findById(payment.targetId) } returns product
+        every { coinPackageAdaptor.findById(product.coinPackageId) } returns coinPackage
+        every { enrollmentAdaptor.findByPaymentId(payment.id) } returns enrollment
+        every { enrollmentAdaptor.save(any()) } answers { firstArg() }
+        every { pgGateway.approve(any(), any(), any()) } returns
+            PgApproveResult(tid = "tid-001", pgOrderId = payment.pgOrderId, amount = 10000)
+        every {
+            coinDomainService.issue(any(), any(), any(), any(), any(), any(), any(), any())
+        } returns mockk<CoinLot>()
+
+        val result =
+            useCase.execute(
+                authResultCode = "0000",
+                tid = "tid-001",
+                orderId = payment.pgOrderId,
+                amount = 10000,
+                authToken = "token",
+                signature = "sig",
+            )
+
+        assertAll(
+            { assertTrue(result.contains("status=COMPLETED")) },
+            { assertTrue(result.contains("issuedCoinAmount=1000")) },
+            { assertEquals(PaymentStatus.COMPLETED, payment.status) },
+            { assertEquals(com.sclass.domain.domains.enrollment.domain.EnrollmentStatus.ACTIVE, enrollment.status) },
+            { assertTrue(enrollment.startAt != null && enrollment.endAt != null) },
+        )
+        verify(exactly = 1) {
+            coinDomainService.issue(any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `멤버십 결제 대상이 MembershipProduct가 아니면 FAILED URL을 반환한다`() {
+        val payment = membershipPayment(amount = 10000)
+        val otherProduct =
+            com.sclass.domain.domains.product.domain.CourseProduct(
+                name = "수학 코스",
+                priceWon = 10000,
+                totalLessons = 12,
+            )
+        val pgApprovedPayment = membershipPayment(amount = 10000)
+        pgApprovedPayment.markPgApproved("tid-001")
+
+        every { pgGateway.verifyReturnSignature(any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(payment.pgOrderId) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment andThen pgApprovedPayment
+        every { productAdaptor.findById(payment.targetId) } returns otherProduct
+        every { pgGateway.approve(any(), any(), any()) } returns
+            PgApproveResult(tid = "tid-001", pgOrderId = payment.pgOrderId, amount = 10000)
+
+        val result =
+            useCase.execute(
+                authResultCode = "0000",
+                tid = "tid-001",
+                orderId = payment.pgOrderId,
+                amount = 10000,
+                authToken = "token",
+                signature = "sig",
+            )
+
+        assertAll(
+            { assertTrue(result.contains("status=FAILED")) },
+            { assertEquals(PaymentStatus.ISSUE_COIN_FAILED, pgApprovedPayment.status) },
+        )
+    }
+
     private fun pendingPayment(amount: Int = 1000) =
         Payment(
             userId = "user-00000000000000000000000001",
@@ -248,5 +343,15 @@ class HandleNicePayReturnUseCaseTest {
             amount = amount,
             pgType = PgType.NICEPAY,
             pgOrderId = "order-00000000000000000000000001",
+        )
+
+    private fun membershipPayment(amount: Int = 10000) =
+        Payment(
+            userId = "user-00000000000000000000000001",
+            targetType = PaymentTargetType.MEMBERSHIP_PRODUCT,
+            targetId = "mp-000000000000000000000000001",
+            amount = amount,
+            pgType = PgType.NICEPAY,
+            pgOrderId = "order-00000000000000000000000002",
         )
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
@@ -87,4 +87,9 @@ class EnrollmentAdaptor(
             productId,
             setOf(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.ACTIVE),
         )
+
+    fun countLiveMembershipEnrollmentsByProductIds(productIds: Collection<String>): Map<String, Long> =
+        enrollmentRepository
+            .countLiveMembershipEnrollmentsByProductIds(productIds)
+            .associate { it.productId to it.count }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
@@ -60,6 +60,17 @@ class EnrollmentAdaptor(
                 setOf(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.ACTIVE),
             ).firstOrNull()
 
+    fun findLiveMembershipEnrollment(
+        productId: String,
+        studentUserId: String,
+    ): Enrollment? =
+        enrollmentRepository
+            .findAllByProductIdAndStudentUserIdAndStatusIn(
+                productId,
+                studentUserId,
+                setOf(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.ACTIVE),
+            ).firstOrNull()
+
     fun findByPaymentId(paymentId: String): Enrollment =
         enrollmentRepository.findByPaymentId(paymentId) ?: throw EnrollmentNotFoundException()
 
@@ -68,6 +79,12 @@ class EnrollmentAdaptor(
     fun countLiveEnrollments(courseId: Long): Long =
         enrollmentRepository.countByCourseIdAndStatusIn(
             courseId,
+            setOf(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.ACTIVE),
+        )
+
+    fun countLiveMembershipEnrollments(productId: String): Long =
+        enrollmentRepository.countByProductIdAndStatusIn(
+            productId,
             setOf(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.ACTIVE),
         )
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/domain/Enrollment.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/domain/Enrollment.kt
@@ -29,8 +29,12 @@ class Enrollment private constructor(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 
-    @Column(name = "course_id", nullable = false)
-    val courseId: Long,
+    @Column(name = "course_id")
+    val courseId: Long? = null,
+
+    // MEMBERSHIP 구매 시 저장
+    @Column(name = "product_id", length = 26)
+    val productId: String? = null,
 
     @Column(name = "student_user_id", nullable = false, length = 26)
     val studentUserId: String,
@@ -60,17 +64,34 @@ class Enrollment private constructor(
     @Column(nullable = false, length = 20)
     var status: EnrollmentStatus,
 
+    // ===== 유효기간 (MEMBERSHIP 구매 시에만 채워짐) =====
+    @Column(name = "start_at")
+    var startAt: LocalDateTime? = null,
+
+    @Column(name = "end_at")
+    var endAt: LocalDateTime? = null,
+
     @Column(name = "cancelled_at")
     var cancelledAt: LocalDateTime? = null,
 
     @Column(name = "cancel_reason", length = 500)
     var cancelReason: String? = null,
 ) : BaseTimeEntity() {
-    fun markPaid() {
+    fun markPaid(
+        startAt: LocalDateTime? = null,
+        endAt: LocalDateTime? = null,
+    ) {
         require(enrollmentType == EnrollmentType.PURCHASE) {
             "markPaid is only valid for PURCHASE enrollments"
         }
         require(paymentId != null) { "paymentId must be set before markPaid" }
+        if (productId != null) {
+            require(startAt != null && endAt != null) {
+                "membership enrollment requires startAt/endAt on markPaid"
+            }
+            this.startAt = startAt
+            this.endAt = endAt
+        }
         validateTransition(EnrollmentStatus.ACTIVE)
         this.status = EnrollmentStatus.ACTIVE
     }
@@ -136,12 +157,28 @@ class Enrollment private constructor(
                 status = EnrollmentStatus.PENDING_PAYMENT,
             )
 
+        fun createForMembershipPurchase(
+            productId: String,
+            studentUserId: String,
+            tuitionAmountWon: Int,
+            paymentId: String,
+        ): Enrollment =
+            Enrollment(
+                courseId = null,
+                productId = productId,
+                studentUserId = studentUserId,
+                enrollmentType = EnrollmentType.PURCHASE,
+                tuitionAmountWon = tuitionAmountWon,
+                paymentId = paymentId,
+                status = EnrollmentStatus.PENDING_PAYMENT,
+            )
+
         /**
          * 백오피스/LMS 관리자가 직접 등록.
          * 결제 절차 없이 바로 ACTIVE 상태로 생성.
          */
         fun createByGrant(
-            courseId: Long,
+            courseId: Long?,
             studentUserId: String,
             grantedByUserId: String,
             grantReason: String,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/dto/ProductEnrollmentCountDto.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/dto/ProductEnrollmentCountDto.kt
@@ -1,0 +1,6 @@
+package com.sclass.domain.domains.enrollment.dto
+
+data class ProductEnrollmentCountDto(
+    val productId: String,
+    val count: Long,
+)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentErrorCode.kt
@@ -15,4 +15,5 @@ enum class EnrollmentErrorCode(
     ENROLLMENT_NOT_ACTIVE("ENROLLMENT_006", "활성 상태의 수강 등록이 아닙니다", 400),
     ENROLLMENT_TYPE_MISMATCH("ENROLLMENT_007", "해당 작업은 이 등록 유형에서 허용되지 않습니다", 400),
     ENROLLMENT_UNAUTHORIZED_ACCESS("ENROLLMENT_008", "해당 수강에 대한 권한이 없습니다", 403),
+    MEMBERSHIP_CAPACITY_EXCEEDED("ENROLLMENT_009", "멤버십 정원이 초과되었습니다", 409),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/MembershipCapacityExceededException.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/MembershipCapacityExceededException.kt
@@ -1,0 +1,5 @@
+package com.sclass.domain.domains.enrollment.exception
+
+import com.sclass.common.exception.BusinessException
+
+class MembershipCapacityExceededException : BusinessException(EnrollmentErrorCode.MEMBERSHIP_CAPACITY_EXCEEDED)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepository.kt
@@ -4,6 +4,7 @@ import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithCourseDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithStudentDto
+import com.sclass.domain.domains.enrollment.dto.ProductEnrollmentCountDto
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
@@ -19,4 +20,6 @@ interface EnrollmentCustomRepository {
         status: EnrollmentStatus?,
         pageable: Pageable,
     ): Page<EnrollmentWithDetailDto>
+
+    fun countLiveMembershipEnrollmentsByProductIds(productIds: Collection<String>): List<ProductEnrollmentCountDto>
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.sclass.domain.domains.enrollment.domain.QEnrollment.enrollment
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithCourseDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithStudentDto
+import com.sclass.domain.domains.enrollment.dto.ProductEnrollmentCountDto
 import com.sclass.domain.domains.product.domain.QCourseProduct.courseProduct
 import com.sclass.domain.domains.user.domain.QUser
 import com.sclass.domain.domains.user.domain.QUser.user
@@ -113,6 +114,22 @@ class EnrollmentCustomRepositoryImpl(
                 .fetchOne() ?: 0L
 
         return PageImpl(content, pageable, total)
+    }
+
+    override fun countLiveMembershipEnrollmentsByProductIds(productIds: Collection<String>): List<ProductEnrollmentCountDto> {
+        if (productIds.isEmpty()) return emptyList()
+        return queryFactory
+            .select(enrollment.productId, enrollment.count())
+            .from(enrollment)
+            .where(
+                enrollment.productId.`in`(productIds),
+                enrollment.status.`in`(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.ACTIVE),
+            ).groupBy(enrollment.productId)
+            .fetch()
+            .mapNotNull { tuple ->
+                val productId = tuple[enrollment.productId] ?: return@mapNotNull null
+                ProductEnrollmentCountDto(productId = productId, count = tuple[enrollment.count()] ?: 0L)
+            }
     }
 
     private fun Sort.toOrderSpecifiers(): Array<OrderSpecifier<*>> {

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentRepository.kt
@@ -28,11 +28,22 @@ interface EnrollmentRepository :
         statuses: Collection<EnrollmentStatus>,
     ): List<Enrollment>
 
+    fun findAllByProductIdAndStudentUserIdAndStatusIn(
+        productId: String,
+        studentUserId: String,
+        statuses: Collection<EnrollmentStatus>,
+    ): List<Enrollment>
+
     // Payment → Enrollment 역조회 (콜백 처리용)
     fun findByPaymentId(paymentId: String): Enrollment?
 
     fun countByCourseIdAndStatusIn(
         courseId: Long,
+        statuses: Collection<EnrollmentStatus>,
+    ): Long
+
+    fun countByProductIdAndStatusIn(
+        productId: String,
         statuses: Collection<EnrollmentStatus>,
     ): Long
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/payment/domain/PaymentTargetType.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/payment/domain/PaymentTargetType.kt
@@ -3,4 +3,5 @@ package com.sclass.domain.domains.payment.domain
 enum class PaymentTargetType {
     COIN_PACKAGE,
     COURSE_PRODUCT,
+    MEMBERSHIP_PRODUCT,
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/adaptor/ProductAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/adaptor/ProductAdaptor.kt
@@ -1,9 +1,9 @@
 package com.sclass.domain.domains.product.adaptor
 
 import com.sclass.common.annotation.Adaptor
-import com.sclass.domain.domains.product.domain.MembershipProduct
 import com.sclass.domain.domains.product.domain.Product
 import com.sclass.domain.domains.product.domain.ProductType
+import com.sclass.domain.domains.product.dto.MembershipProductWithCoinPackageDto
 import com.sclass.domain.domains.product.exception.ProductNotFoundException
 import com.sclass.domain.domains.product.repository.ProductRepository
 import org.springframework.data.domain.Page
@@ -19,11 +19,8 @@ class ProductAdaptor(
 
     fun save(product: Product): Product = productRepository.save(product)
 
-    @Suppress("UNCHECKED_CAST")
-    fun findVisibleMemberships(pageable: Pageable): Page<MembershipProduct> =
-        productRepository.findVisibleByType(ProductType.MEMBERSHIP, pageable) as Page<MembershipProduct>
-
-    @Suppress("UNCHECKED_CAST")
-    fun findAllMemberships(pageable: Pageable): Page<MembershipProduct> =
-        productRepository.findByType(ProductType.MEMBERSHIP, pageable) as Page<MembershipProduct>
+    fun findMembershipsWithCoinPackage(
+        visibleOnly: Boolean,
+        pageable: Pageable,
+    ): Page<MembershipProductWithCoinPackageDto> = productRepository.findMembershipsWithCoinPackage(visibleOnly, pageable)
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/adaptor/ProductAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/adaptor/ProductAdaptor.kt
@@ -1,10 +1,13 @@
 package com.sclass.domain.domains.product.adaptor
 
 import com.sclass.common.annotation.Adaptor
+import com.sclass.domain.domains.product.domain.MembershipProduct
 import com.sclass.domain.domains.product.domain.Product
 import com.sclass.domain.domains.product.domain.ProductType
 import com.sclass.domain.domains.product.exception.ProductNotFoundException
 import com.sclass.domain.domains.product.repository.ProductRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 @Adaptor
 class ProductAdaptor(
@@ -15,4 +18,12 @@ class ProductAdaptor(
     fun findAllActive(type: ProductType? = null): List<Product> = productRepository.findAllActiveByType(type)
 
     fun save(product: Product): Product = productRepository.save(product)
+
+    @Suppress("UNCHECKED_CAST")
+    fun findVisibleMemberships(pageable: Pageable): Page<MembershipProduct> =
+        productRepository.findVisibleByType(ProductType.MEMBERSHIP, pageable) as Page<MembershipProduct>
+
+    @Suppress("UNCHECKED_CAST")
+    fun findAllMemberships(pageable: Pageable): Page<MembershipProduct> =
+        productRepository.findByType(ProductType.MEMBERSHIP, pageable) as Page<MembershipProduct>
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/MembershipProduct.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/MembershipProduct.kt
@@ -1,0 +1,38 @@
+package com.sclass.domain.domains.product.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+
+@Entity
+@DiscriminatorValue("MEMBERSHIP")
+class MembershipProduct(
+    name: String,
+    priceWon: Int,
+    description: String? = null,
+    thumbnailFileId: String? = null,
+
+    @Column(name = "period_days", nullable = true)
+    var periodDays: Int,
+
+    @Column(name = "max_enrollments", nullable = true)
+    var maxEnrollments: Int? = null,
+
+    @Column(name = "coin_package_id", nullable = true, length = 26)
+    var coinPackageId: String,
+) : Product(
+        name = name,
+        priceWon = priceWon,
+        description = description,
+        thumbnailFileId = thumbnailFileId,
+    ) {
+    fun updateMembership(
+        newPeriodDays: Int?,
+        newMaxEnrollments: Int?,
+        newCoinPackageId: String?,
+    ) {
+        newPeriodDays?.let { periodDays = it }
+        newMaxEnrollments?.let { maxEnrollments = it }
+        newCoinPackageId?.let { coinPackageId = it }
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/ProductType.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/ProductType.kt
@@ -4,4 +4,5 @@ enum class ProductType(
     val entityClass: Class<out Product>,
 ) {
     COURSE(CourseProduct::class.java),
+    MEMBERSHIP(MembershipProduct::class.java),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/dto/MembershipProductWithCoinPackageDto.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/dto/MembershipProductWithCoinPackageDto.kt
@@ -1,0 +1,9 @@
+package com.sclass.domain.domains.product.dto
+
+import com.sclass.domain.domains.coin.domain.CoinPackage
+import com.sclass.domain.domains.product.domain.MembershipProduct
+
+data class MembershipProductWithCoinPackageDto(
+    val product: MembershipProduct,
+    val coinPackage: CoinPackage?,
+)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/exception/ProductErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/exception/ProductErrorCode.kt
@@ -9,5 +9,6 @@ enum class ProductErrorCode(
 ) : ErrorCode {
     PRODUCT_NOT_FOUND("PRODUCT_001", "상품을 찾을 수 없습니다", 404),
     PRODUCT_TYPE_MISMATCH("PRODUCT_002", "상품 타입이 올바르지 않습니다", 400),
+    PRODUCT_NOT_PURCHASABLE("PRODUCT_003", "현재 구매할 수 없는 상품입니다", 400),
     UNKNOWN_PRODUCT_TYPE("PRODUCT_004", "알 수 없는 상품 타입입니다", 500),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/exception/ProductNotPurchasableException.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/exception/ProductNotPurchasableException.kt
@@ -1,0 +1,5 @@
+package com.sclass.domain.domains.product.exception
+
+import com.sclass.common.exception.BusinessException
+
+class ProductNotPurchasableException : BusinessException(ProductErrorCode.PRODUCT_NOT_PURCHASABLE)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/repository/ProductCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/repository/ProductCustomRepository.kt
@@ -2,7 +2,19 @@ package com.sclass.domain.domains.product.repository
 
 import com.sclass.domain.domains.product.domain.Product
 import com.sclass.domain.domains.product.domain.ProductType
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface ProductCustomRepository {
     fun findAllActiveByType(type: ProductType?): List<Product>
+
+    fun findVisibleByType(
+        type: ProductType,
+        pageable: Pageable,
+    ): Page<Product>
+
+    fun findByType(
+        type: ProductType,
+        pageable: Pageable,
+    ): Page<Product>
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/repository/ProductCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/repository/ProductCustomRepository.kt
@@ -2,19 +2,15 @@ package com.sclass.domain.domains.product.repository
 
 import com.sclass.domain.domains.product.domain.Product
 import com.sclass.domain.domains.product.domain.ProductType
+import com.sclass.domain.domains.product.dto.MembershipProductWithCoinPackageDto
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
 interface ProductCustomRepository {
     fun findAllActiveByType(type: ProductType?): List<Product>
 
-    fun findVisibleByType(
-        type: ProductType,
+    fun findMembershipsWithCoinPackage(
+        visibleOnly: Boolean,
         pageable: Pageable,
-    ): Page<Product>
-
-    fun findByType(
-        type: ProductType,
-        pageable: Pageable,
-    ): Page<Product>
+    ): Page<MembershipProductWithCoinPackageDto>
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/repository/ProductCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/repository/ProductCustomRepositoryImpl.kt
@@ -4,6 +4,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import com.sclass.domain.domains.product.domain.Product
 import com.sclass.domain.domains.product.domain.ProductType
 import com.sclass.domain.domains.product.domain.QProduct
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 
 class ProductCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
@@ -15,4 +18,52 @@ class ProductCustomRepositoryImpl(
                 QProduct.product.visible.isTrue,
                 type?.let { QProduct.product.instanceOf(it.entityClass) },
             ).fetch()
+
+    override fun findVisibleByType(
+        type: ProductType,
+        pageable: Pageable,
+    ): Page<Product> {
+        val where =
+            arrayOf(
+                QProduct.product.visible.isTrue,
+                QProduct.product.instanceOf(type.entityClass),
+            )
+        val content =
+            queryFactory
+                .selectFrom(QProduct.product)
+                .where(*where)
+                .offset(pageable.offset)
+                .limit(pageable.pageSize.toLong())
+                .orderBy(QProduct.product.createdAt.desc())
+                .fetch()
+        val total =
+            queryFactory
+                .select(QProduct.product.count())
+                .from(QProduct.product)
+                .where(*where)
+                .fetchOne() ?: 0L
+        return PageImpl(content, pageable, total)
+    }
+
+    override fun findByType(
+        type: ProductType,
+        pageable: Pageable,
+    ): Page<Product> {
+        val where = QProduct.product.instanceOf(type.entityClass)
+        val content =
+            queryFactory
+                .selectFrom(QProduct.product)
+                .where(where)
+                .offset(pageable.offset)
+                .limit(pageable.pageSize.toLong())
+                .orderBy(QProduct.product.createdAt.desc())
+                .fetch()
+        val total =
+            queryFactory
+                .select(QProduct.product.count())
+                .from(QProduct.product)
+                .where(where)
+                .fetchOne() ?: 0L
+        return PageImpl(content, pageable, total)
+    }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/repository/ProductCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/repository/ProductCustomRepositoryImpl.kt
@@ -1,9 +1,13 @@
 package com.sclass.domain.domains.product.repository
 
+import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sclass.domain.domains.coin.domain.QCoinPackage
 import com.sclass.domain.domains.product.domain.Product
 import com.sclass.domain.domains.product.domain.ProductType
+import com.sclass.domain.domains.product.domain.QMembershipProduct
 import com.sclass.domain.domains.product.domain.QProduct
+import com.sclass.domain.domains.product.dto.MembershipProductWithCoinPackageDto
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -19,49 +23,35 @@ class ProductCustomRepositoryImpl(
                 type?.let { QProduct.product.instanceOf(it.entityClass) },
             ).fetch()
 
-    override fun findVisibleByType(
-        type: ProductType,
+    override fun findMembershipsWithCoinPackage(
+        visibleOnly: Boolean,
         pageable: Pageable,
-    ): Page<Product> {
-        val where =
-            arrayOf(
-                QProduct.product.visible.isTrue,
-                QProduct.product.instanceOf(type.entityClass),
-            )
-        val content =
-            queryFactory
-                .selectFrom(QProduct.product)
-                .where(*where)
-                .offset(pageable.offset)
-                .limit(pageable.pageSize.toLong())
-                .orderBy(QProduct.product.createdAt.desc())
-                .fetch()
-        val total =
-            queryFactory
-                .select(QProduct.product.count())
-                .from(QProduct.product)
-                .where(*where)
-                .fetchOne() ?: 0L
-        return PageImpl(content, pageable, total)
-    }
+    ): Page<MembershipProductWithCoinPackageDto> {
+        val qMembership = QMembershipProduct.membershipProduct
+        val qCoin = QCoinPackage.coinPackage
+        val where: BooleanExpression? = if (visibleOnly) qMembership.visible.isTrue else null
 
-    override fun findByType(
-        type: ProductType,
-        pageable: Pageable,
-    ): Page<Product> {
-        val where = QProduct.product.instanceOf(type.entityClass)
         val content =
             queryFactory
-                .selectFrom(QProduct.product)
+                .select(qMembership, qCoin)
+                .from(qMembership)
+                .leftJoin(qCoin)
+                .on(qMembership.coinPackageId.eq(qCoin.id))
                 .where(where)
                 .offset(pageable.offset)
                 .limit(pageable.pageSize.toLong())
-                .orderBy(QProduct.product.createdAt.desc())
+                .orderBy(qMembership.createdAt.desc())
                 .fetch()
+                .map { tuple ->
+                    MembershipProductWithCoinPackageDto(
+                        product = tuple[qMembership]!!,
+                        coinPackage = tuple[qCoin],
+                    )
+                }
         val total =
             queryFactory
-                .select(QProduct.product.count())
-                .from(QProduct.product)
+                .select(qMembership.count())
+                .from(qMembership)
                 .where(where)
                 .fetchOne() ?: 0L
         return PageImpl(content, pageable, total)


### PR DESCRIPTION
Closes #255

## Summary
- 기간제 멤버십 상품(`MembershipProduct`) 도입: `period_days`, `max_enrollments`, `coin_package_id` 필드. 구매 시 가입 기간 + 동일 기간 만료 코인 자동 발급
- 결제 후처리에 `MEMBERSHIP_PRODUCT` 분기 추가 (Return/Webhook 양쪽) — PG 승인 후 enrollment `ACTIVE` 전환 + `startAt`/`endAt` 세팅 + 기간 만료 코인 발급
- Supporters 구매 + 공개 카탈로그 API, Backoffice CRUD (정원 초과/중복 구매/비공개 검증 + 분산락)

## 주요 변경
### Domain
- `MembershipProduct` 엔티티 (Product 서브클래스, `DTYPE=MEMBERSHIP`)
- `Enrollment` 확장: `courseId` nullable, `productId`/`startAt`/`endAt` 추가, `markPaid(startAt, endAt)`, `createForMembershipPurchase` 팩토리
- `ProductAdaptor` + `ProductCustomRepository`에 멤버십 조회 메서드 (`findVisibleMemberships`, `findAllMemberships`)
- `PaymentTargetType.MEMBERSHIP_PRODUCT` 추가
- 새 예외: `MembershipCapacityExceededException`, `ProductNotPurchasableException`

### Supporters
- `POST /api/v1/memberships/purchase` — `PrepareMembershipPurchaseUseCase` (가시성/정원/중복 검증, `@DistributedLock`)
- `GET /api/v1/catalog/memberships`, `/{productId}` — 공개 카탈로그 (페이징, 잔여 좌석 계산)
- `HandleNicePayReturnUseCase` / `HandleNicePayWebhookUseCase`에 멤버십 분기: enrollment `ACTIVE` + 기간 만료 코인 발급 (`sourceMeta`에 `membershipProductId` 기록)

### Backoffice
- `/api/v1/membership-products` — 생성/리스트/상세/수정 (visibility는 기존 `/api/v1/products/{id}/visibility` 재사용)

### 사이드 이펙트
- `Enrollment.courseId` nullable 전환으로 영향받은 DTO 5개 타입 시그니처 동기화 (`EnrollmentWithStudentResponse`, `MyEnrollmentResponse`, `GetEnrollmentLessonsUseCase`, `EnrollmentPageResponse`, `EnrollmentResponse`)

## Test plan
- [x] `PrepareMembershipPurchaseUseCaseTest` — 성공 3건 + 실패 4건 (타입 mismatch, 비공개, 정원 초과, 중복 구매)
- [x] `HandleNicePayReturnUseCaseTest` — 멤버십 성공(ACTIVE 전환/코인 발급/startAt·endAt 세팅) + 타입 mismatch 시 ISSUE_COIN_FAILED 마킹
- [x] Backoffice CRUD 4종 테스트 (Create/Update/GetDetail/GetList)
- [x] `./gradlew build` 통과
- [ ] dev 환경 통합 테스트 (결제 실제 PG 연동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)