### PR TITLE
refactor: 코스 구매를 productId 기준으로 정리

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coin/usecase/AdminGrantCoinUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/coin/usecase/AdminGrantCoinUseCase.kt
@@ -7,12 +7,15 @@ import com.sclass.domain.domains.coin.domain.CoinLotSourceType
 import com.sclass.domain.domains.coin.service.CoinDomainService
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.exception.EnrollmentTypeMismatchException
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.MembershipProduct
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class AdminGrantCoinUseCase(
     private val coinDomainService: CoinDomainService,
     private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val productAdaptor: ProductAdaptor,
 ) {
     @Transactional
     fun execute(
@@ -21,7 +24,8 @@ class AdminGrantCoinUseCase(
     ): AdminGrantCoinResponse {
         request.enrollmentId?.let { id ->
             val enrollment = enrollmentAdaptor.findById(id)
-            if (enrollment.productId == null) throw EnrollmentTypeMismatchException()
+            val productId = enrollment.productId ?: throw EnrollmentTypeMismatchException()
+            if (productAdaptor.findById(productId) !is MembershipProduct) throw EnrollmentTypeMismatchException()
         }
 
         val lot =

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/ExtendMembershipExpireUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/ExtendMembershipExpireUseCase.kt
@@ -6,12 +6,15 @@ import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.coin.adaptor.CoinAdaptor
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.exception.EnrollmentTypeMismatchException
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.MembershipProduct
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class ExtendMembershipExpireUseCase(
     private val enrollmentAdaptor: EnrollmentAdaptor,
     private val coinAdaptor: CoinAdaptor,
+    private val productAdaptor: ProductAdaptor,
 ) {
     @Transactional
     fun execute(
@@ -19,7 +22,8 @@ class ExtendMembershipExpireUseCase(
         request: ExtendMembershipExpireRequest,
     ): EnrollmentResponse {
         val enrollment = enrollmentAdaptor.findById(enrollmentId)
-        if (enrollment.productId == null) throw EnrollmentTypeMismatchException()
+        val productId = enrollment.productId ?: throw EnrollmentTypeMismatchException()
+        if (productAdaptor.findById(productId) !is MembershipProduct) throw EnrollmentTypeMismatchException()
 
         enrollment.endAt = request.newEndAt
 

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/coin/usecase/AdminGrantCoinUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/coin/usecase/AdminGrantCoinUseCaseTest.kt
@@ -7,6 +7,9 @@ import com.sclass.domain.domains.coin.service.CoinDomainService
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.exception.EnrollmentTypeMismatchException
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.product.domain.RollingMembershipProduct
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -20,25 +23,42 @@ import java.time.LocalDateTime
 class AdminGrantCoinUseCaseTest {
     private lateinit var coinDomainService: CoinDomainService
     private lateinit var enrollmentAdaptor: EnrollmentAdaptor
+    private lateinit var productAdaptor: ProductAdaptor
     private lateinit var useCase: AdminGrantCoinUseCase
 
     @BeforeEach
     fun setUp() {
         coinDomainService = mockk()
         enrollmentAdaptor = mockk()
-        useCase = AdminGrantCoinUseCase(coinDomainService, enrollmentAdaptor)
+        productAdaptor = mockk()
+        useCase = AdminGrantCoinUseCase(coinDomainService, enrollmentAdaptor, productAdaptor)
     }
 
     private fun mockMembershipEnrollment(id: Long): Enrollment =
         mockk<Enrollment>().also {
-            every { it.productId } returns "product-id-000000000000000000001"
+            val productId = "membership-product-id-000000001"
+            every { it.productId } returns productId
             every { enrollmentAdaptor.findById(id) } returns it
+            every { productAdaptor.findById(productId) } returns
+                RollingMembershipProduct(
+                    name = "프리미엄 멤버십",
+                    priceWon = 50000,
+                    periodDays = 30,
+                    coinPackageId = "coin-package-id-000000001",
+                )
         }
 
     private fun mockCourseEnrollment(id: Long): Enrollment =
         mockk<Enrollment>().also {
-            every { it.productId } returns null
+            val productId = "course-product-id-000000000001"
+            every { it.productId } returns productId
             every { enrollmentAdaptor.findById(id) } returns it
+            every { productAdaptor.findById(productId) } returns
+                CourseProduct(
+                    name = "수학 코스",
+                    priceWon = 300000,
+                    totalLessons = 12,
+                )
         }
 
     @Test

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/usecase/ExtendMembershipExpireUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/usecase/ExtendMembershipExpireUseCaseTest.kt
@@ -7,6 +7,9 @@ import com.sclass.domain.domains.coin.domain.CoinLotSourceType
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.exception.EnrollmentTypeMismatchException
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.product.domain.RollingMembershipProduct
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -20,13 +23,15 @@ import java.time.LocalDateTime
 class ExtendMembershipExpireUseCaseTest {
     private lateinit var enrollmentAdaptor: EnrollmentAdaptor
     private lateinit var coinAdaptor: CoinAdaptor
+    private lateinit var productAdaptor: ProductAdaptor
     private lateinit var useCase: ExtendMembershipExpireUseCase
 
     @BeforeEach
     fun setUp() {
         enrollmentAdaptor = mockk()
         coinAdaptor = mockk(relaxed = true)
-        useCase = ExtendMembershipExpireUseCase(enrollmentAdaptor, coinAdaptor)
+        productAdaptor = mockk()
+        useCase = ExtendMembershipExpireUseCase(enrollmentAdaptor, coinAdaptor, productAdaptor)
     }
 
     @Test
@@ -51,6 +56,13 @@ class ExtendMembershipExpireUseCaseTest {
                 sourceType = CoinLotSourceType.ADMIN_GRANT,
             )
         every { enrollmentAdaptor.findById(1L) } returns enrollment
+        every { productAdaptor.findById("product-id-000000000000000000001") } returns
+            RollingMembershipProduct(
+                name = "프리미엄 멤버십",
+                priceWon = 50000,
+                periodDays = 30,
+                coinPackageId = "coin-package-id-000000001",
+            )
         every { coinAdaptor.findLotsByEnrollmentId(1L) } returns listOf(lot)
         val savedSlot = slot<Enrollment>()
         every { enrollmentAdaptor.save(capture(savedSlot)) } answers { savedSlot.captured }
@@ -65,8 +77,14 @@ class ExtendMembershipExpireUseCaseTest {
     @Test
     fun `코스 enrollment이면 예외가 발생한다`() {
         val enrollment = mockk<Enrollment>()
-        every { enrollment.productId } returns null
+        every { enrollment.productId } returns "course-product-id-000000000001"
         every { enrollmentAdaptor.findById(2L) } returns enrollment
+        every { productAdaptor.findById("course-product-id-000000000001") } returns
+            CourseProduct(
+                name = "수학 코스",
+                priceWon = 300000,
+                totalLessons = 12,
+            )
 
         assertThrows<EnrollmentTypeMismatchException> {
             useCase.execute(2L, ExtendMembershipExpireRequest(LocalDateTime.of(2026, 12, 31, 23, 59)))

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/controller/EnrollmentController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/controller/EnrollmentController.kt
@@ -33,7 +33,8 @@ class EnrollmentController(
     fun prepareEnrollment(
         @CurrentUserId userId: String,
         @RequestBody @Valid request: PrepareEnrollmentRequest,
-    ): ApiResponse<PrepareEnrollmentResponse> = success(prepareEnrollmentUseCase.execute(userId, request.courseId, request.pgType))
+    ): ApiResponse<PrepareEnrollmentResponse> =
+        success(prepareEnrollmentUseCase.execute(userId, request.productId, request.courseId, request.pgType))
 
     @GetMapping("/me")
     fun getMyEnrollments(

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/PrepareEnrollmentRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/PrepareEnrollmentRequest.kt
@@ -1,9 +1,11 @@
 package com.sclass.supporters.enrollment.dto
 
 import com.sclass.domain.domains.payment.domain.PgType
+import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 
 data class PrepareEnrollmentRequest(
+    @field:NotBlank val productId: String,
     @field:NotNull val courseId: Long,
     @field:NotNull val pgType: PgType,
 )

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/PrepareEnrollmentResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/PrepareEnrollmentResponse.kt
@@ -4,6 +4,7 @@ data class PrepareEnrollmentResponse(
     val paymentId: String,
     val pgOrderId: String,
     val amount: Int,
+    val productId: String,
     val courseId: Long,
     val courseName: String,
 )

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
@@ -6,6 +6,7 @@ import com.sclass.domain.domains.course.adaptor.CourseAdaptor
 import com.sclass.domain.domains.course.exception.CourseNotEnrollableException
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.exception.EnrollmentInvalidPurchaseTargetException
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.Payment
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
@@ -30,17 +31,19 @@ class PrepareEnrollmentUseCase(
     @DistributedLock(prefix = "enrollment")
     fun execute(
         studentUserId: String,
+        productId: String,
         @LockKey courseId: Long,
         pgType: PgType,
     ): PrepareEnrollmentResponse {
         val course = courseAdaptor.findById(courseId)
+        if (course.productId != productId) throw EnrollmentInvalidPurchaseTargetException()
         val product =
-            productAdaptor.findById(course.productId) as? CourseProduct
+            productAdaptor.findById(productId) as? CourseProduct
                 ?: throw ProductTypeMismatchException()
 
         enrollmentAdaptor.findResumableEnrollment(courseId, studentUserId)?.let { live ->
             val payment = paymentAdaptor.findById(live.paymentId!!)
-            return PrepareEnrollmentResponse(payment.id, payment.pgOrderId, payment.amount, course.id, product.name)
+            return PrepareEnrollmentResponse(payment.id, payment.pgOrderId, payment.amount, productId, course.id, product.name)
         }
 
         val liveCount = enrollmentAdaptor.countLiveEnrollments(courseId)
@@ -53,7 +56,7 @@ class PrepareEnrollmentUseCase(
                 Payment(
                     userId = studentUserId,
                     targetType = PaymentTargetType.COURSE_PRODUCT,
-                    targetId = product.id,
+                    targetId = productId,
                     amount = product.priceWon,
                     pgType = pgType,
                     pgOrderId = Ulid.generate(),
@@ -62,6 +65,7 @@ class PrepareEnrollmentUseCase(
 
         enrollmentAdaptor.save(
             Enrollment.createForPurchase(
+                productId = productId,
                 courseId = course.id,
                 studentUserId = studentUserId,
                 tuitionAmountWon = product.priceWon,
@@ -73,6 +77,7 @@ class PrepareEnrollmentUseCase(
             paymentId = payment.id,
             pgOrderId = payment.pgOrderId,
             amount = payment.amount,
+            productId = productId,
             courseId = course.id,
             courseName = product.name,
         )

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
@@ -122,7 +122,7 @@ class HandleNicePayReturnUseCase(
                     txTemplate.execute {
                         val fresh = paymentAdaptor.findById(payment.id)
                         val enrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
-                        enrollment.markPaid()
+                        enrollment.markCoursePaid()
                         enrollmentAdaptor.save(enrollment)
                         fresh.markCompleted()
                         paymentAdaptor.save(fresh)
@@ -140,7 +140,7 @@ class HandleNicePayReturnUseCase(
                         val enrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
                         val now = LocalDateTime.now()
                         val period = product.resolveActivePeriod(now)
-                        enrollment.markPaid(startAt = period.startAt, endAt = period.endAt)
+                        enrollment.markMembershipPaid(startAt = period.startAt, endAt = period.endAt)
                         enrollmentAdaptor.save(enrollment)
 
                         coinDomainService.issue(

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -148,7 +148,7 @@ class HandleNicePayWebhookUseCase(
                 txTemplate.execute {
                     val fresh = paymentAdaptor.findById(payment.id)
                     val freshEnrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
-                    freshEnrollment.markPaid()
+                    freshEnrollment.markCoursePaid()
                     enrollmentAdaptor.save(freshEnrollment)
                     fresh.markCompleted()
                     paymentAdaptor.save(fresh)
@@ -182,7 +182,7 @@ class HandleNicePayWebhookUseCase(
                         val freshEnrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
                         val now = LocalDateTime.now()
                         val period = product.resolveActivePeriod(now)
-                        freshEnrollment.markPaid(startAt = period.startAt, endAt = period.endAt)
+                        freshEnrollment.markMembershipPaid(startAt = period.startAt, endAt = period.endAt)
                         enrollmentAdaptor.save(freshEnrollment)
 
                         coinDomainService.issue(

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/GetMyEnrollmentsUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/GetMyEnrollmentsUseCaseTest.kt
@@ -60,6 +60,7 @@ class GetMyEnrollmentsUseCaseTest {
     ): EnrollmentWithCourseDto {
         val enrollment =
             Enrollment.createForPurchase(
+                productId = "product-id-0000000000000001",
                 courseId = 1L,
                 studentUserId = "student-id-0000000000000001",
                 tuitionAmountWon = 300000,

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentConcurrencyTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentConcurrencyTest.kt
@@ -91,6 +91,7 @@ class PrepareEnrollmentConcurrencyTest {
                     try {
                         prepareEnrollmentUseCase.execute(
                             studentUserId = "student-$i",
+                            productId = product.id,
                             courseId = course.id,
                             pgType = PgType.NICEPAY,
                         )

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
@@ -8,6 +8,7 @@ import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.enrollment.exception.EnrollmentAlreadyExistsException
+import com.sclass.domain.domains.enrollment.exception.EnrollmentInvalidPurchaseTargetException
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.Payment
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
@@ -87,11 +88,13 @@ class PrepareEnrollmentUseCaseTest {
             every { paymentAdaptor.save(any()) } returns pendingPayment()
             every { enrollmentAdaptor.save(capture(enrollmentSlot)) } answers { enrollmentSlot.captured }
 
-            val result = useCase.execute("student-id-00000000001", 1L, PgType.NICEPAY)
+            val result = useCase.execute("student-id-00000000001", "product-id-00000000001", 1L, PgType.NICEPAY)
 
+            assertThat(result.productId).isEqualTo("product-id-00000000001")
             assertThat(result.courseId).isEqualTo(1L)
             assertThat(result.courseName).isEqualTo("수학 코스")
             assertThat(result.amount).isEqualTo(300000)
+            assertThat(enrollmentSlot.captured.productId).isEqualTo("product-id-00000000001")
             assertThat(enrollmentSlot.captured.status).isEqualTo(EnrollmentStatus.PENDING_PAYMENT)
             assertThat(enrollmentSlot.captured.tuitionAmountWon).isEqualTo(300000)
         }
@@ -107,7 +110,7 @@ class PrepareEnrollmentUseCaseTest {
             every { enrollmentAdaptor.countLiveEnrollments(1L) } returns 0L
 
             assertThatThrownBy {
-                useCase.execute("student-id-00000000001", 1L, PgType.NICEPAY)
+                useCase.execute("student-id-00000000001", "product-id-00000000001", 1L, PgType.NICEPAY)
             }.isInstanceOf(CourseNotEnrollableException::class.java)
         }
 
@@ -118,7 +121,7 @@ class PrepareEnrollmentUseCaseTest {
             every { enrollmentAdaptor.findResumableEnrollment(1L, "student-id-00000000001") } throws EnrollmentAlreadyExistsException()
 
             assertThatThrownBy {
-                useCase.execute("student-id-00000000001", 1L, PgType.NICEPAY)
+                useCase.execute("student-id-00000000001", "product-id-00000000001", 1L, PgType.NICEPAY)
             }.isInstanceOf(EnrollmentAlreadyExistsException::class.java)
         }
 
@@ -126,6 +129,7 @@ class PrepareEnrollmentUseCaseTest {
         fun `PENDING_PAYMENT enrollment이 있으면 기존 결제 정보를 그대로 반환한다`() {
             val existingEnrollment =
                 Enrollment.createForPurchase(
+                    productId = "product-id-00000000001",
                     courseId = 1L,
                     studentUserId = "student-id-00000000001",
                     tuitionAmountWon = 300000,
@@ -136,8 +140,9 @@ class PrepareEnrollmentUseCaseTest {
             every { enrollmentAdaptor.findResumableEnrollment(1L, "student-id-00000000001") } returns existingEnrollment
             every { paymentAdaptor.findById("payment-id-000000000001") } returns pendingPayment()
 
-            val result = useCase.execute("student-id-00000000001", 1L, PgType.NICEPAY)
+            val result = useCase.execute("student-id-00000000001", "product-id-00000000001", 1L, PgType.NICEPAY)
 
+            assertThat(result.productId).isEqualTo("product-id-00000000001")
             assertThat(result.pgOrderId).isEqualTo("order-id-000000000001")
             verify(exactly = 0) { paymentAdaptor.save(any()) }
             verify(exactly = 0) { enrollmentAdaptor.save(any()) }
@@ -151,8 +156,17 @@ class PrepareEnrollmentUseCaseTest {
             every { enrollmentAdaptor.findResumableEnrollment(any(), any()) } returns null
 
             assertThatThrownBy {
-                useCase.execute("student-id-00000000001", 1L, PgType.NICEPAY)
+                useCase.execute("student-id-00000000001", "product-id-00000000001", 1L, PgType.NICEPAY)
             }.isInstanceOf(ProductTypeMismatchException::class.java)
+        }
+
+        @Test
+        fun `courseId와 productId 조합이 다르면 EnrollmentInvalidPurchaseTargetException이 발생한다`() {
+            every { courseAdaptor.findById(1L) } returns listedCourse()
+
+            assertThatThrownBy {
+                useCase.execute("student-id-00000000001", "different-product-id", 1L, PgType.NICEPAY)
+            }.isInstanceOf(EnrollmentInvalidPurchaseTargetException::class.java)
         }
 
         @Test
@@ -164,7 +178,7 @@ class PrepareEnrollmentUseCaseTest {
             every { paymentAdaptor.save(any()) } returns pendingPayment()
             every { enrollmentAdaptor.save(any()) } answers { firstArg() }
 
-            useCase.execute("student-id-00000000001", 1L, PgType.NICEPAY)
+            useCase.execute("student-id-00000000001", "product-id-00000000001", 1L, PgType.NICEPAY)
 
             verify(exactly = 1) { paymentAdaptor.save(any()) }
             verify(exactly = 1) { enrollmentAdaptor.save(any()) }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
@@ -179,6 +179,7 @@ class HandleNicePayWebhookUseCaseTest {
         val product = CourseProduct(name = "수학 코스", priceWon = 300000, totalLessons = 12)
         val enrollment =
             Enrollment.createForPurchase(
+                productId = payment.targetId,
                 courseId = 1L,
                 studentUserId = "student-id-000000000001",
                 tuitionAmountWon = 300000,
@@ -223,6 +224,7 @@ class HandleNicePayWebhookUseCaseTest {
         val product = CourseProduct(name = "수학 코스", priceWon = 300000, totalLessons = 12)
         val enrollment =
             Enrollment.createForPurchase(
+                productId = payment.targetId,
                 courseId = 1L,
                 studentUserId = "student-id-000000000001",
                 tuitionAmountWon = 300000,
@@ -262,6 +264,7 @@ class HandleNicePayWebhookUseCaseTest {
         val product = CourseProduct(name = "수학 코스", priceWon = 300000, totalLessons = 12)
         val enrollment =
             Enrollment.createForPurchase(
+                productId = payment.targetId,
                 courseId = 1L,
                 studentUserId = "student-id-000000000001",
                 tuitionAmountWon = 300000,
@@ -300,6 +303,7 @@ class HandleNicePayWebhookUseCaseTest {
         val product = CourseProduct(name = "수학 코스", priceWon = 300000, totalLessons = 12)
         val enrollment =
             Enrollment.createForPurchase(
+                productId = payment.targetId,
                 courseId = 1L,
                 studentUserId = "student-id-000000000001",
                 tuitionAmountWon = 300000,

--- a/SClass-Batch/src/test/kotlin/com/sclass/batch/enrollment/CleanupStalePendingEnrollmentsJobTest.kt
+++ b/SClass-Batch/src/test/kotlin/com/sclass/batch/enrollment/CleanupStalePendingEnrollmentsJobTest.kt
@@ -38,6 +38,7 @@ class CleanupStalePendingEnrollmentsJobTest {
 
     private fun createPendingEnrollment(paymentId: String = "pay0000000000000000001") =
         Enrollment.createForPurchase(
+            productId = "prod000000000000000001",
             courseId = 1L,
             studentUserId = "user000000000000000001",
             tuitionAmountWon = 100_000,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/domain/Enrollment.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/domain/Enrollment.kt
@@ -32,7 +32,7 @@ class Enrollment private constructor(
     @Column(name = "course_id")
     val courseId: Long? = null,
 
-    // MEMBERSHIP 구매 시 저장
+    // purchase 대상 product 스냅샷
     @Column(name = "product_id", length = 26)
     val productId: String? = null,
 
@@ -77,21 +77,21 @@ class Enrollment private constructor(
     @Column(name = "cancel_reason", length = 500)
     var cancelReason: String? = null,
 ) : BaseTimeEntity() {
-    fun markPaid(
-        startAt: LocalDateTime? = null,
-        endAt: LocalDateTime? = null,
+    fun markCoursePaid() {
+        require(enrollmentType == EnrollmentType.PURCHASE)
+        require(paymentId != null)
+        validateTransition(EnrollmentStatus.ACTIVE)
+        this.status = EnrollmentStatus.ACTIVE
+    }
+
+    fun markMembershipPaid(
+        startAt: LocalDateTime,
+        endAt: LocalDateTime,
     ) {
-        require(enrollmentType == EnrollmentType.PURCHASE) {
-            "markPaid is only valid for PURCHASE enrollments"
-        }
-        require(paymentId != null) { "paymentId must be set before markPaid" }
-        if (productId != null) {
-            require(startAt != null && endAt != null) {
-                "membership enrollment requires startAt/endAt on markPaid"
-            }
-            this.startAt = startAt
-            this.endAt = endAt
-        }
+        require(enrollmentType == EnrollmentType.PURCHASE)
+        require(paymentId != null)
+        this.startAt = startAt
+        this.endAt = endAt
         validateTransition(EnrollmentStatus.ACTIVE)
         this.status = EnrollmentStatus.ACTIVE
     }
@@ -140,16 +140,18 @@ class Enrollment private constructor(
         /**
          * 학생이 PG 결제로 등록.
          * 호출 순서: Payment 먼저 생성 → Enrollment.createForPurchase(..., paymentId = payment.id)
-         *   → PG 콜백 수신 시 payment.markCompleted() → enrollment.markPaid()
+         *   → PG 콜백 수신 시 payment.markCompleted() → enrollment.markCoursePaid()
          */
         fun createForPurchase(
-            courseId: Long,
+            productId: String,
             studentUserId: String,
             tuitionAmountWon: Int,
             paymentId: String,
+            courseId: Long,
         ): Enrollment =
             Enrollment(
                 courseId = courseId,
+                productId = productId,
                 studentUserId = studentUserId,
                 enrollmentType = EnrollmentType.PURCHASE,
                 tuitionAmountWon = tuitionAmountWon,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/domain/Enrollment.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/domain/Enrollment.kt
@@ -1,6 +1,9 @@
 package com.sclass.domain.domains.enrollment.domain
 
 import com.sclass.domain.common.model.BaseTimeEntity
+import com.sclass.domain.domains.enrollment.exception.EnrollmentInvalidStatusTransitionException
+import com.sclass.domain.domains.enrollment.exception.EnrollmentPaymentRequiredException
+import com.sclass.domain.domains.enrollment.exception.EnrollmentTypeMismatchException
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -78,8 +81,8 @@ class Enrollment private constructor(
     var cancelReason: String? = null,
 ) : BaseTimeEntity() {
     fun markCoursePaid() {
-        require(enrollmentType == EnrollmentType.PURCHASE)
-        require(paymentId != null)
+        requirePurchaseEnrollment()
+        requirePayment()
         validateTransition(EnrollmentStatus.ACTIVE)
         this.status = EnrollmentStatus.ACTIVE
     }
@@ -88,8 +91,8 @@ class Enrollment private constructor(
         startAt: LocalDateTime,
         endAt: LocalDateTime,
     ) {
-        require(enrollmentType == EnrollmentType.PURCHASE)
-        require(paymentId != null)
+        requirePurchaseEnrollment()
+        requirePayment()
         this.startAt = startAt
         this.endAt = endAt
         validateTransition(EnrollmentStatus.ACTIVE)
@@ -115,9 +118,7 @@ class Enrollment private constructor(
         reason: String,
         refundedAt: LocalDateTime = LocalDateTime.now(),
     ) {
-        require(enrollmentType == EnrollmentType.PURCHASE) {
-            "refund is only valid for PURCHASE enrollments"
-        }
+        requirePurchaseEnrollment()
         validateTransition(EnrollmentStatus.REFUNDED)
         this.status = EnrollmentStatus.REFUNDED
         this.cancelledAt = refundedAt
@@ -133,7 +134,15 @@ class Enrollment private constructor(
                 EnrollmentStatus.CANCELLED -> setOf(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.ACTIVE)
                 EnrollmentStatus.REFUNDED -> setOf(EnrollmentStatus.ACTIVE, EnrollmentStatus.CANCELLED)
             }
-        require(status in allowed) { "Cannot transition from $status to $target" }
+        if (status !in allowed) throw EnrollmentInvalidStatusTransitionException()
+    }
+
+    private fun requirePurchaseEnrollment() {
+        if (enrollmentType != EnrollmentType.PURCHASE) throw EnrollmentTypeMismatchException()
+    }
+
+    private fun requirePayment() {
+        if (paymentId == null) throw EnrollmentPaymentRequiredException()
     }
 
     companion object {
@@ -208,9 +217,7 @@ class Enrollment private constructor(
             tuitionAmountWon: Int = 0,
             type: EnrollmentType = EnrollmentType.ADMIN_GRANT,
         ): Enrollment {
-            require(type != EnrollmentType.PURCHASE) {
-                "createByGrant cannot be used for PURCHASE type"
-            }
+            if (type == EnrollmentType.PURCHASE) throw EnrollmentTypeMismatchException()
             return Enrollment(
                 courseId = courseId,
                 studentUserId = studentUserId,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentErrorCode.kt
@@ -17,4 +17,5 @@ enum class EnrollmentErrorCode(
     ENROLLMENT_UNAUTHORIZED_ACCESS("ENROLLMENT_008", "해당 수강에 대한 권한이 없습니다", 403),
     MEMBERSHIP_CAPACITY_EXCEEDED("ENROLLMENT_009", "멤버십 정원이 초과되었습니다", 409),
     NO_ACTIVE_MEMBERSHIP("ENROLLMENT_010", "활성 멤버십이 없습니다", 403),
+    ENROLLMENT_INVALID_PURCHASE_TARGET("ENROLLMENT_011", "courseId와 productId 조합이 올바르지 않습니다", 400),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentExceptions.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentExceptions.kt
@@ -17,3 +17,5 @@ class EnrollmentNotActiveException : BusinessException(EnrollmentErrorCode.ENROL
 class EnrollmentTypeMismatchException : BusinessException(EnrollmentErrorCode.ENROLLMENT_TYPE_MISMATCH)
 
 class NoActiveMembershipException : BusinessException(EnrollmentErrorCode.NO_ACTIVE_MEMBERSHIP)
+
+class EnrollmentInvalidPurchaseTargetException : BusinessException(EnrollmentErrorCode.ENROLLMENT_INVALID_PURCHASE_TARGET)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
@@ -147,9 +147,11 @@ class EnrollmentCustomRepositoryImpl(
         queryFactory
             .selectOne()
             .from(enrollment)
+            .leftJoin(membershipProduct)
+            .on(membershipProduct.id.eq(enrollment.productId))
             .where(
                 enrollment.studentUserId.eq(studentUserId),
-                enrollment.productId.isNotNull,
+                membershipProduct.id.isNotNull,
                 enrollment.status.eq(EnrollmentStatus.ACTIVE),
                 enrollment.endAt.isNull.or(enrollment.endAt.gt(now)),
             ).fetchFirst() != null


### PR DESCRIPTION
## 요약
- 코스 수강 결제 준비 API가 `productId`를 함께 받도록 변경했습니다.
- 코스 구매 `Enrollment`에도 `productId`를 저장하도록 정리했습니다.
- 멤버십 판정을 `courseId`/`productId` null 여부가 아니라 실제 상품 subtype 기준으로 보정했습니다.

## 상세 변경
- `POST /api/v1/enrollments` 요청에 `productId`를 추가했습니다.
- 응답에도 `productId`를 포함하도록 변경했습니다.
- `courseId`와 `productId` 조합이 맞지 않으면 400 에러를 반환합니다.
- 결제 완료 후 course/membership 분기는 명시 메서드(`markCoursePaid`, `markMembershipPaid`)로 분리했습니다.
- 백오피스/도메인에서 멤버십 전용 로직은 실제 `MembershipProduct` subtype 기준으로 확인하도록 수정했습니다.

## 테스트
- `gradle :SClass-Api-Supporters:test :SClass-Api-Backoffice:test :SClass-Batch:test --tests 'com.sclass.supporters.enrollment.usecase.PrepareEnrollmentUseCaseTest' --tests 'com.sclass.supporters.enrollment.usecase.PrepareEnrollmentConcurrencyTest' --tests 'com.sclass.supporters.enrollment.usecase.GetMyEnrollmentsUseCaseTest' --tests 'com.sclass.supporters.payment.usecase.HandleNicePayWebhookUseCaseTest' --tests 'com.sclass.supporters.payment.usecase.HandleNicePayReturnUseCaseTest' --tests 'com.sclass.backoffice.coin.usecase.AdminGrantCoinUseCaseTest' --tests 'com.sclass.backoffice.enrollment.usecase.ExtendMembershipExpireUseCaseTest' --tests 'com.sclass.batch.enrollment.CleanupStalePendingEnrollmentsJobTest'