### PR TITLE
chore(ci): lint·test 병렬 job 분리 및 Gradle 성능 개선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,23 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: ktlint Check
+        run: ./gradlew ktlintCheck
+
+  test:
     name: Build & Test
     runs-on: ubuntu-latest
 
@@ -37,11 +53,12 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
-      - name: ktlint Check
-        run: ./gradlew ktlintCheck --no-daemon
+      - name: Build & Test
+        run: ./gradlew build --parallel
 
-      - name: Build & Test & Coverage
-        run: ./gradlew build koverXmlReport --no-daemon
+      - name: Coverage Report
+        if: github.event_name == 'pull_request'
+        run: ./gradlew koverXmlReport --parallel
 
       - name: Add coverage report to PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
-      - name: Build & Test
-        run: ./gradlew build --parallel
+      - name: Test
+        run: ./gradlew test --parallel
 
       - name: Coverage Report
         if: github.event_name == 'pull_request'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ subprojects {
 
     tasks.withType<Test> {
         useJUnitPlatform()
+        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
     }
 
     ktlint {


### PR DESCRIPTION
## Summary
- `lint`(ktlintCheck)와 `test` job을 병렬 실행으로 분리 → 전체 CI 시간 단축
- test job은 `build` 대신 `test` task 실행 → `build`의 `check`에 포함된 ktlint 중복 실행 제거
- `--no-daemon` 제거: `setup-gradle@v4`의 Gradle 데몬 캐시 활용
- `--parallel` 추가: 멀티모듈 병렬 컴파일·테스트
- `koverXmlReport`를 PR 이벤트에서만 실행 (workflow_call/dispatch 시 스킵)
- `maxParallelForks` 추가: 가용 CPU / 2 개의 fork로 테스트 클래스 병렬 실행 (H2 in-memory는 fork별 격리, Redis 사용 테스트 1개뿐이라 충돌 없음)

## Before / After
| | Before | After |
|---|---|---|
| 구조 | 단일 job (lint → test 순차) | lint / test 병렬 job |
| test job Gradle task | `build` (lint 중복 포함) | `test` (컴파일+테스트만) |
| Gradle 데몬 | `--no-daemon` | 데몬 재사용 |
| 멀티모듈 | 순차 빌드 | `--parallel` |
| 테스트 실행 | 단일 fork | `maxParallelForks = CPU / 2` |
| 커버리지 | 항상 실행 | PR 이벤트에서만 실행 |

## Test plan
- [ ] PR 오픈 시 lint·test job 병렬 실행 확인
- [ ] test job에서 ktlint 미실행 확인
- [ ] PR 커버리지 리포트 정상 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)