### PR TITLE
feat(payment,enrollment): PENDING_PAYMENT 배치 정리 + 수강 불가 코스 자동 환불 (#249)

### DIFF
--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
@@ -6,7 +6,6 @@ import com.sclass.domain.domains.course.adaptor.CourseAdaptor
 import com.sclass.domain.domains.course.exception.CourseNotEnrollableException
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
-import com.sclass.domain.domains.enrollment.exception.EnrollmentAlreadyExistsException
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.Payment
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
@@ -35,17 +34,18 @@ class PrepareEnrollmentUseCase(
         pgType: PgType,
     ): PrepareEnrollmentResponse {
         val course = courseAdaptor.findById(courseId)
-        val liveCount = enrollmentAdaptor.countLiveEnrollments(courseId)
-        if (!course.canEnroll(LocalDateTime.now(), liveCount)) {
-            throw CourseNotEnrollableException()
-        }
-
         val product =
             productAdaptor.findById(course.productId) as? CourseProduct
                 ?: throw ProductTypeMismatchException()
 
-        if (enrollmentAdaptor.findLiveEnrollment(courseId, studentUserId) != null) {
-            throw EnrollmentAlreadyExistsException()
+        enrollmentAdaptor.findResumableEnrollment(courseId, studentUserId)?.let { live ->
+            val payment = paymentAdaptor.findById(live.paymentId!!)
+            return PrepareEnrollmentResponse(payment.id, payment.pgOrderId, payment.amount, course.id, product.name)
+        }
+
+        val liveCount = enrollmentAdaptor.countLiveEnrollments(courseId)
+        if (!course.canEnroll(LocalDateTime.now(), liveCount)) {
+            throw CourseNotEnrollableException()
         }
 
         val payment =

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/membership/usecase/PrepareMembershipPurchaseUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/membership/usecase/PrepareMembershipPurchaseUseCase.kt
@@ -4,7 +4,6 @@ import com.sclass.common.annotation.UseCase
 import com.sclass.domain.common.vo.Ulid
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
-import com.sclass.domain.domains.enrollment.exception.EnrollmentAlreadyExistsException
 import com.sclass.domain.domains.enrollment.exception.MembershipCapacityExceededException
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.Payment
@@ -39,12 +38,14 @@ class PrepareMembershipPurchaseUseCase(
         if (!product.visible) throw ProductNotPurchasableException()
         product.validateSaleable(LocalDateTime.now())
 
+        enrollmentAdaptor.findResumableMembershipEnrollment(product.id, studentUserId)?.let { live ->
+            val payment = paymentAdaptor.findById(live.paymentId!!)
+            return PrepareMembershipPurchaseResponse(payment.id, payment.pgOrderId, payment.amount, product.id, product.name)
+        }
+
         product.maxEnrollments?.let { cap ->
             val live = enrollmentAdaptor.countLiveMembershipEnrollments(product.id)
             if (live >= cap) throw MembershipCapacityExceededException()
-        }
-        if (enrollmentAdaptor.findLiveMembershipEnrollment(product.id, studentUserId) != null) {
-            throw EnrollmentAlreadyExistsException()
         }
 
         val payment =

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -5,6 +5,7 @@ import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
 import com.sclass.domain.domains.coin.domain.CoinLotSourceType
 import com.sclass.domain.domains.coin.service.CoinDomainService
 import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.course.domain.CourseStatus
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.lesson.service.LessonDomainService
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
@@ -118,6 +119,32 @@ class HandleNicePayWebhookUseCase(
                     log.warn("웹훅 수신: enrollment 없음 paymentId={}", payment.id)
                     return
                 }
+
+                val courseId =
+                    enrollment.courseId ?: error("COURSE_PRODUCT enrollment must have courseId")
+                val course = courseAdaptor.findById(courseId)
+
+                if (course.status == CourseStatus.UNLISTED || course.status == CourseStatus.ARCHIVED) {
+                    log.info("웹훅 수신: 수강 불가 코스 상태={} paymentId={}", course.status, payment.id)
+                    val cancelSuccess =
+                        runCatching { pgGateway.cancel(payload.tid, payment.amount, "수강 불가 코스 자동 환불") }
+                            .onFailure { e -> log.error("PG 취소 실패 paymentId={}", payment.id, e) }
+                            .isSuccess
+                    txTemplate.execute {
+                        val fresh = paymentAdaptor.findById(payment.id)
+                        val freshEnrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
+                        if (cancelSuccess) {
+                            fresh.markCancelled()
+                        } else {
+                            fresh.markPgCancelFailed()
+                        }
+                        freshEnrollment.cancel("수강 불가 상태의 코스 - 자동 환불${if (!cancelSuccess) " 실패" else ""}")
+                        paymentAdaptor.save(fresh)
+                        enrollmentAdaptor.save(freshEnrollment)
+                    }
+                    return
+                }
+
                 txTemplate.execute {
                     val fresh = paymentAdaptor.findById(payment.id)
                     val freshEnrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
@@ -126,10 +153,6 @@ class HandleNicePayWebhookUseCase(
                     fresh.markCompleted()
                     paymentAdaptor.save(fresh)
 
-                    val courseId =
-                        freshEnrollment.courseId
-                            ?: error("COURSE_PRODUCT enrollment must have courseId")
-                    val course = courseAdaptor.findById(courseId)
                     lessonService.createLessonsForEnrollment(
                         freshEnrollment,
                         teacherUserId = course.teacherUserId,

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
@@ -83,7 +83,7 @@ class PrepareEnrollmentUseCaseTest {
             every { courseAdaptor.findById(1L) } returns listedCourse()
             every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 0L
             every { productAdaptor.findById("product-id-00000000001") } returns courseProduct()
-            every { enrollmentAdaptor.findLiveEnrollment(1L, "student-id-00000000001") } returns null
+            every { enrollmentAdaptor.findResumableEnrollment(1L, "student-id-00000000001") } returns null
             every { paymentAdaptor.save(any()) } returns pendingPayment()
             every { enrollmentAdaptor.save(capture(enrollmentSlot)) } answers { enrollmentSlot.captured }
 
@@ -102,6 +102,8 @@ class PrepareEnrollmentUseCaseTest {
         @Test
         fun `코스가 등록 불가능하면 CourseNotEnrollableException이 발생한다`() {
             every { courseAdaptor.findById(1L) } returns draftCourse()
+            every { productAdaptor.findById(any()) } returns courseProduct()
+            every { enrollmentAdaptor.findResumableEnrollment(any(), any()) } returns null
             every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 0L
 
             assertThatThrownBy {
@@ -110,7 +112,18 @@ class PrepareEnrollmentUseCaseTest {
         }
 
         @Test
-        fun `이미 등록된 코스이면 EnrollmentAlreadyExistsException이 발생한다`() {
+        fun `ACTIVE enrollment이 있으면 EnrollmentAlreadyExistsException이 발생한다`() {
+            every { courseAdaptor.findById(1L) } returns listedCourse()
+            every { productAdaptor.findById(any()) } returns courseProduct()
+            every { enrollmentAdaptor.findResumableEnrollment(1L, "student-id-00000000001") } throws EnrollmentAlreadyExistsException()
+
+            assertThatThrownBy {
+                useCase.execute("student-id-00000000001", 1L, PgType.NICEPAY)
+            }.isInstanceOf(EnrollmentAlreadyExistsException::class.java)
+        }
+
+        @Test
+        fun `PENDING_PAYMENT enrollment이 있으면 기존 결제 정보를 그대로 반환한다`() {
             val existingEnrollment =
                 Enrollment.createForPurchase(
                     courseId = 1L,
@@ -119,13 +132,15 @@ class PrepareEnrollmentUseCaseTest {
                     paymentId = "payment-id-000000000001",
                 )
             every { courseAdaptor.findById(1L) } returns listedCourse()
-            every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 0L
             every { productAdaptor.findById(any()) } returns courseProduct()
-            every { enrollmentAdaptor.findLiveEnrollment(1L, "student-id-00000000001") } returns existingEnrollment
+            every { enrollmentAdaptor.findResumableEnrollment(1L, "student-id-00000000001") } returns existingEnrollment
+            every { paymentAdaptor.findById("payment-id-000000000001") } returns pendingPayment()
 
-            assertThatThrownBy {
-                useCase.execute("student-id-00000000001", 1L, PgType.NICEPAY)
-            }.isInstanceOf(EnrollmentAlreadyExistsException::class.java)
+            val result = useCase.execute("student-id-00000000001", 1L, PgType.NICEPAY)
+
+            assertThat(result.pgOrderId).isEqualTo("order-id-000000000001")
+            verify(exactly = 0) { paymentAdaptor.save(any()) }
+            verify(exactly = 0) { enrollmentAdaptor.save(any()) }
         }
 
         @Test
@@ -133,7 +148,7 @@ class PrepareEnrollmentUseCaseTest {
             every { courseAdaptor.findById(1L) } returns listedCourse()
             every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 0L
             every { productAdaptor.findById(any()) } returns mockk<Product>()
-            every { enrollmentAdaptor.findLiveEnrollment(any(), any()) } returns null
+            every { enrollmentAdaptor.findResumableEnrollment(any(), any()) } returns null
 
             assertThatThrownBy {
                 useCase.execute("student-id-00000000001", 1L, PgType.NICEPAY)
@@ -145,7 +160,7 @@ class PrepareEnrollmentUseCaseTest {
             every { courseAdaptor.findById(1L) } returns listedCourse()
             every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 0L
             every { productAdaptor.findById(any()) } returns courseProduct()
-            every { enrollmentAdaptor.findLiveEnrollment(any(), any()) } returns null
+            every { enrollmentAdaptor.findResumableEnrollment(any(), any()) } returns null
             every { paymentAdaptor.save(any()) } returns pendingPayment()
             every { enrollmentAdaptor.save(any()) } answers { firstArg() }
 

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/membership/usecase/PrepareMembershipPurchaseUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/membership/usecase/PrepareMembershipPurchaseUseCaseTest.kt
@@ -99,7 +99,7 @@ class PrepareMembershipPurchaseUseCaseTest {
             val product = visibleMembership()
             val enrollmentSlot = slot<Enrollment>()
             every { productAdaptor.findById(membershipProductId) } returns product
-            every { enrollmentAdaptor.findLiveMembershipEnrollment(product.id, studentUserId) } returns null
+            every { enrollmentAdaptor.findResumableMembershipEnrollment(product.id, studentUserId) } returns null
             every { paymentAdaptor.save(any()) } returns pendingPayment()
             every { enrollmentAdaptor.save(capture(enrollmentSlot)) } answers { enrollmentSlot.captured }
 
@@ -119,7 +119,7 @@ class PrepareMembershipPurchaseUseCaseTest {
         fun `maxEnrollments null이면 정원 검증을 건너뛴다`() {
             val product = visibleMembership(maxEnrollments = null)
             every { productAdaptor.findById(membershipProductId) } returns product
-            every { enrollmentAdaptor.findLiveMembershipEnrollment(product.id, studentUserId) } returns null
+            every { enrollmentAdaptor.findResumableMembershipEnrollment(product.id, studentUserId) } returns null
             every { paymentAdaptor.save(any()) } returns pendingPayment()
             every { enrollmentAdaptor.save(any()) } answers { firstArg() }
 
@@ -133,7 +133,7 @@ class PrepareMembershipPurchaseUseCaseTest {
             val product = visibleMembership(maxEnrollments = 10)
             every { productAdaptor.findById(membershipProductId) } returns product
             every { enrollmentAdaptor.countLiveMembershipEnrollments(product.id) } returns 5L
-            every { enrollmentAdaptor.findLiveMembershipEnrollment(product.id, studentUserId) } returns null
+            every { enrollmentAdaptor.findResumableMembershipEnrollment(product.id, studentUserId) } returns null
             every { paymentAdaptor.save(any()) } returns pendingPayment()
             every { enrollmentAdaptor.save(any()) } answers { firstArg() }
 
@@ -168,6 +168,7 @@ class PrepareMembershipPurchaseUseCaseTest {
         fun `정원 초과 시 MembershipCapacityExceededException이 발생한다`() {
             val product = visibleMembership(maxEnrollments = 10)
             every { productAdaptor.findById(membershipProductId) } returns product
+            every { enrollmentAdaptor.findResumableMembershipEnrollment(product.id, studentUserId) } returns null
             every { enrollmentAdaptor.countLiveMembershipEnrollments(product.id) } returns 10L
 
             assertThatThrownBy {
@@ -191,7 +192,19 @@ class PrepareMembershipPurchaseUseCaseTest {
         }
 
         @Test
-        fun `활성 멤버십이 이미 있으면 EnrollmentAlreadyExistsException이 발생한다`() {
+        fun `ACTIVE 멤버십이 이미 있으면 EnrollmentAlreadyExistsException이 발생한다`() {
+            val product = visibleMembership()
+            every { productAdaptor.findById(membershipProductId) } returns product
+            every { enrollmentAdaptor.findResumableMembershipEnrollment(product.id, studentUserId) } throws
+                EnrollmentAlreadyExistsException()
+
+            assertThatThrownBy {
+                useCase.execute(studentUserId, membershipProductId, PgType.NICEPAY)
+            }.isInstanceOf(EnrollmentAlreadyExistsException::class.java)
+        }
+
+        @Test
+        fun `PENDING_PAYMENT 멤버십이 이미 있으면 기존 결제 정보를 반환한다`() {
             val product = visibleMembership()
             val existing =
                 Enrollment.createForMembershipPurchase(
@@ -201,11 +214,14 @@ class PrepareMembershipPurchaseUseCaseTest {
                     paymentId = "payment-id-000000000001",
                 )
             every { productAdaptor.findById(membershipProductId) } returns product
-            every { enrollmentAdaptor.findLiveMembershipEnrollment(product.id, studentUserId) } returns existing
+            every { enrollmentAdaptor.findResumableMembershipEnrollment(product.id, studentUserId) } returns existing
+            every { paymentAdaptor.findById("payment-id-000000000001") } returns pendingPayment()
 
-            assertThatThrownBy {
-                useCase.execute(studentUserId, membershipProductId, PgType.NICEPAY)
-            }.isInstanceOf(EnrollmentAlreadyExistsException::class.java)
+            val result = useCase.execute(studentUserId, membershipProductId, PgType.NICEPAY)
+
+            assertThat(result.pgOrderId).isEqualTo("order-id-000000000001")
+            verify(exactly = 0) { paymentAdaptor.save(any()) }
+            verify(exactly = 0) { enrollmentAdaptor.save(any()) }
         }
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
@@ -217,6 +217,121 @@ class HandleNicePayWebhookUseCaseTest {
         }
     }
 
+    @Test
+    fun `CourseProduct 결제 시 코스가 UNLISTED이면 자동 환불 처리된다`() {
+        val payment = courseProductPayment()
+        val product = CourseProduct(name = "수학 코스", priceWon = 300000, totalLessons = 12)
+        val enrollment =
+            Enrollment.createForPurchase(
+                courseId = 1L,
+                studentUserId = "student-id-000000000001",
+                tuitionAmountWon = 300000,
+                paymentId = payment.id,
+            )
+        val course =
+            Course(
+                id = 1L,
+                productId = "prod-00000000000000000000000001",
+                teacherUserId = "teacher-id-00000000001",
+                status = CourseStatus.UNLISTED,
+            )
+
+        every { pgGateway.verifyWebhookSignature(any(), any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(any()) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { paymentAdaptor.save(any()) } answers { firstArg() }
+        every { productAdaptor.findById(any()) } returns product
+        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns enrollment
+        every { enrollmentAdaptor.findByPaymentId(payment.id) } returns enrollment
+        every { enrollmentAdaptor.save(any()) } answers { firstArg() }
+        every { courseAdaptor.findById(1L) } returns course
+        every { pgGateway.cancel(any(), any(), any()) } returns mockk()
+
+        useCase.execute(payment.pgOrderId, successPayload(payment.pgOrderId))
+
+        assertAll(
+            { assertEquals(PaymentStatus.CANCELLED, payment.status) },
+            { assertEquals(EnrollmentStatus.CANCELLED, enrollment.status) },
+        )
+        verify(exactly = 0) { lessonService.createLessonsForEnrollment(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `CourseProduct 결제 시 코스가 ARCHIVED이면 자동 환불 처리된다`() {
+        val payment = courseProductPayment()
+        val product = CourseProduct(name = "수학 코스", priceWon = 300000, totalLessons = 12)
+        val enrollment =
+            Enrollment.createForPurchase(
+                courseId = 1L,
+                studentUserId = "student-id-000000000001",
+                tuitionAmountWon = 300000,
+                paymentId = payment.id,
+            )
+        val course =
+            Course(
+                id = 1L,
+                productId = "prod-00000000000000000000000001",
+                teacherUserId = "teacher-id-00000000001",
+                status = CourseStatus.ARCHIVED,
+            )
+
+        every { pgGateway.verifyWebhookSignature(any(), any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(any()) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { paymentAdaptor.save(any()) } answers { firstArg() }
+        every { productAdaptor.findById(any()) } returns product
+        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns enrollment
+        every { enrollmentAdaptor.findByPaymentId(payment.id) } returns enrollment
+        every { enrollmentAdaptor.save(any()) } answers { firstArg() }
+        every { courseAdaptor.findById(1L) } returns course
+        every { pgGateway.cancel(any(), any(), any()) } returns mockk()
+
+        useCase.execute(payment.pgOrderId, successPayload(payment.pgOrderId))
+
+        assertAll(
+            { assertEquals(PaymentStatus.CANCELLED, payment.status) },
+            { assertEquals(EnrollmentStatus.CANCELLED, enrollment.status) },
+        )
+    }
+
+    @Test
+    fun `자동 환불 시 PG 취소 API 실패하면 PG_CANCEL_FAILED로 마킹된다`() {
+        val payment = courseProductPayment()
+        val product = CourseProduct(name = "수학 코스", priceWon = 300000, totalLessons = 12)
+        val enrollment =
+            Enrollment.createForPurchase(
+                courseId = 1L,
+                studentUserId = "student-id-000000000001",
+                tuitionAmountWon = 300000,
+                paymentId = payment.id,
+            )
+        val course =
+            Course(
+                id = 1L,
+                productId = "prod-00000000000000000000000001",
+                teacherUserId = "teacher-id-00000000001",
+                status = CourseStatus.UNLISTED,
+            )
+
+        every { pgGateway.verifyWebhookSignature(any(), any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(any()) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { paymentAdaptor.save(any()) } answers { firstArg() }
+        every { productAdaptor.findById(any()) } returns product
+        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns enrollment
+        every { enrollmentAdaptor.findByPaymentId(payment.id) } returns enrollment
+        every { enrollmentAdaptor.save(any()) } answers { firstArg() }
+        every { courseAdaptor.findById(1L) } returns course
+        every { pgGateway.cancel(any(), any(), any()) } throws RuntimeException("PG 오류")
+
+        useCase.execute(payment.pgOrderId, successPayload(payment.pgOrderId))
+
+        assertAll(
+            { assertEquals(PaymentStatus.PG_CANCEL_FAILED, payment.status) },
+            { assertEquals(EnrollmentStatus.CANCELLED, enrollment.status) },
+        )
+    }
+
     private fun pendingPayment() =
         Payment(
             userId = "user-00000000000000000000000001",

--- a/SClass-Batch/src/main/kotlin/com/sclass/batch/enrollment/CleanupStalePendingEnrollmentsJob.kt
+++ b/SClass-Batch/src/main/kotlin/com/sclass/batch/enrollment/CleanupStalePendingEnrollmentsJob.kt
@@ -8,6 +8,7 @@ import com.sclass.domain.domains.payment.domain.PaymentStatus
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
 import java.time.LocalDateTime
 
 @BatchJob
@@ -15,12 +16,13 @@ class CleanupStalePendingEnrollmentsJob(
     private val enrollmentAdaptor: EnrollmentAdaptor,
     private val paymentAdaptor: PaymentAdaptor,
     private val txTemplate: TransactionTemplate,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Scheduled(fixedDelay = INTERVAL_MS)
     fun execute() {
-        val threshold = LocalDateTime.now().minusMinutes(TTL_MINUTES)
+        val threshold = LocalDateTime.now(clock).minusMinutes(TTL_MINUTES)
         val staleEnrollments = enrollmentAdaptor.findPendingPaymentOlderThan(threshold)
 
         if (staleEnrollments.isEmpty()) return
@@ -36,9 +38,21 @@ class CleanupStalePendingEnrollmentsJob(
 
                     val paymentId = enrollment.paymentId ?: return@execute null
                     val payment = paymentAdaptor.findById(paymentId)
-                    if (payment.status == PaymentStatus.PENDING) {
-                        payment.markCancelled()
-                        paymentAdaptor.save(payment)
+                    when (payment.status) {
+                        PaymentStatus.PENDING -> {
+                            payment.markCancelled()
+                            paymentAdaptor.save(payment)
+                        }
+                        PaymentStatus.CANCELLED -> {}
+                        else -> {
+                            // PG_APPROVED/COMPLETED 등 결제가 이미 진행 중 — 건너뜀
+                            log.warn(
+                                "PENDING_PAYMENT enrollment이지만 결제 상태가 취소 불가 enrollmentId={} paymentStatus={}",
+                                enrollment.id,
+                                payment.status,
+                            )
+                            return@execute null
+                        }
                     }
                     enrollment.cancel("결제 시간 초과 (${TTL_MINUTES}분)")
                     enrollmentAdaptor.save(enrollment)

--- a/SClass-Batch/src/main/kotlin/com/sclass/batch/enrollment/CleanupStalePendingEnrollmentsJob.kt
+++ b/SClass-Batch/src/main/kotlin/com/sclass/batch/enrollment/CleanupStalePendingEnrollmentsJob.kt
@@ -1,0 +1,60 @@
+package com.sclass.batch.enrollment
+
+import com.sclass.common.annotation.BatchJob
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.PaymentStatus
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.LocalDateTime
+
+@BatchJob
+class CleanupStalePendingEnrollmentsJob(
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val paymentAdaptor: PaymentAdaptor,
+    private val txTemplate: TransactionTemplate,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedDelay = INTERVAL_MS)
+    fun execute() {
+        val threshold = LocalDateTime.now().minusMinutes(TTL_MINUTES)
+        val staleEnrollments = enrollmentAdaptor.findPendingPaymentOlderThan(threshold)
+
+        if (staleEnrollments.isEmpty()) return
+
+        log.info("만료된 PENDING_PAYMENT enrollment 정리 시작 - {}건", staleEnrollments.size)
+
+        var successCount = 0
+        staleEnrollments.forEach { stale ->
+            runCatching {
+                txTemplate.execute {
+                    val enrollment = enrollmentAdaptor.findById(stale.id)
+                    if (enrollment.status != EnrollmentStatus.PENDING_PAYMENT) return@execute null
+
+                    val paymentId = enrollment.paymentId ?: return@execute null
+                    val payment = paymentAdaptor.findById(paymentId)
+                    if (payment.status == PaymentStatus.PENDING) {
+                        payment.markCancelled()
+                        paymentAdaptor.save(payment)
+                    }
+                    enrollment.cancel("결제 시간 초과 (${TTL_MINUTES}분)")
+                    enrollmentAdaptor.save(enrollment)
+                    null
+                }
+                successCount++
+            }.onFailure { e ->
+                log.error("PENDING_PAYMENT enrollment 정리 실패 enrollmentId={}", stale.id, e)
+            }
+        }
+
+        log.info("만료된 PENDING_PAYMENT enrollment 정리 완료 - 성공 {}건 / 전체 {}건", successCount, staleEnrollments.size)
+    }
+
+    companion object {
+        private const val TTL_MINUTES = 30L
+        private const val INTERVAL_MS = 5 * 60 * 1000L
+    }
+}

--- a/SClass-Batch/src/test/kotlin/com/sclass/batch/enrollment/CleanupStalePendingEnrollmentsJobTest.kt
+++ b/SClass-Batch/src/test/kotlin/com/sclass/batch/enrollment/CleanupStalePendingEnrollmentsJobTest.kt
@@ -18,12 +18,16 @@ import org.junit.jupiter.api.Test
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.TransactionCallback
 import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 
 class CleanupStalePendingEnrollmentsJobTest {
     private val enrollmentAdaptor = mockk<EnrollmentAdaptor>()
     private val paymentAdaptor = mockk<PaymentAdaptor>()
     private val txTemplate = mockk<TransactionTemplate>()
-    private val job = CleanupStalePendingEnrollmentsJob(enrollmentAdaptor, paymentAdaptor, txTemplate)
+    private val fixedClock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneId.of("UTC"))
+    private val job = CleanupStalePendingEnrollmentsJob(enrollmentAdaptor, paymentAdaptor, txTemplate, fixedClock)
 
     @BeforeEach
     fun setUp() {
@@ -99,6 +103,24 @@ class CleanupStalePendingEnrollmentsJobTest {
         job.execute()
 
         verify(exactly = 0) { paymentAdaptor.findById(any()) }
+        verify(exactly = 0) { enrollmentAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `payment가 PG_APPROVED 상태이면 enrollment를 취소하지 않고 건너뛴다`() {
+        val enrollment = createPendingEnrollment()
+        val payment = createPayment().also { it.markPgApproved("tid-001") }
+
+        every { enrollmentAdaptor.findPendingPaymentOlderThan(any()) } returns listOf(enrollment)
+        every { enrollmentAdaptor.findById(enrollment.id) } returns enrollment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+
+        job.execute()
+
+        assertAll(
+            { assertEquals(EnrollmentStatus.PENDING_PAYMENT, enrollment.status) },
+            { assertEquals(PaymentStatus.PG_APPROVED, payment.status) },
+        )
         verify(exactly = 0) { enrollmentAdaptor.save(any()) }
     }
 

--- a/SClass-Batch/src/test/kotlin/com/sclass/batch/enrollment/CleanupStalePendingEnrollmentsJobTest.kt
+++ b/SClass-Batch/src/test/kotlin/com/sclass/batch/enrollment/CleanupStalePendingEnrollmentsJobTest.kt
@@ -1,0 +1,125 @@
+package com.sclass.batch.enrollment
+
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.Payment
+import com.sclass.domain.domains.payment.domain.PaymentStatus
+import com.sclass.domain.domains.payment.domain.PaymentTargetType
+import com.sclass.domain.domains.payment.domain.PgType
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
+
+class CleanupStalePendingEnrollmentsJobTest {
+    private val enrollmentAdaptor = mockk<EnrollmentAdaptor>()
+    private val paymentAdaptor = mockk<PaymentAdaptor>()
+    private val txTemplate = mockk<TransactionTemplate>()
+    private val job = CleanupStalePendingEnrollmentsJob(enrollmentAdaptor, paymentAdaptor, txTemplate)
+
+    @BeforeEach
+    fun setUp() {
+        every { txTemplate.execute<Any?>(any()) } answers {
+            firstArg<TransactionCallback<Any?>>().doInTransaction(mockk<TransactionStatus>())
+        }
+    }
+
+    private fun createPendingEnrollment(paymentId: String = "pay0000000000000000001") =
+        Enrollment.createForPurchase(
+            courseId = 1L,
+            studentUserId = "user000000000000000001",
+            tuitionAmountWon = 100_000,
+            paymentId = paymentId,
+        )
+
+    private fun createPayment(id: String = "pay0000000000000000001") =
+        Payment(
+            id = id,
+            userId = "user000000000000000001",
+            targetType = PaymentTargetType.COURSE_PRODUCT,
+            targetId = "prod000000000000000001",
+            amount = 100_000,
+            pgType = PgType.NICEPAY,
+            pgOrderId = "order-$id",
+        )
+
+    @Test
+    fun `만료된 PENDING_PAYMENT enrollment가 없으면 아무것도 처리하지 않는다`() {
+        every { enrollmentAdaptor.findPendingPaymentOlderThan(any()) } returns emptyList()
+
+        job.execute()
+
+        verify(exactly = 0) { paymentAdaptor.findById(any()) }
+        verify(exactly = 0) { enrollmentAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `만료된 PENDING_PAYMENT enrollment와 연결된 Payment를 모두 CANCELLED로 변경한다`() {
+        val enrollment = createPendingEnrollment()
+        val payment = createPayment()
+
+        every { enrollmentAdaptor.findPendingPaymentOlderThan(any()) } returns listOf(enrollment)
+        every { enrollmentAdaptor.findById(enrollment.id) } returns enrollment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { enrollmentAdaptor.save(any()) } returns enrollment
+        every { paymentAdaptor.save(any()) } returns payment
+
+        job.execute()
+
+        assertAll(
+            { assertEquals(EnrollmentStatus.CANCELLED, enrollment.status) },
+            { assertEquals(PaymentStatus.CANCELLED, payment.status) },
+        )
+        verify { enrollmentAdaptor.save(enrollment) }
+        verify { paymentAdaptor.save(payment) }
+    }
+
+    @Test
+    fun `enrollment가 이미 PENDING_PAYMENT가 아니면 건너뛴다`() {
+        val staleRef = createPendingEnrollment()
+        val alreadyActive =
+            Enrollment.createByGrant(
+                courseId = 1L,
+                studentUserId = "user000000000000000001",
+                grantedByUserId = "admin00000000000000001",
+                grantReason = "테스트",
+            )
+
+        every { enrollmentAdaptor.findPendingPaymentOlderThan(any()) } returns listOf(staleRef)
+        every { enrollmentAdaptor.findById(staleRef.id) } returns alreadyActive
+
+        job.execute()
+
+        verify(exactly = 0) { paymentAdaptor.findById(any()) }
+        verify(exactly = 0) { enrollmentAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `하나의 처리가 실패해도 나머지 enrollment는 계속 처리한다`() {
+        val enrollment1 = createPendingEnrollment("pay0000000000000000001")
+        val enrollment2 = createPendingEnrollment("pay0000000000000000002")
+        val payment2 = createPayment("pay0000000000000000002")
+
+        every { enrollmentAdaptor.findPendingPaymentOlderThan(any()) } returns listOf(enrollment1, enrollment2)
+        every { enrollmentAdaptor.findById(enrollment1.id) } throws RuntimeException("DB 오류")
+        every { enrollmentAdaptor.findById(enrollment2.id) } returns enrollment2
+        every { paymentAdaptor.findById("pay0000000000000000002") } returns payment2
+        every { enrollmentAdaptor.save(any()) } returns enrollment2
+        every { paymentAdaptor.save(any()) } returns payment2
+
+        job.execute()
+
+        assertAll(
+            { assertEquals(EnrollmentStatus.CANCELLED, enrollment2.status) },
+            { assertEquals(PaymentStatus.CANCELLED, payment2.status) },
+        )
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
@@ -93,6 +93,9 @@ class EnrollmentAdaptor(
             .countLiveMembershipEnrollmentsByProductIds(productIds)
             .associate { it.productId to it.count }
 
+    fun findPendingPaymentOlderThan(threshold: java.time.LocalDateTime): List<Enrollment> =
+        enrollmentRepository.findAllByStatusAndCreatedAtBefore(EnrollmentStatus.PENDING_PAYMENT, threshold)
+
     fun hasActiveMembershipEnrollment(studentUserId: String): Boolean =
         enrollmentRepository.hasActiveMembershipEnrollment(
             studentUserId = studentUserId,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
@@ -7,6 +7,7 @@ import com.sclass.domain.domains.enrollment.domain.EnrollmentType
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithCourseDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithStudentDto
+import com.sclass.domain.domains.enrollment.exception.EnrollmentAlreadyExistsException
 import com.sclass.domain.domains.enrollment.exception.EnrollmentNotFoundException
 import com.sclass.domain.domains.enrollment.repository.EnrollmentRepository
 import org.springframework.data.domain.Page
@@ -60,6 +61,15 @@ class EnrollmentAdaptor(
                 setOf(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.ACTIVE),
             ).firstOrNull()
 
+    fun findResumableEnrollment(
+        courseId: Long,
+        studentUserId: String,
+    ): Enrollment? {
+        val live = findLiveEnrollment(courseId, studentUserId) ?: return null
+        if (live.status == EnrollmentStatus.ACTIVE) throw EnrollmentAlreadyExistsException()
+        return live
+    }
+
     fun findLiveMembershipEnrollment(
         productId: String,
         studentUserId: String,
@@ -70,6 +80,15 @@ class EnrollmentAdaptor(
                 studentUserId,
                 setOf(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.ACTIVE),
             ).firstOrNull()
+
+    fun findResumableMembershipEnrollment(
+        productId: String,
+        studentUserId: String,
+    ): Enrollment? {
+        val live = findLiveMembershipEnrollment(productId, studentUserId) ?: return null
+        if (live.status == EnrollmentStatus.ACTIVE) throw EnrollmentAlreadyExistsException()
+        return live
+    }
 
     fun findByPaymentId(paymentId: String): Enrollment =
         enrollmentRepository.findByPaymentId(paymentId) ?: throw EnrollmentNotFoundException()

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentRepository.kt
@@ -37,6 +37,11 @@ interface EnrollmentRepository :
     // Payment → Enrollment 역조회 (콜백 처리용)
     fun findByPaymentId(paymentId: String): Enrollment?
 
+    fun findAllByStatusAndCreatedAtBefore(
+        status: EnrollmentStatus,
+        createdAt: java.time.LocalDateTime,
+    ): List<Enrollment>
+
     fun countByCourseIdAndStatusIn(
         courseId: Long,
         statuses: Collection<EnrollmentStatus>,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/payment/domain/Payment.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/payment/domain/Payment.kt
@@ -92,7 +92,7 @@ class Payment(
     }
 
     fun markCancelled() {
-        if (status != PaymentStatus.COMPLETED) {
+        if (status !in setOf(PaymentStatus.PENDING, PaymentStatus.PG_APPROVED, PaymentStatus.COMPLETED)) {
             throw InvalidPaymentStatusException()
         }
         this.status = PaymentStatus.CANCELLED

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/payment/domain/PaymentTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/payment/domain/PaymentTest.kt
@@ -23,6 +23,7 @@ class PaymentTest {
                     it.markPgApproved("tid-001")
                     it.markCompleted()
                 }
+                PaymentStatus.PG_APPROVE_FAILED -> it.markPgApproveFailed()
                 else -> {}
             }
         }
@@ -84,8 +85,26 @@ class PaymentTest {
         }
 
         @Test
-        fun `COMPLETED가 아닌 상태에서 취소 시 예외가 발생한다`() {
+        fun `PENDING 상태에서 취소 시 CANCELLED로 변경된다`() {
             val payment = createPayment()
+
+            payment.markCancelled()
+
+            assertEquals(PaymentStatus.CANCELLED, payment.status)
+        }
+
+        @Test
+        fun `PG_APPROVED 상태에서 취소 시 CANCELLED로 변경된다`() {
+            val payment = createPayment(PaymentStatus.PG_APPROVED)
+
+            payment.markCancelled()
+
+            assertEquals(PaymentStatus.CANCELLED, payment.status)
+        }
+
+        @Test
+        fun `PG_APPROVE_FAILED 상태에서 취소 시 예외가 발생한다`() {
+            val payment = createPayment(PaymentStatus.PG_APPROVE_FAILED)
 
             assertThrows<InvalidPaymentStatusException> {
                 payment.markCancelled()


### PR DESCRIPTION
Closes #249

## Summary

- **Scenario 1**: `CleanupStalePendingEnrollmentsJob` — 30분 초과 `PENDING_PAYMENT` enrollment를 5분마다 스캔하여 enrollment + payment 양쪽 CANCELLED 처리
- **Scenario 2**: `HandleNicePayWebhookUseCase` — COURSE_PRODUCT 웹훅 수신 시 코스가 UNLISTED/ARCHIVED이면 PG 취소 API 호출 후 자동 환불
- `Payment.markCancelled()` 상태 전이 확장: `PENDING`, `PG_APPROVED`, `COMPLETED` → `CANCELLED`
- `PrepareEnrollment` / `PrepareMembershipPurchase`: PENDING_PAYMENT 고아 주문 resume 처리 (기존 pgOrderId 반환)

## Test plan

- [ ] `CleanupStalePendingEnrollmentsJobTest` — 4개 케이스
- [ ] `HandleNicePayWebhookUseCaseTest` — UNLISTED/ARCHIVED 자동 환불, PG 취소 실패 시 PG_CANCEL_FAILED
- [ ] `PrepareEnrollmentUseCaseTest` / `PrepareMembershipPurchaseUseCaseTest` — resume 케이스 추가
- [ ] `PaymentTest` — markCancelled 상태 전이 확장 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)