### PR TITLE
feat(commission): 의뢰 생성 시 활성 멤버십 검증 추가 (#256)

### DIFF
--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/CreateCommissionUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/CreateCommissionUseCase.kt
@@ -8,6 +8,8 @@ import com.sclass.domain.domains.commission.adaptor.CommissionPolicyAdaptor
 import com.sclass.domain.domains.commission.domain.Commission
 import com.sclass.domain.domains.commission.domain.CommissionFile
 import com.sclass.domain.domains.commission.domain.GuideInfo
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.exception.NoActiveMembershipException
 import com.sclass.domain.domains.file.adaptor.FileAdaptor
 import com.sclass.domain.domains.teacherassignment.adaptor.TeacherAssignmentAdaptor
 import com.sclass.domain.domains.user.domain.Platform
@@ -29,12 +31,15 @@ class CreateCommissionUseCase(
     private val commissionReminderScheduler: CommissionReminderScheduler,
     private val coinDomainService: CoinDomainService,
     private val commissionPolicyAdaptor: CommissionPolicyAdaptor,
+    private val enrollmentAdaptor: EnrollmentAdaptor,
 ) {
     @Transactional
     fun execute(
         studentUserId: String,
         request: CreateCommissionRequest,
     ): CommissionResponse {
+        if (!enrollmentAdaptor.hasActiveMembershipEnrollment(studentUserId)) throw NoActiveMembershipException()
+
         val assignment =
             teacherAssignmentAdaptor.findActiveByStudentUserIdAndPlatformAndOrganizationId(
                 studentUserId = studentUserId,

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/CreateCommissionUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/CreateCommissionUseCaseTest.kt
@@ -10,6 +10,8 @@ import com.sclass.domain.domains.commission.domain.Commission
 import com.sclass.domain.domains.commission.domain.CommissionPolicy
 import com.sclass.domain.domains.commission.domain.CommissionStatus
 import com.sclass.domain.domains.commission.domain.OutputFormat
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.exception.NoActiveMembershipException
 import com.sclass.domain.domains.file.adaptor.FileAdaptor
 import com.sclass.domain.domains.file.domain.File
 import com.sclass.domain.domains.teacherassignment.adaptor.TeacherAssignmentAdaptor
@@ -39,6 +41,7 @@ class CreateCommissionUseCaseTest {
     private lateinit var commissionReminderScheduler: CommissionReminderScheduler
     private lateinit var coinDomainService: CoinDomainService
     private lateinit var commissionPolicyAdaptor: CommissionPolicyAdaptor
+    private lateinit var enrollmentAdaptor: EnrollmentAdaptor
     private lateinit var useCase: CreateCommissionUseCase
 
     @BeforeEach
@@ -51,6 +54,8 @@ class CreateCommissionUseCaseTest {
         commissionReminderScheduler = mockk(relaxed = true)
         coinDomainService = mockk(relaxed = true)
         commissionPolicyAdaptor = mockk()
+        enrollmentAdaptor = mockk()
+        every { enrollmentAdaptor.hasActiveMembershipEnrollment(any()) } returns true
         useCase =
             CreateCommissionUseCase(
                 commissionAdaptor,
@@ -61,6 +66,7 @@ class CreateCommissionUseCaseTest {
                 commissionReminderScheduler,
                 coinDomainService,
                 commissionPolicyAdaptor,
+                enrollmentAdaptor,
             )
     }
 
@@ -117,6 +123,15 @@ class CreateCommissionUseCaseTest {
             { assertEquals("미시경제학", result.guideInfo.subject) },
             { assertEquals("A4 3매 이내", result.guideInfo.volume) },
         )
+    }
+
+    @Test
+    fun `활성 멤버십이 없으면 의뢰 생성이 거부된다`() {
+        every { enrollmentAdaptor.hasActiveMembershipEnrollment(any()) } returns false
+
+        assertThrows<NoActiveMembershipException> {
+            useCase.execute("student-user-id-0000000001", createRequest())
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `CreateCommissionUseCase`에 `EnrollmentAdaptor.hasActiveMembershipEnrollment` 검증 추가
- 활성 멤버십 없는 유저가 의뢰 생성 시 `NoActiveMembershipException` (403) 반환
- `CreateCommissionUseCaseTest`에 멤버십 없을 때 거부 케이스 추가

## Test plan
- [x] 활성 멤버십 없는 유저 → `NoActiveMembershipException` 발생
- [x] 기존 테스트 전체 통과 (코인 차감, 파일 첨부, 선생님 미배정 등)

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)