### PR TITLE
feat(coin): 코인 트랜잭션 히스토리 조회 + 잔액 lot 상세 개선 (#261)

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coin/controller/AdminCoinController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coin/controller/AdminCoinController.kt
@@ -1,12 +1,9 @@
-package com.sclass.supporters.coin.controller
+package com.sclass.backoffice.coin.controller
 
-import com.sclass.common.annotation.CurrentUserId
+import com.sclass.backoffice.coin.dto.AdminCoinTransactionHistoryResponse
+import com.sclass.backoffice.coin.usecase.GetAdminCoinTransactionHistoryUseCase
 import com.sclass.common.dto.ApiResponse
 import com.sclass.domain.domains.coin.domain.CoinTransactionType
-import com.sclass.supporters.coin.dto.CoinBalanceResponse
-import com.sclass.supporters.coin.dto.CoinTransactionHistoryResponse
-import com.sclass.supporters.coin.usecase.GetCoinBalanceUseCase
-import com.sclass.supporters.coin.usecase.GetCoinTransactionHistoryUseCase
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -16,23 +13,17 @@ import java.time.LocalDateTime
 
 @RestController
 @RequestMapping("/api/v1/coins")
-class CoinController(
-    private val getCoinBalanceUseCase: GetCoinBalanceUseCase,
-    private val getCoinTransactionHistoryUseCase: GetCoinTransactionHistoryUseCase,
+class AdminCoinController(
+    private val getAdminCoinTransactionHistoryUseCase: GetAdminCoinTransactionHistoryUseCase,
 ) {
-    @GetMapping("/balance")
-    fun getBalance(
-        @CurrentUserId userId: String,
-    ): ApiResponse<CoinBalanceResponse> = ApiResponse.success(getCoinBalanceUseCase.execute(userId))
-
     @GetMapping("/transactions")
     fun getTransactions(
-        @CurrentUserId userId: String,
+        @RequestParam userId: String,
         @RequestParam(required = false) type: CoinTransactionType?,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: LocalDateTime?,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: LocalDateTime?,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "20") size: Int,
-    ): ApiResponse<CoinTransactionHistoryResponse> =
-        ApiResponse.success(getCoinTransactionHistoryUseCase.execute(userId, type, from, to, page, size))
+    ): ApiResponse<AdminCoinTransactionHistoryResponse> =
+        ApiResponse.success(getAdminCoinTransactionHistoryUseCase.execute(userId, type, from, to, page, size))
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coin/dto/AdminCoinTransactionHistoryResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coin/dto/AdminCoinTransactionHistoryResponse.kt
@@ -1,0 +1,43 @@
+package com.sclass.backoffice.coin.dto
+
+import com.sclass.domain.domains.coin.domain.CoinTransactionType
+import com.sclass.domain.domains.coin.dto.CoinTransactionGroupDto
+import org.springframework.data.domain.Page
+import java.time.LocalDateTime
+
+data class AdminCoinTransactionHistoryResponse(
+    val content: List<CoinTransactionItem>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+) {
+    data class CoinTransactionItem(
+        val type: CoinTransactionType,
+        val totalAmount: Int,
+        val referenceId: String?,
+        val description: String?,
+        val createdAt: LocalDateTime,
+    )
+
+    companion object {
+        fun from(
+            page: Page<CoinTransactionGroupDto>,
+            currentPage: Int,
+        ): AdminCoinTransactionHistoryResponse =
+            AdminCoinTransactionHistoryResponse(
+                content =
+                    page.content.map {
+                        CoinTransactionItem(
+                            type = it.type,
+                            totalAmount = it.totalAmount,
+                            referenceId = it.referenceId,
+                            description = it.description,
+                            createdAt = it.createdAt,
+                        )
+                    },
+                totalElements = page.totalElements,
+                totalPages = page.totalPages,
+                currentPage = currentPage,
+            )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coin/dto/AdminCoinTransactionHistoryResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coin/dto/AdminCoinTransactionHistoryResponse.kt
@@ -13,7 +13,7 @@ data class AdminCoinTransactionHistoryResponse(
 ) {
     data class CoinTransactionItem(
         val type: CoinTransactionType,
-        val totalAmount: Int,
+        val totalAmount: Long,
         val referenceId: String?,
         val description: String?,
         val createdAt: LocalDateTime,

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coin/usecase/GetAdminCoinTransactionHistoryUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coin/usecase/GetAdminCoinTransactionHistoryUseCase.kt
@@ -1,0 +1,28 @@
+package com.sclass.backoffice.coin.usecase
+
+import com.sclass.backoffice.coin.dto.AdminCoinTransactionHistoryResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.coin.adaptor.CoinAdaptor
+import com.sclass.domain.domains.coin.domain.CoinTransactionType
+import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@UseCase
+class GetAdminCoinTransactionHistoryUseCase(
+    private val coinAdaptor: CoinAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(
+        userId: String,
+        type: CoinTransactionType?,
+        from: LocalDateTime?,
+        to: LocalDateTime?,
+        page: Int,
+        size: Int,
+    ): AdminCoinTransactionHistoryResponse {
+        val pageable = PageRequest.of(page, size)
+        val result = coinAdaptor.findGroupedTransactions(userId, type, from, to, pageable)
+        return AdminCoinTransactionHistoryResponse.from(result, page)
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/coin/usecase/GetAdminCoinTransactionHistoryUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/coin/usecase/GetAdminCoinTransactionHistoryUseCaseTest.kt
@@ -1,4 +1,4 @@
-package com.sclass.supporters.coin.usecase
+package com.sclass.backoffice.coin.usecase
 
 import com.sclass.domain.domains.coin.adaptor.CoinAdaptor
 import com.sclass.domain.domains.coin.domain.CoinTransactionType
@@ -13,18 +13,18 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import java.time.LocalDateTime
 
-class GetCoinTransactionHistoryUseCaseTest {
+class GetAdminCoinTransactionHistoryUseCaseTest {
     private lateinit var coinAdaptor: CoinAdaptor
-    private lateinit var useCase: GetCoinTransactionHistoryUseCase
+    private lateinit var useCase: GetAdminCoinTransactionHistoryUseCase
 
     @BeforeEach
     fun setUp() {
         coinAdaptor = mockk()
-        useCase = GetCoinTransactionHistoryUseCase(coinAdaptor)
+        useCase = GetAdminCoinTransactionHistoryUseCase(coinAdaptor)
     }
 
     @Test
-    fun `트랜잭션 히스토리를 그룹핑하여 반환한다`() {
+    fun `userId 기준으로 트랜잭션 히스토리를 반환한다`() {
         val now = LocalDateTime.of(2026, 4, 19, 12, 0)
         val items =
             listOf(

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/coin/dto/CoinBalanceResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/coin/dto/CoinBalanceResponse.kt
@@ -1,5 +1,36 @@
 package com.sclass.supporters.coin.dto
 
+import com.sclass.domain.domains.coin.domain.CoinLot
+import com.sclass.domain.domains.coin.domain.CoinLotSourceType
+import java.time.LocalDateTime
+
 data class CoinBalanceResponse(
     val balance: Int,
-)
+    val lots: List<CoinLotItem>,
+) {
+    data class CoinLotItem(
+        val lotId: String,
+        val remaining: Int,
+        val expireAt: LocalDateTime?,
+        val sourceType: CoinLotSourceType,
+    )
+
+    companion object {
+        fun of(
+            balance: Int,
+            activeLots: List<CoinLot>,
+        ): CoinBalanceResponse =
+            CoinBalanceResponse(
+                balance = balance,
+                lots =
+                    activeLots.map {
+                        CoinLotItem(
+                            lotId = it.id,
+                            remaining = it.remaining,
+                            expireAt = it.expireAt,
+                            sourceType = it.sourceType,
+                        )
+                    },
+            )
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/coin/dto/CoinTransactionHistoryResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/coin/dto/CoinTransactionHistoryResponse.kt
@@ -1,0 +1,43 @@
+package com.sclass.supporters.coin.dto
+
+import com.sclass.domain.domains.coin.domain.CoinTransactionType
+import com.sclass.domain.domains.coin.dto.CoinTransactionGroupDto
+import org.springframework.data.domain.Page
+import java.time.LocalDateTime
+
+data class CoinTransactionHistoryResponse(
+    val content: List<CoinTransactionItem>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+) {
+    data class CoinTransactionItem(
+        val type: CoinTransactionType,
+        val totalAmount: Int,
+        val referenceId: String?,
+        val description: String?,
+        val createdAt: LocalDateTime,
+    )
+
+    companion object {
+        fun from(
+            page: Page<CoinTransactionGroupDto>,
+            currentPage: Int,
+        ): CoinTransactionHistoryResponse =
+            CoinTransactionHistoryResponse(
+                content =
+                    page.content.map {
+                        CoinTransactionItem(
+                            type = it.type,
+                            totalAmount = it.totalAmount,
+                            referenceId = it.referenceId,
+                            description = it.description,
+                            createdAt = it.createdAt,
+                        )
+                    },
+                totalElements = page.totalElements,
+                totalPages = page.totalPages,
+                currentPage = currentPage,
+            )
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/coin/dto/CoinTransactionHistoryResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/coin/dto/CoinTransactionHistoryResponse.kt
@@ -13,7 +13,7 @@ data class CoinTransactionHistoryResponse(
 ) {
     data class CoinTransactionItem(
         val type: CoinTransactionType,
-        val totalAmount: Int,
+        val totalAmount: Long,
         val referenceId: String?,
         val description: String?,
         val createdAt: LocalDateTime,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/coin/usecase/GetCoinBalanceUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/coin/usecase/GetCoinBalanceUseCase.kt
@@ -10,5 +10,9 @@ class GetCoinBalanceUseCase(
     private val coinAdaptor: CoinAdaptor,
 ) {
     @Transactional(readOnly = true)
-    fun execute(userId: String): CoinBalanceResponse = CoinBalanceResponse(balance = coinAdaptor.sumActiveLots(userId))
+    fun execute(userId: String): CoinBalanceResponse {
+        val lots = coinAdaptor.findActiveLots(userId)
+        val balance = lots.sumOf { it.remaining }
+        return CoinBalanceResponse.of(balance, lots)
+    }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/coin/usecase/GetCoinTransactionHistoryUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/coin/usecase/GetCoinTransactionHistoryUseCase.kt
@@ -1,0 +1,28 @@
+package com.sclass.supporters.coin.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.coin.adaptor.CoinAdaptor
+import com.sclass.domain.domains.coin.domain.CoinTransactionType
+import com.sclass.supporters.coin.dto.CoinTransactionHistoryResponse
+import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@UseCase
+class GetCoinTransactionHistoryUseCase(
+    private val coinAdaptor: CoinAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(
+        userId: String,
+        type: CoinTransactionType?,
+        from: LocalDateTime?,
+        to: LocalDateTime?,
+        page: Int,
+        size: Int,
+    ): CoinTransactionHistoryResponse {
+        val pageable = PageRequest.of(page, size)
+        val result = coinAdaptor.findGroupedTransactions(userId, type, from, to, pageable)
+        return CoinTransactionHistoryResponse.from(result, page)
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/coin/usecase/GetCoinBalanceUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/coin/usecase/GetCoinBalanceUseCaseTest.kt
@@ -1,11 +1,15 @@
 package com.sclass.supporters.coin.usecase
 
 import com.sclass.domain.domains.coin.adaptor.CoinAdaptor
+import com.sclass.domain.domains.coin.domain.CoinLot
+import com.sclass.domain.domains.coin.domain.CoinLotSourceType
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
 
 class GetCoinBalanceUseCaseTest {
     private lateinit var coinAdaptor: CoinAdaptor
@@ -17,21 +21,43 @@ class GetCoinBalanceUseCaseTest {
         useCase = GetCoinBalanceUseCase(coinAdaptor)
     }
 
+    private fun makeLot(
+        remaining: Int,
+        expireAt: LocalDateTime? = null,
+    ) = CoinLot(
+        userId = "user-id-0000000000000000000001",
+        amount = remaining,
+        remaining = remaining,
+        expireAt = expireAt,
+        sourceType = CoinLotSourceType.PURCHASE,
+    )
+
     @Test
-    fun `활성 Lot 합계를 잔액으로 반환한다`() {
-        every { coinAdaptor.sumActiveLots(any(), any()) } returns 200
+    fun `활성 Lot 합계를 잔액으로 반환하고 lot 목록을 포함한다`() {
+        val expireAt = LocalDateTime.of(2026, 6, 30, 0, 0)
+        val lots = listOf(makeLot(300, expireAt), makeLot(200))
+        every { coinAdaptor.findActiveLots(any(), any()) } returns lots
 
         val result = useCase.execute("user-id-0000000000000000000001")
 
-        assertEquals(200, result.balance)
+        assertAll(
+            { assertEquals(500, result.balance) },
+            { assertEquals(2, result.lots.size) },
+            { assertEquals(300, result.lots[0].remaining) },
+            { assertEquals(expireAt, result.lots[0].expireAt) },
+            { assertEquals(200, result.lots[1].remaining) },
+        )
     }
 
     @Test
-    fun `활성 Lot 이 없으면 0 을 반환한다`() {
-        every { coinAdaptor.sumActiveLots(any(), any()) } returns 0
+    fun `활성 Lot이 없으면 잔액 0에 빈 목록을 반환한다`() {
+        every { coinAdaptor.findActiveLots(any(), any()) } returns emptyList()
 
         val result = useCase.execute("user-id-0000000000000000000001")
 
-        assertEquals(0, result.balance)
+        assertAll(
+            { assertEquals(0, result.balance) },
+            { assertEquals(0, result.lots.size) },
+        )
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/coin/usecase/GetCoinTransactionHistoryUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/coin/usecase/GetCoinTransactionHistoryUseCaseTest.kt
@@ -1,0 +1,66 @@
+package com.sclass.supporters.coin.usecase
+
+import com.sclass.domain.domains.coin.adaptor.CoinAdaptor
+import com.sclass.domain.domains.coin.domain.CoinTransactionType
+import com.sclass.domain.domains.coin.dto.CoinTransactionGroupDto
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDateTime
+
+class GetCoinTransactionHistoryUseCaseTest {
+    private lateinit var coinAdaptor: CoinAdaptor
+    private lateinit var useCase: GetCoinTransactionHistoryUseCase
+
+    @BeforeEach
+    fun setUp() {
+        coinAdaptor = mockk()
+        useCase = GetCoinTransactionHistoryUseCase(coinAdaptor)
+    }
+
+    @Test
+    fun `트랜잭션 히스토리를 그룹핑하여 반환한다`() {
+        val now = LocalDateTime.of(2026, 4, 19, 12, 0)
+        val items =
+            listOf(
+                CoinTransactionGroupDto(CoinTransactionType.ISSUED, 500, "ref-001", "멤버십 코인 지급", now.minusDays(2)),
+                CoinTransactionGroupDto(CoinTransactionType.DEDUCTED, 100, "ref-002", "의뢰 생성 코인 차감", now.minusDays(1)),
+            )
+        every {
+            coinAdaptor.findGroupedTransactions("user-01", null, null, null, PageRequest.of(0, 20))
+        } returns PageImpl(items, PageRequest.of(0, 20), 2)
+
+        val result = useCase.execute("user-01", null, null, null, 0, 20)
+
+        assertAll(
+            { assertEquals(2, result.content.size) },
+            { assertEquals(CoinTransactionType.ISSUED, result.content[0].type) },
+            { assertEquals(500, result.content[0].totalAmount) },
+            { assertEquals("ref-001", result.content[0].referenceId) },
+            { assertEquals(CoinTransactionType.DEDUCTED, result.content[1].type) },
+            { assertEquals(100, result.content[1].totalAmount) },
+            { assertEquals(2L, result.totalElements) },
+            { assertEquals(1, result.totalPages) },
+            { assertEquals(0, result.currentPage) },
+        )
+    }
+
+    @Test
+    fun `트랜잭션이 없으면 빈 목록을 반환한다`() {
+        every {
+            coinAdaptor.findGroupedTransactions(any(), any(), any(), any(), any())
+        } returns PageImpl(emptyList(), PageRequest.of(0, 20), 0)
+
+        val result = useCase.execute("user-01", null, null, null, 0, 20)
+
+        assertAll(
+            { assertEquals(0, result.content.size) },
+            { assertEquals(0L, result.totalElements) },
+        )
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/adaptor/CoinAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/adaptor/CoinAdaptor.kt
@@ -3,6 +3,8 @@ package com.sclass.domain.domains.coin.adaptor
 import com.sclass.common.annotation.Adaptor
 import com.sclass.domain.domains.coin.domain.CoinLot
 import com.sclass.domain.domains.coin.domain.CoinTransaction
+import com.sclass.domain.domains.coin.domain.CoinTransactionType
+import com.sclass.domain.domains.coin.dto.CoinTransactionGroupDto
 import com.sclass.domain.domains.coin.repository.CoinLotRepository
 import com.sclass.domain.domains.coin.repository.CoinTransactionRepository
 import org.springframework.data.domain.Page
@@ -17,6 +19,11 @@ class CoinAdaptor(
     fun saveLot(lot: CoinLot): CoinLot = coinLotRepository.save(lot)
 
     fun saveLots(lots: List<CoinLot>): List<CoinLot> = coinLotRepository.saveAll(lots)
+
+    fun findActiveLots(
+        userId: String,
+        now: LocalDateTime = LocalDateTime.now(),
+    ): List<CoinLot> = coinLotRepository.findActive(userId, now)
 
     fun findActiveLotsForUpdate(
         userId: String,
@@ -43,4 +50,12 @@ class CoinAdaptor(
         userId: String,
         pageable: Pageable,
     ): Page<CoinTransaction> = coinTransactionRepository.findAllByUserId(userId, pageable)
+
+    fun findGroupedTransactions(
+        userId: String,
+        type: CoinTransactionType?,
+        from: LocalDateTime?,
+        to: LocalDateTime?,
+        pageable: Pageable,
+    ): Page<CoinTransactionGroupDto> = coinTransactionRepository.findGroupedByUser(userId, type, from, to, pageable)
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/dto/CoinTransactionGroupDto.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/dto/CoinTransactionGroupDto.kt
@@ -1,0 +1,12 @@
+package com.sclass.domain.domains.coin.dto
+
+import com.sclass.domain.domains.coin.domain.CoinTransactionType
+import java.time.LocalDateTime
+
+data class CoinTransactionGroupDto(
+    val type: CoinTransactionType,
+    val totalAmount: Int,
+    val referenceId: String?,
+    val description: String?,
+    val createdAt: LocalDateTime,
+)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/dto/CoinTransactionGroupDto.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/dto/CoinTransactionGroupDto.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 
 data class CoinTransactionGroupDto(
     val type: CoinTransactionType,
-    val totalAmount: Int,
+    val totalAmount: Long,
     val referenceId: String?,
     val description: String?,
     val createdAt: LocalDateTime,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinLotCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinLotCustomRepository.kt
@@ -14,6 +14,11 @@ interface CoinLotCustomRepository {
         now: LocalDateTime,
     ): Int
 
+    fun findActive(
+        userId: String,
+        now: LocalDateTime,
+    ): List<CoinLot>
+
     fun findExpiringBefore(
         now: LocalDateTime,
         limit: Int,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinLotCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinLotCustomRepositoryImpl.kt
@@ -46,6 +46,27 @@ class CoinLotCustomRepositoryImpl(
                 coinLot.expireAt.isNull.or(coinLot.expireAt.gt(now)),
             ).fetchOne() ?: 0
 
+    override fun findActive(
+        userId: String,
+        now: LocalDateTime,
+    ): List<CoinLot> =
+        queryFactory
+            .selectFrom(coinLot)
+            .where(
+                coinLot.userId.eq(userId),
+                coinLot.remaining.gt(0),
+                coinLot.expireAt.isNull.or(coinLot.expireAt.gt(now)),
+            ).orderBy(
+                Expressions
+                    .numberTemplate(
+                        Int::class.java,
+                        "case when {0} is null then 1 else 0 end",
+                        coinLot.expireAt,
+                    ).asc(),
+                coinLot.expireAt.asc(),
+                coinLot.createdAt.asc(),
+            ).fetch()
+
     override fun findExpiringBefore(
         now: LocalDateTime,
         limit: Int,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinLotCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinLotCustomRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.sclass.domain.domains.coin.repository
 
-import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.sclass.domain.domains.coin.domain.CoinLot
 import com.sclass.domain.domains.coin.domain.QCoinLot.coinLot
@@ -21,14 +20,7 @@ class CoinLotCustomRepositoryImpl(
                 coinLot.remaining.gt(0),
                 coinLot.expireAt.isNull.or(coinLot.expireAt.gt(now)),
             ).orderBy(
-                // expireAt null 을 뒤로 (만료 임박 순)
-                Expressions
-                    .numberTemplate(
-                        Int::class.java,
-                        "case when {0} is null then 1 else 0 end",
-                        coinLot.expireAt,
-                    ).asc(),
-                coinLot.expireAt.asc(),
+                coinLot.expireAt.asc().nullsLast(),
                 coinLot.createdAt.asc(),
             ).setLockMode(LockModeType.PESSIMISTIC_WRITE)
             .fetch()
@@ -57,13 +49,7 @@ class CoinLotCustomRepositoryImpl(
                 coinLot.remaining.gt(0),
                 coinLot.expireAt.isNull.or(coinLot.expireAt.gt(now)),
             ).orderBy(
-                Expressions
-                    .numberTemplate(
-                        Int::class.java,
-                        "case when {0} is null then 1 else 0 end",
-                        coinLot.expireAt,
-                    ).asc(),
-                coinLot.expireAt.asc(),
+                coinLot.expireAt.asc().nullsLast(),
                 coinLot.createdAt.asc(),
             ).fetch()
 

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinTransactionCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinTransactionCustomRepository.kt
@@ -1,0 +1,17 @@
+package com.sclass.domain.domains.coin.repository
+
+import com.sclass.domain.domains.coin.domain.CoinTransactionType
+import com.sclass.domain.domains.coin.dto.CoinTransactionGroupDto
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
+
+interface CoinTransactionCustomRepository {
+    fun findGroupedByUser(
+        userId: String,
+        type: CoinTransactionType?,
+        from: LocalDateTime?,
+        to: LocalDateTime?,
+        pageable: Pageable,
+    ): Page<CoinTransactionGroupDto>
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinTransactionCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinTransactionCustomRepositoryImpl.kt
@@ -1,0 +1,67 @@
+package com.sclass.domain.domains.coin.repository
+
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sclass.domain.domains.coin.domain.CoinTransactionType
+import com.sclass.domain.domains.coin.domain.QCoinTransaction.coinTransaction
+import com.sclass.domain.domains.coin.dto.CoinTransactionGroupDto
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
+
+class CoinTransactionCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : CoinTransactionCustomRepository {
+    override fun findGroupedByUser(
+        userId: String,
+        type: CoinTransactionType?,
+        from: LocalDateTime?,
+        to: LocalDateTime?,
+        pageable: Pageable,
+    ): Page<CoinTransactionGroupDto> {
+        val conditions =
+            listOfNotNull(
+                coinTransaction.userId.eq(userId),
+                type?.let { coinTransaction.type.eq(it) },
+                from?.let { coinTransaction.createdAt.goe(it) },
+                to?.let { coinTransaction.createdAt.loe(it) },
+            ).toTypedArray()
+
+        val content =
+            queryFactory
+                .select(
+                    Projections.constructor(
+                        CoinTransactionGroupDto::class.java,
+                        coinTransaction.type,
+                        coinTransaction.amount.sum(),
+                        coinTransaction.referenceId,
+                        coinTransaction.description.max(),
+                        coinTransaction.createdAt.min(),
+                    ),
+                ).from(coinTransaction)
+                .where(*conditions)
+                .groupBy(coinTransaction.type, coinTransaction.referenceId)
+                .orderBy(coinTransaction.createdAt.min().desc())
+                .offset(pageable.offset)
+                .limit(pageable.pageSize.toLong())
+                .fetch()
+
+        // referenceId가 있는 그룹 수 + referenceId가 null인 row 수
+        val groupedCount =
+            queryFactory
+                .select(coinTransaction.referenceId.countDistinct())
+                .from(coinTransaction)
+                .where(*conditions, coinTransaction.referenceId.isNotNull)
+                .fetchOne() ?: 0L
+
+        val ungroupedCount =
+            queryFactory
+                .select(coinTransaction.count())
+                .from(coinTransaction)
+                .where(*conditions, coinTransaction.referenceId.isNull)
+                .fetchOne() ?: 0L
+
+        return PageImpl(content, pageable, groupedCount + ungroupedCount)
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinTransactionCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinTransactionCustomRepositoryImpl.kt
@@ -34,7 +34,7 @@ class CoinTransactionCustomRepositoryImpl(
                     Projections.constructor(
                         CoinTransactionGroupDto::class.java,
                         coinTransaction.type,
-                        coinTransaction.amount.sum(),
+                        coinTransaction.amount.sum().longValue(),
                         coinTransaction.referenceId,
                         coinTransaction.description.max(),
                         coinTransaction.createdAt.min(),

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinTransactionCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinTransactionCustomRepositoryImpl.kt
@@ -42,26 +42,21 @@ class CoinTransactionCustomRepositoryImpl(
                 ).from(coinTransaction)
                 .where(*conditions)
                 .groupBy(coinTransaction.type, coinTransaction.referenceId)
-                .orderBy(coinTransaction.createdAt.min().desc())
+                .orderBy(coinTransaction.createdAt.min().desc(), coinTransaction.id.min().asc())
                 .offset(pageable.offset)
                 .limit(pageable.pageSize.toLong())
                 .fetch()
 
-        // referenceId가 있는 그룹 수 + referenceId가 null인 row 수
-        val groupedCount =
+        val total =
             queryFactory
-                .select(coinTransaction.referenceId.countDistinct())
+                .select(coinTransaction.type, coinTransaction.referenceId)
                 .from(coinTransaction)
-                .where(*conditions, coinTransaction.referenceId.isNotNull)
-                .fetchOne() ?: 0L
+                .where(*conditions)
+                .groupBy(coinTransaction.type, coinTransaction.referenceId)
+                .fetch()
+                .size
+                .toLong()
 
-        val ungroupedCount =
-            queryFactory
-                .select(coinTransaction.count())
-                .from(coinTransaction)
-                .where(*conditions, coinTransaction.referenceId.isNull)
-                .fetchOne() ?: 0L
-
-        return PageImpl(content, pageable, groupedCount + ungroupedCount)
+        return PageImpl(content, pageable, total)
     }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinTransactionRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/coin/repository/CoinTransactionRepository.kt
@@ -5,7 +5,9 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CoinTransactionRepository : JpaRepository<CoinTransaction, String> {
+interface CoinTransactionRepository :
+    JpaRepository<CoinTransaction, String>,
+    CoinTransactionCustomRepository {
     fun findAllByUserId(
         userId: String,
         pageable: Pageable,


### PR DESCRIPTION
## Summary
- `GET /api/v1/coins/transactions` (Supporters) — referenceId 기준 그룹핑된 트랜잭션 히스토리 (type/from/to 필터, 페이지네이션)
- `GET /api/v1/coins/transactions?userId=` (Backoffice) — 어드민용 유저 트랜잭션 조회
- `GET /api/v1/coins/balance` 개선 — 잔액 합계 + 활성 lot 목록(remaining, expireAt, sourceType) 함께 반환
- `CoinLotCustomRepository.findActive()` 추가 — lock 없는 읽기 전용 조회
- `CoinTransactionCustomRepository` 신설 — QueryDSL GROUP BY referenceId + type 집계 쿼리

## Test plan
- [x] 트랜잭션 그룹핑 반환, 빈 목록 케이스
- [x] balance lot 목록 포함, 빈 lot 케이스

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)