### PR TITLE
fix(alimtalk): 탐구 주제 추천 알림톡 템플릿 내용 불일치 수정

### DIFF
--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/CommissionAlimtalkTemplates.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/message/CommissionAlimtalkTemplates.kt
@@ -54,8 +54,8 @@ class CommissionAlimtalkTemplates(
         content =
             "[S클래스] 탐구 주제 추천이 도착했습니다\n\n" +
                 "${studentName}님, 안녕하세요.\n\n" +
-                "앱에서 추천 주제를 확인하고 선택해 주세요.\n\n" +
-                "※ 본 메시지는 발신 전용으로, S클래스에서 자동 발송됩니다.",
+                "회원님이 신청하신 탐구 주제 추천 결과가 도착했습니다.\n" +
+                "앱에서 추천 주제를 확인하고 선택해 주세요.",
         buttons = listOf(studentButton(name = "주제 확인하기", commissionId = commissionId)),
     )
 


### PR DESCRIPTION
## Summary
- 카카오에 등록된 승인 템플릿과 코드에서 전송하는 `content` 불일치로 알림톡 발송 실패하던 문제 수정
- 누락된 `회원님이 신청하신 탐구 주제 추천 결과가 도착했습니다.` 문구 추가
- 미등록 고정문구(`※ 본 메시지는 발신 전용으로, S클래스에서 자동 발송됩니다.`) 제거

## 변경 파일
- `CommissionAlimtalkTemplates.kt` — `topicSuggested()` content 수정

## Test plan
- [ ] 탐구 주제 추천 알림톡 발송 시 정상 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)