### PR TITLE
feat(enrollment): add pending-match flow for matching products

### DIFF
--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/MyEnrollmentResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/MyEnrollmentResponse.kt
@@ -5,6 +5,7 @@ import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.enrollment.domain.EnrollmentType
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithCourseDto
 import com.sclass.domain.domains.product.domain.CohortMembershipProduct
+import com.sclass.domain.domains.product.domain.MembershipProduct
 import com.sclass.domain.domains.product.domain.ProductType
 import com.sclass.domain.domains.product.domain.RollingMembershipProduct
 import java.time.LocalDateTime
@@ -17,58 +18,52 @@ data class MyEnrollmentResponse(
     val tuitionAmountWon: Int,
     val startAt: LocalDateTime?,
     val endAt: LocalDateTime?,
+    val product: ProductSummary?,
     val course: CourseSummary?,
-    val membership: MembershipSummary?,
 ) {
-    data class CourseSummary(
+    data class ProductSummary(
+        val id: String,
+        val type: ProductType,
         val name: String,
         val description: String?,
         val thumbnailUrl: String?,
-        val teacherName: String?,
-        val courseStatus: CourseStatus,
-        val enrollmentDeadLine: LocalDateTime?,
-        val startAt: LocalDateTime?,
-        val endAt: LocalDateTime?,
     )
 
-    data class MembershipSummary(
-        val productId: String,
-        val productType: ProductType,
-        val productName: String,
-        val thumbnailUrl: String?,
+    data class CourseSummary(
+        val id: Long,
+        val status: CourseStatus,
+        val teacherName: String?,
     )
 
     companion object {
         fun from(
             dto: EnrollmentWithCourseDto,
-            courseThumbnailUrl: String?,
-            membershipThumbnailUrl: String?,
+            productThumbnailUrl: String?,
         ): MyEnrollmentResponse {
+            val product =
+                dto.courseProduct?.let { cp ->
+                    ProductSummary(
+                        id = cp.id,
+                        type = ProductType.COURSE,
+                        name = cp.name,
+                        description = cp.description,
+                        thumbnailUrl = productThumbnailUrl,
+                    )
+                } ?: dto.membershipProduct?.let { mp ->
+                    ProductSummary(
+                        id = mp.id,
+                        type = mp.toProductType(),
+                        name = mp.name,
+                        description = mp.description,
+                        thumbnailUrl = productThumbnailUrl,
+                    )
+                }
             val course =
                 dto.course?.let { c ->
                     CourseSummary(
-                        name = dto.courseProduct?.name ?: "",
-                        description = dto.courseProduct?.description,
-                        thumbnailUrl = courseThumbnailUrl,
+                        id = c.id,
+                        status = c.status,
                         teacherName = dto.teacherName,
-                        courseStatus = c.status,
-                        enrollmentDeadLine = c.enrollmentDeadLine,
-                        startAt = c.startAt,
-                        endAt = c.endAt,
-                    )
-                }
-            val membership =
-                dto.membershipProduct?.let { mp ->
-                    MembershipSummary(
-                        productId = mp.id,
-                        productType =
-                            when (mp) {
-                                is RollingMembershipProduct -> ProductType.ROLLING_MEMBERSHIP
-                                is CohortMembershipProduct -> ProductType.COHORT_MEMBERSHIP
-                                else -> error("Unknown MembershipProduct subtype")
-                            },
-                        productName = mp.name,
-                        thumbnailUrl = membershipThumbnailUrl,
                     )
                 }
             return MyEnrollmentResponse(
@@ -79,9 +74,16 @@ data class MyEnrollmentResponse(
                 tuitionAmountWon = dto.enrollment.tuitionAmountWon,
                 startAt = dto.enrollment.startAt,
                 endAt = dto.enrollment.endAt,
+                product = product,
                 course = course,
-                membership = membership,
             )
         }
+
+        private fun MembershipProduct.toProductType(): ProductType =
+            when (this) {
+                is RollingMembershipProduct -> ProductType.ROLLING_MEMBERSHIP
+                is CohortMembershipProduct -> ProductType.COHORT_MEMBERSHIP
+                else -> error("Unknown MembershipProduct subtype")
+            }
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/PrepareEnrollmentRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/PrepareEnrollmentRequest.kt
@@ -6,6 +6,6 @@ import jakarta.validation.constraints.NotNull
 
 data class PrepareEnrollmentRequest(
     @field:NotBlank val productId: String,
-    @field:NotNull val courseId: Long,
     @field:NotNull val pgType: PgType,
+    val courseId: Long?,
 )

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/PrepareEnrollmentResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/dto/PrepareEnrollmentResponse.kt
@@ -5,6 +5,6 @@ data class PrepareEnrollmentResponse(
     val pgOrderId: String,
     val amount: Int,
     val productId: String,
-    val courseId: Long,
+    val courseId: Long?,
     val courseName: String,
 )

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/GetMyEnrollmentsUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/GetMyEnrollmentsUseCase.kt
@@ -16,8 +16,10 @@ class GetMyEnrollmentsUseCase(
         enrollmentAdaptor.findAllByStudentWithCourse(studentUserId).map {
             MyEnrollmentResponse.from(
                 dto = it,
-                courseThumbnailUrl = thumbnailUrlResolver.resolve(it.courseProduct?.thumbnailFileId),
-                membershipThumbnailUrl = thumbnailUrlResolver.resolve(it.membershipProduct?.thumbnailFileId),
+                productThumbnailUrl =
+                    thumbnailUrlResolver.resolve(
+                        it.courseProduct?.thumbnailFileId ?: it.membershipProduct?.thumbnailFileId,
+                    ),
             )
         }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
@@ -1,37 +1,22 @@
 package com.sclass.supporters.enrollment.usecase
 
 import com.sclass.common.annotation.UseCase
-import com.sclass.domain.common.vo.Ulid
-import com.sclass.domain.domains.course.adaptor.CourseAdaptor
-import com.sclass.domain.domains.course.exception.CourseNotEnrollableException
-import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
-import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.exception.EnrollmentInvalidPurchaseTargetException
-import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
-import com.sclass.domain.domains.payment.domain.Payment
-import com.sclass.domain.domains.payment.domain.PaymentTargetType
 import com.sclass.domain.domains.payment.domain.PgType
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
 import com.sclass.domain.domains.product.domain.CourseProduct
 import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
-import com.sclass.infrastructure.redis.DistributedLock
-import com.sclass.infrastructure.redis.LockKey
 import com.sclass.supporters.enrollment.dto.PrepareEnrollmentResponse
-import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 @UseCase
 class PrepareEnrollmentUseCase(
-    private val courseAdaptor: CourseAdaptor,
     private val productAdaptor: ProductAdaptor,
-    private val enrollmentAdaptor: EnrollmentAdaptor,
-    private val paymentAdaptor: PaymentAdaptor,
+    private val prepareRegularEnrollmentUseCase: PrepareRegularEnrollmentUseCase,
+    private val prepareMatchingEnrollmentUseCase: PrepareMatchingEnrollmentUseCase,
 ) {
-    @Transactional
-    @DistributedLock(prefix = "enrollment")
     fun execute(
         studentUserId: String,
-        @LockKey productId: String,
+        productId: String,
         courseId: Long?,
         pgType: PgType,
     ): PrepareEnrollmentResponse {
@@ -40,7 +25,7 @@ class PrepareEnrollmentUseCase(
                 ?: throw ProductTypeMismatchException()
 
         return if (product.requiresMatching) {
-            prepareMatchingEnrollment(
+            prepareMatchingEnrollmentUseCase.execute(
                 studentUserId = studentUserId,
                 productId = productId,
                 product = product,
@@ -48,127 +33,13 @@ class PrepareEnrollmentUseCase(
                 pgType = pgType,
             )
         } else {
-            prepareRegularEnrollment(
+            prepareRegularEnrollmentUseCase.execute(
                 studentUserId = studentUserId,
                 productId = productId,
                 product = product,
-                courseId = courseId,
+                courseId = courseId ?: throw EnrollmentInvalidPurchaseTargetException(),
                 pgType = pgType,
             )
         }
-    }
-
-    private fun prepareMatchingEnrollment(
-        studentUserId: String,
-        productId: String,
-        product: CourseProduct,
-        courseId: Long?,
-        pgType: PgType,
-    ): PrepareEnrollmentResponse {
-        if (courseId != null) throw EnrollmentInvalidPurchaseTargetException()
-
-        enrollmentAdaptor.findResumableCourseProductEnrollment(productId, studentUserId)?.let { live ->
-            val payment = paymentAdaptor.findById(live.paymentId!!)
-            return PrepareEnrollmentResponse(
-                paymentId = payment.id,
-                pgOrderId = payment.pgOrderId,
-                amount = payment.amount,
-                productId = productId,
-                courseId = null,
-                courseName = product.name,
-            )
-        }
-
-        val payment =
-            paymentAdaptor.save(
-                Payment(
-                    userId = studentUserId,
-                    targetType = PaymentTargetType.COURSE_PRODUCT,
-                    targetId = productId,
-                    amount = product.priceWon,
-                    pgType = pgType,
-                    pgOrderId = Ulid.generate(),
-                ),
-            )
-
-        enrollmentAdaptor.save(
-            Enrollment.createForPurchase(
-                productId = productId,
-                courseId = null,
-                studentUserId = studentUserId,
-                tuitionAmountWon = product.priceWon,
-                paymentId = payment.id,
-            ),
-        )
-
-        return PrepareEnrollmentResponse(
-            paymentId = payment.id,
-            pgOrderId = payment.pgOrderId,
-            amount = payment.amount,
-            productId = productId,
-            courseId = null,
-            courseName = product.name,
-        )
-    }
-
-    private fun prepareRegularEnrollment(
-        studentUserId: String,
-        productId: String,
-        product: CourseProduct,
-        courseId: Long?,
-        pgType: PgType,
-    ): PrepareEnrollmentResponse {
-        val resolvedCourseId = courseId ?: throw EnrollmentInvalidPurchaseTargetException()
-        val course = courseAdaptor.findById(resolvedCourseId)
-
-        if (course.productId != productId) throw EnrollmentInvalidPurchaseTargetException()
-
-        enrollmentAdaptor.findResumableEnrollment(resolvedCourseId, studentUserId)?.let { live ->
-            val payment = paymentAdaptor.findById(live.paymentId!!)
-            return PrepareEnrollmentResponse(
-                payment.id,
-                payment.pgOrderId,
-                payment.amount,
-                productId,
-                course.id,
-                product.name,
-            )
-        }
-
-        val liveCount = enrollmentAdaptor.countLiveEnrollments(resolvedCourseId)
-        if (!course.canEnroll(LocalDateTime.now(), liveCount)) {
-            throw CourseNotEnrollableException()
-        }
-
-        val payment =
-            paymentAdaptor.save(
-                Payment(
-                    userId = studentUserId,
-                    targetType = PaymentTargetType.COURSE_PRODUCT,
-                    targetId = productId,
-                    amount = product.priceWon,
-                    pgType = pgType,
-                    pgOrderId = Ulid.generate(),
-                ),
-            )
-
-        enrollmentAdaptor.save(
-            Enrollment.createForPurchase(
-                productId = productId,
-                courseId = course.id,
-                studentUserId = studentUserId,
-                tuitionAmountWon = product.priceWon,
-                paymentId = payment.id,
-            ),
-        )
-
-        return PrepareEnrollmentResponse(
-            paymentId = payment.id,
-            pgOrderId = payment.pgOrderId,
-            amount = payment.amount,
-            productId = productId,
-            courseId = course.id,
-            courseName = product.name,
-        )
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
@@ -32,7 +32,7 @@ class PrepareEnrollmentUseCase(
     fun execute(
         studentUserId: String,
         @LockKey productId: String,
-        @LockKey courseId: Long?,
+        courseId: Long?,
         pgType: PgType,
     ): PrepareEnrollmentResponse {
         val product =

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
@@ -39,7 +39,7 @@ class PrepareEnrollmentUseCase(
             productAdaptor.findById(productId) as? CourseProduct
                 ?: throw ProductTypeMismatchException()
 
-        return if (product.matchingEnabled) {
+        return if (product.requiresMatching) {
             prepareMatchingEnrollment(
                 studentUserId = studentUserId,
                 productId = productId,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
@@ -31,22 +31,111 @@ class PrepareEnrollmentUseCase(
     @DistributedLock(prefix = "enrollment")
     fun execute(
         studentUserId: String,
-        productId: String,
-        @LockKey courseId: Long,
+        @LockKey productId: String,
+        @LockKey courseId: Long?,
         pgType: PgType,
     ): PrepareEnrollmentResponse {
-        val course = courseAdaptor.findById(courseId)
-        if (course.productId != productId) throw EnrollmentInvalidPurchaseTargetException()
         val product =
             productAdaptor.findById(productId) as? CourseProduct
                 ?: throw ProductTypeMismatchException()
 
-        enrollmentAdaptor.findResumableEnrollment(courseId, studentUserId)?.let { live ->
+        return if (product.matchingEnabled) {
+            prepareMatchingEnrollment(
+                studentUserId = studentUserId,
+                productId = productId,
+                product = product,
+                courseId = courseId,
+                pgType = pgType,
+            )
+        } else {
+            prepareRegularEnrollment(
+                studentUserId = studentUserId,
+                productId = productId,
+                product = product,
+                courseId = courseId,
+                pgType = pgType,
+            )
+        }
+    }
+
+    private fun prepareMatchingEnrollment(
+        studentUserId: String,
+        productId: String,
+        product: CourseProduct,
+        courseId: Long?,
+        pgType: PgType,
+    ): PrepareEnrollmentResponse {
+        if (courseId != null) throw EnrollmentInvalidPurchaseTargetException()
+
+        enrollmentAdaptor.findResumableCourseProductEnrollment(productId, studentUserId)?.let { live ->
             val payment = paymentAdaptor.findById(live.paymentId!!)
-            return PrepareEnrollmentResponse(payment.id, payment.pgOrderId, payment.amount, productId, course.id, product.name)
+            return PrepareEnrollmentResponse(
+                paymentId = payment.id,
+                pgOrderId = payment.pgOrderId,
+                amount = payment.amount,
+                productId = productId,
+                courseId = null,
+                courseName = product.name,
+            )
         }
 
-        val liveCount = enrollmentAdaptor.countLiveEnrollments(courseId)
+        val payment =
+            paymentAdaptor.save(
+                Payment(
+                    userId = studentUserId,
+                    targetType = PaymentTargetType.COURSE_PRODUCT,
+                    targetId = productId,
+                    amount = product.priceWon,
+                    pgType = pgType,
+                    pgOrderId = Ulid.generate(),
+                ),
+            )
+
+        enrollmentAdaptor.save(
+            Enrollment.createForPurchase(
+                productId = productId,
+                courseId = null,
+                studentUserId = studentUserId,
+                tuitionAmountWon = product.priceWon,
+                paymentId = payment.id,
+            ),
+        )
+
+        return PrepareEnrollmentResponse(
+            paymentId = payment.id,
+            pgOrderId = payment.pgOrderId,
+            amount = payment.amount,
+            productId = productId,
+            courseId = null,
+            courseName = product.name,
+        )
+    }
+
+    private fun prepareRegularEnrollment(
+        studentUserId: String,
+        productId: String,
+        product: CourseProduct,
+        courseId: Long?,
+        pgType: PgType,
+    ): PrepareEnrollmentResponse {
+        val resolvedCourseId = courseId ?: throw EnrollmentInvalidPurchaseTargetException()
+        val course = courseAdaptor.findById(resolvedCourseId)
+
+        if (course.productId != productId) throw EnrollmentInvalidPurchaseTargetException()
+
+        enrollmentAdaptor.findResumableEnrollment(resolvedCourseId, studentUserId)?.let { live ->
+            val payment = paymentAdaptor.findById(live.paymentId!!)
+            return PrepareEnrollmentResponse(
+                payment.id,
+                payment.pgOrderId,
+                payment.amount,
+                productId,
+                course.id,
+                product.name,
+            )
+        }
+
+        val liveCount = enrollmentAdaptor.countLiveEnrollments(resolvedCourseId)
         if (!course.canEnroll(LocalDateTime.now(), liveCount)) {
             throw CourseNotEnrollableException()
         }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareMatchingEnrollmentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareMatchingEnrollmentUseCase.kt
@@ -1,0 +1,77 @@
+package com.sclass.supporters.enrollment.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.common.vo.Ulid
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.exception.EnrollmentInvalidPurchaseTargetException
+import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.Payment
+import com.sclass.domain.domains.payment.domain.PaymentTargetType
+import com.sclass.domain.domains.payment.domain.PgType
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import com.sclass.supporters.enrollment.dto.PrepareEnrollmentResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class PrepareMatchingEnrollmentUseCase(
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val paymentAdaptor: PaymentAdaptor,
+) {
+    @Transactional
+    @DistributedLock(prefix = "enrollment")
+    fun execute(
+        @LockKey studentUserId: String,
+        @LockKey productId: String,
+        product: CourseProduct,
+        courseId: Long?,
+        pgType: PgType,
+    ): PrepareEnrollmentResponse {
+        if (courseId != null) throw EnrollmentInvalidPurchaseTargetException()
+
+        enrollmentAdaptor.findResumableCourseProductEnrollment(productId, studentUserId)?.let { live ->
+            val payment = paymentAdaptor.findById(live.paymentId!!)
+            return PrepareEnrollmentResponse(
+                paymentId = payment.id,
+                pgOrderId = payment.pgOrderId,
+                amount = payment.amount,
+                productId = productId,
+                courseId = null,
+                courseName = product.name,
+            )
+        }
+
+        val payment =
+            paymentAdaptor.save(
+                Payment(
+                    userId = studentUserId,
+                    targetType = PaymentTargetType.COURSE_PRODUCT,
+                    targetId = productId,
+                    amount = product.priceWon,
+                    pgType = pgType,
+                    pgOrderId = Ulid.generate(),
+                ),
+            )
+
+        enrollmentAdaptor.save(
+            Enrollment.createForPurchase(
+                productId = productId,
+                courseId = null,
+                studentUserId = studentUserId,
+                tuitionAmountWon = product.priceWon,
+                paymentId = payment.id,
+            ),
+        )
+
+        return PrepareEnrollmentResponse(
+            paymentId = payment.id,
+            pgOrderId = payment.pgOrderId,
+            amount = payment.amount,
+            productId = productId,
+            courseId = null,
+            courseName = product.name,
+        )
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareRegularEnrollmentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareRegularEnrollmentUseCase.kt
@@ -1,0 +1,88 @@
+package com.sclass.supporters.enrollment.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.common.vo.Ulid
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.course.exception.CourseNotEnrollableException
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.exception.EnrollmentInvalidPurchaseTargetException
+import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.Payment
+import com.sclass.domain.domains.payment.domain.PaymentTargetType
+import com.sclass.domain.domains.payment.domain.PgType
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import com.sclass.supporters.enrollment.dto.PrepareEnrollmentResponse
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@UseCase
+class PrepareRegularEnrollmentUseCase(
+    private val courseAdaptor: CourseAdaptor,
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val paymentAdaptor: PaymentAdaptor,
+) {
+    @Transactional
+    @DistributedLock(prefix = "enrollment")
+    fun execute(
+        studentUserId: String,
+        productId: String,
+        product: CourseProduct,
+        @LockKey courseId: Long,
+        pgType: PgType,
+    ): PrepareEnrollmentResponse {
+        val course = courseAdaptor.findById(courseId)
+
+        if (course.productId != productId) throw EnrollmentInvalidPurchaseTargetException()
+
+        enrollmentAdaptor.findResumableEnrollment(courseId, studentUserId)?.let { live ->
+            val payment = paymentAdaptor.findById(live.paymentId!!)
+            return PrepareEnrollmentResponse(
+                payment.id,
+                payment.pgOrderId,
+                payment.amount,
+                productId,
+                course.id,
+                product.name,
+            )
+        }
+
+        val liveCount = enrollmentAdaptor.countLiveEnrollments(courseId)
+        if (!course.canEnroll(LocalDateTime.now(), liveCount)) {
+            throw CourseNotEnrollableException()
+        }
+
+        val payment =
+            paymentAdaptor.save(
+                Payment(
+                    userId = studentUserId,
+                    targetType = PaymentTargetType.COURSE_PRODUCT,
+                    targetId = productId,
+                    amount = product.priceWon,
+                    pgType = pgType,
+                    pgOrderId = Ulid.generate(),
+                ),
+            )
+
+        enrollmentAdaptor.save(
+            Enrollment.createForPurchase(
+                productId = productId,
+                courseId = course.id,
+                studentUserId = studentUserId,
+                tuitionAmountWon = product.priceWon,
+                paymentId = payment.id,
+            ),
+        )
+
+        return PrepareEnrollmentResponse(
+            paymentId = payment.id,
+            pgOrderId = payment.pgOrderId,
+            amount = payment.amount,
+            productId = productId,
+            courseId = course.id,
+            courseName = product.name,
+        )
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
@@ -5,10 +5,12 @@ import com.sclass.domain.domains.coin.adaptor.CoinPackageAdaptor
 import com.sclass.domain.domains.coin.domain.CoinLotSourceType
 import com.sclass.domain.domains.coin.service.CoinDomainService
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.exception.EnrollmentCourseRequiredException
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.CourseProduct
 import com.sclass.domain.domains.product.domain.MembershipProduct
 import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
 import com.sclass.infrastructure.nicepay.PgGateway
@@ -119,10 +121,18 @@ class HandleNicePayReturnUseCase(
                     successUrl(coinPackage.coinAmount)
                 }
                 PaymentTargetType.COURSE_PRODUCT -> {
+                    val product =
+                        productAdaptor.findById(payment.targetId) as? CourseProduct
+                            ?: throw ProductTypeMismatchException()
                     txTemplate.execute {
                         val fresh = paymentAdaptor.findById(payment.id)
                         val enrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
-                        enrollment.markCoursePaid()
+                        if (product.matchingEnabled) {
+                            enrollment.markPendingMatch()
+                        } else {
+                            if (enrollment.courseId == null) throw EnrollmentCourseRequiredException()
+                            enrollment.markCoursePaid()
+                        }
                         enrollmentAdaptor.save(enrollment)
                         fresh.markCompleted()
                         paymentAdaptor.save(fresh)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
@@ -127,7 +127,7 @@ class HandleNicePayReturnUseCase(
                     txTemplate.execute {
                         val fresh = paymentAdaptor.findById(payment.id)
                         val enrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
-                        if (product.matchingEnabled) {
+                        if (product.requiresMatching) {
                             enrollment.markPendingMatch()
                         } else {
                             if (enrollment.courseId == null) throw EnrollmentCourseRequiredException()

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -123,7 +123,7 @@ class HandleNicePayWebhookUseCase(
                     return
                 }
 
-                if (product.matchingEnabled) {
+                if (product.requiresMatching) {
                     txTemplate.execute {
                         val fresh = paymentAdaptor.findById(payment.id)
                         val freshEnrollment =

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -7,6 +7,7 @@ import com.sclass.domain.domains.coin.service.CoinDomainService
 import com.sclass.domain.domains.course.adaptor.CourseAdaptor
 import com.sclass.domain.domains.course.domain.CourseStatus
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.exception.EnrollmentCourseRequiredException
 import com.sclass.domain.domains.lesson.service.LessonDomainService
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.PaymentStatus
@@ -114,14 +115,29 @@ class HandleNicePayWebhookUseCase(
                     fresh.markPgApproved(payload.tid)
                     paymentAdaptor.save(fresh)
                 }
+
                 val enrollment = enrollmentAdaptor.findByPaymentIdOrNull(payment.id)
                 if (enrollment == null) {
                     log.warn("웹훅 수신: enrollment 없음 paymentId={}", payment.id)
                     return
                 }
 
-                val courseId =
-                    enrollment.courseId ?: error("COURSE_PRODUCT enrollment must have courseId")
+                if (product.matchingEnabled) {
+                    txTemplate.execute {
+                        val fresh = paymentAdaptor.findById(payment.id)
+                        val freshEnrollment =
+                            enrollmentAdaptor.findByPaymentId(fresh.id)
+
+                        freshEnrollment.markPendingMatch()
+                        enrollmentAdaptor.save(freshEnrollment)
+
+                        fresh.markCompleted()
+                        paymentAdaptor.save(fresh)
+                    }
+                    return
+                }
+
+                val courseId = enrollment.courseId ?: throw EnrollmentCourseRequiredException()
                 val course = courseAdaptor.findById(courseId)
 
                 if (course.status == CourseStatus.UNLISTED || course.status == CourseStatus.ARCHIVED) {
@@ -148,8 +164,10 @@ class HandleNicePayWebhookUseCase(
                 txTemplate.execute {
                     val fresh = paymentAdaptor.findById(payment.id)
                     val freshEnrollment = enrollmentAdaptor.findByPaymentId(fresh.id)
+
                     freshEnrollment.markCoursePaid()
                     enrollmentAdaptor.save(freshEnrollment)
+
                     fresh.markCompleted()
                     paymentAdaptor.save(fresh)
 
@@ -157,7 +175,7 @@ class HandleNicePayWebhookUseCase(
                         freshEnrollment,
                         teacherUserId = course.teacherUserId,
                         courseName = product.name,
-                        totalLessons = product.totalLessons,
+                        totalLessons = course.totalLessons ?: product.totalLessons,
                     )
                 }
             }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -77,6 +77,7 @@ class HandleNicePayWebhookUseCase(
             return
         }
 
+        // TODO: 전략패턴으로 리팩토링
         when (payment.targetType) {
             PaymentTargetType.COIN_PACKAGE -> {
                 val coinPackage = coinPackageAdaptor.findById(payment.targetId)

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/GetMyEnrollmentsUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/GetMyEnrollmentsUseCaseTest.kt
@@ -112,15 +112,18 @@ class GetMyEnrollmentsUseCaseTest {
             { assertEquals(1L, result[0].courseId) },
             { assertEquals(EnrollmentStatus.PENDING_PAYMENT, result[0].status) },
             { assertEquals(300000, result[0].tuitionAmountWon) },
-            { assertNull(result[0].membership) },
-            { assertEquals("수학 기초", summary.name) },
-            { assertEquals("수학 심화", summary.description) },
-            { assertEquals("https://static.test.sclass.click/course_thumbnail/file-id-00000000000000001", summary.thumbnailUrl) },
+            { assertEquals(ProductType.COURSE, result[0].product?.type) },
+            { assertEquals("수학 기초", result[0].product?.name) },
+            { assertEquals("수학 심화", result[0].product?.description) },
+            {
+                assertEquals(
+                    "https://static.test.sclass.click/course_thumbnail/file-id-00000000000000001",
+                    result[0].product?.thumbnailUrl,
+                )
+            },
+            { assertEquals(1L, summary.id) },
             { assertEquals("김선생", summary.teacherName) },
-            { assertEquals(CourseStatus.LISTED, summary.courseStatus) },
-            { assertEquals(LocalDateTime.of(2026, 4, 30, 0, 0), summary.enrollmentDeadLine) },
-            { assertEquals(LocalDateTime.of(2026, 5, 1, 0, 0), summary.startAt) },
-            { assertEquals(LocalDateTime.of(2026, 6, 30, 0, 0), summary.endAt) },
+            { assertEquals(CourseStatus.LISTED, summary.status) },
         )
     }
 
@@ -130,24 +133,67 @@ class GetMyEnrollmentsUseCaseTest {
 
         val result = useCase.execute("student-id-0000000000000001")
 
-        val membership = result[0].membership!!
+        val product = result[0].product!!
         assertAll(
             { assertNull(result[0].course) },
-            { assertNotNull(result[0].membership) },
-            { assertEquals(ProductType.ROLLING_MEMBERSHIP, membership.productType) },
-            { assertEquals("프리미엄 멤버십", membership.productName) },
-            { assertEquals("https://static.test.sclass.click/course_thumbnail/mp-thumb-00000000000000001", membership.thumbnailUrl) },
+            { assertNotNull(result[0].product) },
+            { assertEquals(ProductType.ROLLING_MEMBERSHIP, product.type) },
+            { assertEquals("프리미엄 멤버십", product.name) },
+            { assertEquals("https://static.test.sclass.click/course_thumbnail/mp-thumb-00000000000000001", product.thumbnailUrl) },
         )
     }
 
     @Test
-    fun `코스가 삭제되어 join 결과가 null 이면 course 요약은 null 이다`() {
+    fun `코스가 삭제되어 join 결과가 null 이면 course는 null이고 product 요약은 유지된다`() {
         every { enrollmentAdaptor.findAllByStudentWithCourse("student-id-0000000000000001") } returns
-            listOf(makeCourseDto(course = null, courseProduct = null, teacherName = null))
+            listOf(makeCourseDto(course = null, teacherName = null))
 
         val result = useCase.execute("student-id-0000000000000001")
 
-        assertNull(result[0].course)
+        assertAll(
+            { assertNull(result[0].course) },
+            { assertEquals(ProductType.COURSE, result[0].product?.type) },
+            { assertEquals("수학 기초", result[0].product?.name) },
+        )
+    }
+
+    @Test
+    fun `매칭 대기 enrollment는 course는 null이고 product 요약을 포함한다`() {
+        val enrollment =
+            Enrollment
+                .createForPurchase(
+                    productId = "product-id-0000000000000001",
+                    courseId = null,
+                    studentUserId = "student-id-0000000000000001",
+                    tuitionAmountWon = 300000,
+                    paymentId = "payment-id-00000000000000",
+                ).apply { markPendingMatch() }
+        val dto =
+            EnrollmentWithCourseDto(
+                enrollment = enrollment,
+                course = null,
+                courseProduct =
+                    CourseProduct(
+                        name = "매칭형 수학 기초",
+                        priceWon = 300000,
+                        totalLessons = 12,
+                        description = "강사 배정 대기 중인 코스",
+                        thumbnailFileId = "file-id-00000000000000001",
+                    ),
+                teacherName = null,
+            )
+        every { enrollmentAdaptor.findAllByStudentWithCourse("student-id-0000000000000001") } returns listOf(dto)
+
+        val result = useCase.execute("student-id-0000000000000001")
+
+        assertAll(
+            { assertNull(result[0].courseId) },
+            { assertEquals(EnrollmentStatus.PENDING_MATCH, result[0].status) },
+            { assertNull(result[0].course) },
+            { assertEquals(ProductType.COURSE, result[0].product?.type) },
+            { assertEquals("매칭형 수학 기초", result[0].product?.name) },
+            { assertEquals("강사 배정 대기 중인 코스", result[0].product?.description) },
+        )
     }
 
     @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
@@ -66,6 +66,14 @@ class PrepareEnrollmentUseCaseTest {
             totalLessons = 12,
         )
 
+    private fun matchingCourseProduct() =
+        CourseProduct(
+            name = "매칭형 수학 코스",
+            priceWon = 300000,
+            totalLessons = 12,
+            matchingEnabled = true,
+        )
+
     private fun pendingPayment() =
         Payment(
             userId = "student-id-00000000001",
@@ -97,6 +105,29 @@ class PrepareEnrollmentUseCaseTest {
             assertThat(enrollmentSlot.captured.productId).isEqualTo("product-id-00000000001")
             assertThat(enrollmentSlot.captured.status).isEqualTo(EnrollmentStatus.PENDING_PAYMENT)
             assertThat(enrollmentSlot.captured.tuitionAmountWon).isEqualTo(300000)
+        }
+
+        @Test
+        fun `매칭형 상품 결제 준비 시 courseId 없이 Payment와 Enrollment가 생성된다`() {
+            val enrollmentSlot = slot<Enrollment>()
+            every { productAdaptor.findById("product-id-00000000001") } returns matchingCourseProduct()
+            every {
+                enrollmentAdaptor.findResumableCourseProductEnrollment(
+                    "product-id-00000000001",
+                    "student-id-00000000001",
+                )
+            } returns null
+            every { paymentAdaptor.save(any()) } returns pendingPayment()
+            every { enrollmentAdaptor.save(capture(enrollmentSlot)) } answers { enrollmentSlot.captured }
+
+            val result = useCase.execute("student-id-00000000001", "product-id-00000000001", null, PgType.NICEPAY)
+
+            assertThat(result.productId).isEqualTo("product-id-00000000001")
+            assertThat(result.courseId).isNull()
+            assertThat(result.courseName).isEqualTo("매칭형 수학 코스")
+            assertThat(enrollmentSlot.captured.courseId).isNull()
+            assertThat(enrollmentSlot.captured.productId).isEqualTo("product-id-00000000001")
+            verify(exactly = 0) { courseAdaptor.findById(any()) }
         }
     }
 
@@ -163,9 +194,19 @@ class PrepareEnrollmentUseCaseTest {
         @Test
         fun `courseId와 productId 조합이 다르면 EnrollmentInvalidPurchaseTargetException이 발생한다`() {
             every { courseAdaptor.findById(1L) } returns listedCourse()
+            every { productAdaptor.findById("different-product-id") } returns courseProduct()
 
             assertThatThrownBy {
                 useCase.execute("student-id-00000000001", "different-product-id", 1L, PgType.NICEPAY)
+            }.isInstanceOf(EnrollmentInvalidPurchaseTargetException::class.java)
+        }
+
+        @Test
+        fun `매칭형 상품에 courseId를 보내면 EnrollmentInvalidPurchaseTargetException이 발생한다`() {
+            every { productAdaptor.findById("product-id-00000000001") } returns matchingCourseProduct()
+
+            assertThatThrownBy {
+                useCase.execute("student-id-00000000001", "product-id-00000000001", 1L, PgType.NICEPAY)
             }.isInstanceOf(EnrollmentInvalidPurchaseTargetException::class.java)
         }
 

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
@@ -129,6 +129,34 @@ class PrepareEnrollmentUseCaseTest {
             assertThat(enrollmentSlot.captured.productId).isEqualTo("product-id-00000000001")
             verify(exactly = 0) { courseAdaptor.findById(any()) }
         }
+
+        @Test
+        fun `매칭형 상품에 PENDING_PAYMENT enrollment이 있으면 기존 결제 정보를 그대로 반환한다`() {
+            val existingEnrollment =
+                Enrollment.createForPurchase(
+                    productId = "product-id-00000000001",
+                    courseId = null,
+                    studentUserId = "student-id-00000000001",
+                    tuitionAmountWon = 300000,
+                    paymentId = "payment-id-000000000001",
+                )
+            every { productAdaptor.findById("product-id-00000000001") } returns matchingCourseProduct()
+            every {
+                enrollmentAdaptor.findResumableCourseProductEnrollment(
+                    "product-id-00000000001",
+                    "student-id-00000000001",
+                )
+            } returns existingEnrollment
+            every { paymentAdaptor.findById("payment-id-000000000001") } returns pendingPayment()
+
+            val result = useCase.execute("student-id-00000000001", "product-id-00000000001", null, PgType.NICEPAY)
+
+            assertThat(result.productId).isEqualTo("product-id-00000000001")
+            assertThat(result.courseId).isNull()
+            assertThat(result.pgOrderId).isEqualTo("order-id-000000000001")
+            verify(exactly = 0) { paymentAdaptor.save(any()) }
+            verify(exactly = 0) { enrollmentAdaptor.save(any()) }
+        }
     }
 
     @Nested
@@ -208,6 +236,21 @@ class PrepareEnrollmentUseCaseTest {
             assertThatThrownBy {
                 useCase.execute("student-id-00000000001", "product-id-00000000001", 1L, PgType.NICEPAY)
             }.isInstanceOf(EnrollmentInvalidPurchaseTargetException::class.java)
+        }
+
+        @Test
+        fun `매칭형 상품에 PENDING_MATCH enrollment이 있으면 EnrollmentAlreadyExistsException이 발생한다`() {
+            every { productAdaptor.findById("product-id-00000000001") } returns matchingCourseProduct()
+            every {
+                enrollmentAdaptor.findResumableCourseProductEnrollment(
+                    "product-id-00000000001",
+                    "student-id-00000000001",
+                )
+            } throws EnrollmentAlreadyExistsException()
+
+            assertThatThrownBy {
+                useCase.execute("student-id-00000000001", "product-id-00000000001", null, PgType.NICEPAY)
+            }.isInstanceOf(EnrollmentAlreadyExistsException::class.java)
         }
 
         @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
@@ -32,6 +32,8 @@ class PrepareEnrollmentUseCaseTest {
     private lateinit var productAdaptor: ProductAdaptor
     private lateinit var enrollmentAdaptor: EnrollmentAdaptor
     private lateinit var paymentAdaptor: PaymentAdaptor
+    private lateinit var prepareRegularEnrollmentUseCase: PrepareRegularEnrollmentUseCase
+    private lateinit var prepareMatchingEnrollmentUseCase: PrepareMatchingEnrollmentUseCase
     private lateinit var useCase: PrepareEnrollmentUseCase
 
     @BeforeEach
@@ -40,7 +42,23 @@ class PrepareEnrollmentUseCaseTest {
         productAdaptor = mockk()
         enrollmentAdaptor = mockk()
         paymentAdaptor = mockk()
-        useCase = PrepareEnrollmentUseCase(courseAdaptor, productAdaptor, enrollmentAdaptor, paymentAdaptor)
+        prepareRegularEnrollmentUseCase =
+            PrepareRegularEnrollmentUseCase(
+                courseAdaptor = courseAdaptor,
+                enrollmentAdaptor = enrollmentAdaptor,
+                paymentAdaptor = paymentAdaptor,
+            )
+        prepareMatchingEnrollmentUseCase =
+            PrepareMatchingEnrollmentUseCase(
+                enrollmentAdaptor = enrollmentAdaptor,
+                paymentAdaptor = paymentAdaptor,
+            )
+        useCase =
+            PrepareEnrollmentUseCase(
+                productAdaptor = productAdaptor,
+                prepareRegularEnrollmentUseCase = prepareRegularEnrollmentUseCase,
+                prepareMatchingEnrollmentUseCase = prepareMatchingEnrollmentUseCase,
+            )
     }
 
     private fun listedCourse() =

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCaseTest.kt
@@ -71,7 +71,7 @@ class PrepareEnrollmentUseCaseTest {
             name = "매칭형 수학 코스",
             priceWon = 300000,
             totalLessons = 12,
-            matchingEnabled = true,
+            requiresMatching = true,
         )
 
     private fun pendingPayment() =

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCaseTest.kt
@@ -251,7 +251,7 @@ class HandleNicePayReturnUseCaseTest {
     @Test
     fun `매칭형 코스 상품 결제 성공 시 enrollment가 PENDING_MATCH로 전환된다`() {
         val payment = courseProductPayment(amount = 300000)
-        val product = CourseProduct(name = "매칭형 수학 코스", priceWon = 300000, totalLessons = 12, matchingEnabled = true)
+        val product = CourseProduct(name = "매칭형 수학 코스", priceWon = 300000, totalLessons = 12, requiresMatching = true)
         val enrollment =
             Enrollment.createForPurchase(
                 productId = product.id,

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCaseTest.kt
@@ -6,12 +6,14 @@ import com.sclass.domain.domains.coin.domain.CoinPackage
 import com.sclass.domain.domains.coin.service.CoinDomainService
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.Payment
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
 import com.sclass.domain.domains.payment.domain.PgType
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.CourseProduct
 import com.sclass.domain.domains.product.domain.RollingMembershipProduct
 import com.sclass.infrastructure.nicepay.PgGateway
 import com.sclass.infrastructure.nicepay.dto.PgApproveResult
@@ -247,6 +249,45 @@ class HandleNicePayReturnUseCaseTest {
     }
 
     @Test
+    fun `매칭형 코스 상품 결제 성공 시 enrollment가 PENDING_MATCH로 전환된다`() {
+        val payment = courseProductPayment(amount = 300000)
+        val product = CourseProduct(name = "매칭형 수학 코스", priceWon = 300000, totalLessons = 12, matchingEnabled = true)
+        val enrollment =
+            Enrollment.createForPurchase(
+                productId = product.id,
+                studentUserId = payment.userId,
+                tuitionAmountWon = 300000,
+                paymentId = payment.id,
+                courseId = null,
+            )
+
+        every { pgGateway.verifyReturnSignature(any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(payment.pgOrderId) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { productAdaptor.findById(payment.targetId) } returns product
+        every { enrollmentAdaptor.findByPaymentId(payment.id) } returns enrollment
+        every { enrollmentAdaptor.save(any()) } answers { firstArg() }
+        every { pgGateway.approve(any(), any(), any()) } returns
+            PgApproveResult(tid = "tid-001", pgOrderId = payment.pgOrderId, amount = 300000)
+
+        val result =
+            useCase.execute(
+                authResultCode = "0000",
+                tid = "tid-001",
+                orderId = payment.pgOrderId,
+                amount = 300000,
+                authToken = "token",
+                signature = "sig",
+            )
+
+        assertAll(
+            { assertTrue(result.contains("status=COMPLETED")) },
+            { assertEquals(PaymentStatus.COMPLETED, payment.status) },
+            { assertEquals(EnrollmentStatus.PENDING_MATCH, enrollment.status) },
+        )
+    }
+
+    @Test
     fun `멤버십 결제 성공 시 enrollment가 ACTIVE로 전환되고 멤버십 코인이 발급된다`() {
         val payment = membershipPayment(amount = 10000)
         val product =
@@ -353,5 +394,15 @@ class HandleNicePayReturnUseCaseTest {
             amount = amount,
             pgType = PgType.NICEPAY,
             pgOrderId = "order-00000000000000000000000002",
+        )
+
+    private fun courseProductPayment(amount: Int = 300000) =
+        Payment(
+            userId = "user-00000000000000000000000001",
+            targetType = PaymentTargetType.COURSE_PRODUCT,
+            targetId = "prod-00000000000000000000000001",
+            amount = amount,
+            pgType = PgType.NICEPAY,
+            pgOrderId = "order-00000000000000000000000003",
         )
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
@@ -219,6 +219,38 @@ class HandleNicePayWebhookUseCaseTest {
     }
 
     @Test
+    fun `CourseProduct 결제 시 매칭형 상품이면 PENDING_MATCH 처리된다`() {
+        val payment = courseProductPayment()
+        val product = CourseProduct(name = "매칭형 수학 코스", priceWon = 300000, totalLessons = 12, matchingEnabled = true)
+        val enrollment =
+            Enrollment.createForPurchase(
+                productId = payment.targetId,
+                courseId = null,
+                studentUserId = "student-id-000000000001",
+                tuitionAmountWon = 300000,
+                paymentId = payment.id,
+            )
+
+        every { pgGateway.verifyWebhookSignature(any(), any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(any()) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { paymentAdaptor.save(any()) } answers { firstArg() }
+        every { productAdaptor.findById(any()) } returns product
+        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns enrollment
+        every { enrollmentAdaptor.findByPaymentId(payment.id) } returns enrollment
+        every { enrollmentAdaptor.save(any()) } answers { firstArg() }
+
+        useCase.execute(payment.pgOrderId, successPayload(payment.pgOrderId))
+
+        assertAll(
+            { assertEquals(EnrollmentStatus.PENDING_MATCH, enrollment.status) },
+            { assertEquals(PaymentStatus.COMPLETED, payment.status) },
+        )
+        verify(exactly = 0) { courseAdaptor.findById(any()) }
+        verify(exactly = 0) { lessonService.createLessonsForEnrollment(any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `CourseProduct 결제 시 코스가 UNLISTED이면 자동 환불 처리된다`() {
         val payment = courseProductPayment()
         val product = CourseProduct(name = "수학 코스", priceWon = 300000, totalLessons = 12)

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
@@ -221,7 +221,7 @@ class HandleNicePayWebhookUseCaseTest {
     @Test
     fun `CourseProduct 결제 시 매칭형 상품이면 PENDING_MATCH 처리된다`() {
         val payment = courseProductPayment()
-        val product = CourseProduct(name = "매칭형 수학 코스", priceWon = 300000, totalLessons = 12, matchingEnabled = true)
+        val product = CourseProduct(name = "매칭형 수학 코스", priceWon = 300000, totalLessons = 12, requiresMatching = true)
         val enrollment =
             Enrollment.createForPurchase(
                 productId = payment.targetId,

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/product/ProductPersistenceIntegrationTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/product/ProductPersistenceIntegrationTest.kt
@@ -1,0 +1,31 @@
+package com.sclass.supporters.product
+
+import com.sclass.domain.domains.product.domain.RollingMembershipProduct
+import com.sclass.domain.domains.product.repository.ProductRepository
+import com.sclass.supporters.config.ApiIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+@ApiIntegrationTest
+class ProductPersistenceIntegrationTest {
+    @Autowired
+    private lateinit var productRepository: ProductRepository
+
+    @Test
+    fun `rolling membership product를 저장할 수 있다`() {
+        val product =
+            productRepository.saveAndFlush(
+                RollingMembershipProduct(
+                    name = "프리미엄 멤버십",
+                    priceWon = 50000,
+                    periodDays = 30,
+                    coinPackageId = "coin-package-id-0000000001",
+                ),
+            )
+
+        assertThat(product.id).isNotBlank()
+
+        productRepository.delete(product)
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/domain/Course.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/course/domain/Course.kt
@@ -52,6 +52,12 @@ class Course(
     @Column(name = "enrollment_deadline")
     var enrollmentDeadLine: LocalDateTime? = null,
 
+    @Column(name = "total_lessons")
+    var totalLessons: Int? = null,
+
+    @Column(columnDefinition = "TEXT")
+    var curriculum: String? = null,
+
     @Column(name = "start_at")
     var startAt: LocalDateTime? = null,
 
@@ -71,6 +77,14 @@ class Course(
     fun archive() {
         validateTransition(CourseStatus.ARCHIVED)
         this.status = CourseStatus.ARCHIVED
+    }
+
+    fun updateFulfillmentInfo(
+        newCurriculum: String?,
+        newTotalLessons: Int?,
+    ) {
+        newCurriculum?.let { curriculum = it }
+        newTotalLessons?.let { totalLessons = it }
     }
 
     fun canEnroll(

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
@@ -124,5 +124,11 @@ class EnrollmentAdaptor(
     fun findResumableCourseProductEnrollment(
         productId: String,
         studentUserId: String,
-    ): Enrollment? = enrollmentRepository.findResumableCourseProductEnrollment(productId, studentUserId)
+    ): Enrollment? {
+        val live = enrollmentRepository.findResumableCourseProductEnrollment(productId, studentUserId) ?: return null
+        if (live.status in setOf(EnrollmentStatus.ACTIVE, EnrollmentStatus.PENDING_MATCH)) {
+            throw EnrollmentAlreadyExistsException()
+        }
+        return live
+    }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
@@ -120,4 +120,9 @@ class EnrollmentAdaptor(
             studentUserId = studentUserId,
             now = java.time.LocalDateTime.now(),
         )
+
+    fun findResumableCourseProductEnrollment(
+        productId: String,
+        studentUserId: String,
+    ): Enrollment? = enrollmentRepository.findResumableCourseProductEnrollment(productId, studentUserId)
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/domain/Enrollment.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/domain/Enrollment.kt
@@ -108,6 +108,8 @@ class Enrollment private constructor(
 
     fun assignCourse(courseId: Long) {
         requirePurchaseEnrollment()
+        requirePayment()
+        if (status != EnrollmentStatus.PENDING_MATCH) throw EnrollmentInvalidStatusTransitionException()
         if (this.courseId != null) throw EnrollmentInvalidStatusTransitionException()
         validateTransition(EnrollmentStatus.ACTIVE)
         this.courseId = courseId

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/domain/Enrollment.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/domain/Enrollment.kt
@@ -33,7 +33,7 @@ class Enrollment private constructor(
     val id: Long = 0L,
 
     @Column(name = "course_id")
-    val courseId: Long? = null,
+    var courseId: Long? = null,
 
     // purchase 대상 product 스냅샷
     @Column(name = "product_id", length = 26)
@@ -99,6 +99,21 @@ class Enrollment private constructor(
         this.status = EnrollmentStatus.ACTIVE
     }
 
+    fun markPendingMatch() {
+        requirePurchaseEnrollment()
+        requirePayment()
+        validateTransition(EnrollmentStatus.PENDING_MATCH)
+        status = EnrollmentStatus.PENDING_MATCH
+    }
+
+    fun assignCourse(courseId: Long) {
+        requirePurchaseEnrollment()
+        if (this.courseId != null) throw EnrollmentInvalidStatusTransitionException()
+        validateTransition(EnrollmentStatus.ACTIVE)
+        this.courseId = courseId
+        status = EnrollmentStatus.ACTIVE
+    }
+
     fun complete() {
         validateTransition(EnrollmentStatus.COMPLETED)
         this.status = EnrollmentStatus.COMPLETED
@@ -129,11 +144,25 @@ class Enrollment private constructor(
         val allowed =
             when (target) {
                 EnrollmentStatus.PENDING_PAYMENT -> emptySet()
-                EnrollmentStatus.ACTIVE -> setOf(EnrollmentStatus.PENDING_PAYMENT)
+                EnrollmentStatus.PENDING_MATCH ->
+                    setOf(EnrollmentStatus.PENDING_PAYMENT)
+                EnrollmentStatus.ACTIVE ->
+                    setOf(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.PENDING_MATCH)
                 EnrollmentStatus.COMPLETED -> setOf(EnrollmentStatus.ACTIVE)
-                EnrollmentStatus.CANCELLED -> setOf(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.ACTIVE)
-                EnrollmentStatus.REFUNDED -> setOf(EnrollmentStatus.ACTIVE, EnrollmentStatus.CANCELLED)
+                EnrollmentStatus.CANCELLED ->
+                    setOf(
+                        EnrollmentStatus.PENDING_PAYMENT,
+                        EnrollmentStatus.PENDING_MATCH,
+                        EnrollmentStatus.ACTIVE,
+                    )
+                EnrollmentStatus.REFUNDED ->
+                    setOf(
+                        EnrollmentStatus.PENDING_MATCH,
+                        EnrollmentStatus.ACTIVE,
+                        EnrollmentStatus.CANCELLED,
+                    )
             }
+
         if (status !in allowed) throw EnrollmentInvalidStatusTransitionException()
     }
 
@@ -156,7 +185,7 @@ class Enrollment private constructor(
             studentUserId: String,
             tuitionAmountWon: Int,
             paymentId: String,
-            courseId: Long,
+            courseId: Long? = null,
         ): Enrollment =
             Enrollment(
                 courseId = courseId,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/domain/EnrollmentStatus.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/domain/EnrollmentStatus.kt
@@ -2,6 +2,7 @@ package com.sclass.domain.domains.enrollment.domain
 
 enum class EnrollmentStatus {
     PENDING_PAYMENT, // 결제 대기 (PURCHASE만 사용)
+    PENDING_MATCH, // 매칭 대기
     ACTIVE, // 수강 중
     COMPLETED, // 전 차시 완료
     CANCELLED, // 취소

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentErrorCode.kt
@@ -18,4 +18,5 @@ enum class EnrollmentErrorCode(
     MEMBERSHIP_CAPACITY_EXCEEDED("ENROLLMENT_009", "멤버십 정원이 초과되었습니다", 409),
     NO_ACTIVE_MEMBERSHIP("ENROLLMENT_010", "활성 멤버십이 없습니다", 403),
     ENROLLMENT_INVALID_PURCHASE_TARGET("ENROLLMENT_011", "courseId와 productId 조합이 올바르지 않습니다", 400),
+    ENROLLMENT_COURSE_REQUIRED("ENROLLMENT_012", "코스형 수강 등록에 courseId가 필요합니다", 400),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentExceptions.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/exception/EnrollmentExceptions.kt
@@ -19,3 +19,5 @@ class EnrollmentTypeMismatchException : BusinessException(EnrollmentErrorCode.EN
 class NoActiveMembershipException : BusinessException(EnrollmentErrorCode.NO_ACTIVE_MEMBERSHIP)
 
 class EnrollmentInvalidPurchaseTargetException : BusinessException(EnrollmentErrorCode.ENROLLMENT_INVALID_PURCHASE_TARGET)
+
+class EnrollmentCourseRequiredException : BusinessException(EnrollmentErrorCode.ENROLLMENT_COURSE_REQUIRED)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepository.kt
@@ -1,5 +1,6 @@
 package com.sclass.domain.domains.enrollment.repository
 
+import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithCourseDto
 import com.sclass.domain.domains.enrollment.dto.EnrollmentWithDetailDto
@@ -27,4 +28,9 @@ interface EnrollmentCustomRepository {
         studentUserId: String,
         now: java.time.LocalDateTime,
     ): Boolean
+
+    fun findResumableCourseProductEnrollment(
+        productId: String,
+        studentUserId: String,
+    ): Enrollment?
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
@@ -156,6 +156,20 @@ class EnrollmentCustomRepositoryImpl(
                 enrollment.endAt.isNull.or(enrollment.endAt.gt(now)),
             ).fetchFirst() != null
 
+    override fun findResumableCourseProductEnrollment(
+        productId: String,
+        studentUserId: String,
+    ): Enrollment? =
+        queryFactory
+            .selectFrom(enrollment)
+            .where(
+                enrollment.productId.eq(productId),
+                enrollment.studentUserId.eq(studentUserId),
+                enrollment.courseId.isNull,
+                enrollment.status.eq(EnrollmentStatus.PENDING_PAYMENT),
+            ).orderBy(enrollment.createdAt.desc())
+            .fetchFirst()
+
     private fun Sort.toOrderSpecifiers(): Array<OrderSpecifier<*>> {
         if (isUnsorted) return arrayOf(enrollment.createdAt.desc())
         val path = PathBuilder(Enrollment::class.java, "enrollment")

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.sclass.domain.domains.enrollment.repository
 import com.querydsl.core.types.Order
 import com.querydsl.core.types.OrderSpecifier
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.CaseBuilder
 import com.querydsl.core.types.dsl.PathBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.sclass.domain.domains.course.domain.QCourse.course
@@ -165,10 +166,21 @@ class EnrollmentCustomRepositoryImpl(
             .where(
                 enrollment.productId.eq(productId),
                 enrollment.studentUserId.eq(studentUserId),
-                enrollment.courseId.isNull,
-                enrollment.status.eq(EnrollmentStatus.PENDING_PAYMENT),
-            ).orderBy(enrollment.createdAt.desc())
-            .fetchFirst()
+                enrollment.status.`in`(
+                    EnrollmentStatus.PENDING_PAYMENT,
+                    EnrollmentStatus.PENDING_MATCH,
+                    EnrollmentStatus.ACTIVE,
+                ),
+            ).orderBy(
+                CaseBuilder()
+                    .`when`(enrollment.status.eq(EnrollmentStatus.ACTIVE))
+                    .then(0)
+                    .`when`(enrollment.status.eq(EnrollmentStatus.PENDING_MATCH))
+                    .then(1)
+                    .otherwise(2)
+                    .asc(),
+                enrollment.createdAt.desc(),
+            ).fetchFirst()
 
     private fun Sort.toOrderSpecifiers(): Array<OrderSpecifier<*>> {
         if (isUnsorted) return arrayOf(enrollment.createdAt.desc())

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
@@ -29,12 +29,14 @@ class EnrollmentCustomRepositoryImpl(
 ) : EnrollmentCustomRepository {
     override fun findAllByStudentUserIdWithCourse(studentUserId: String): List<EnrollmentWithCourseDto> =
         queryFactory
-            .select(enrollment, course, courseProduct, user.name, membershipProduct)
+            .select(enrollment, course, courseProduct, courseProductFromEnrollment, user.name, membershipProduct)
             .from(enrollment)
             .leftJoin(course)
             .on(course.id.eq(enrollment.courseId))
             .leftJoin(courseProduct)
             .on(courseProduct.id.eq(course.productId))
+            .leftJoin(courseProductFromEnrollment)
+            .on(courseProductFromEnrollment.id.eq(enrollment.productId))
             .leftJoin(user)
             .on(user.id.eq(course.teacherUserId))
             .leftJoin(membershipProduct)
@@ -46,7 +48,7 @@ class EnrollmentCustomRepositoryImpl(
                 EnrollmentWithCourseDto(
                     enrollment = tuple[enrollment]!!,
                     course = tuple[course],
-                    courseProduct = tuple[courseProduct],
+                    courseProduct = tuple[courseProduct] ?: tuple[courseProductFromEnrollment],
                     teacherName = tuple[user.name],
                     membershipProduct = tuple[membershipProduct],
                 )
@@ -189,5 +191,11 @@ class EnrollmentCustomRepositoryImpl(
             val direction = if (order.isAscending) Order.ASC else Order.DESC
             OrderSpecifier(direction, path.get(order.property, Comparable::class.java))
         }.toList().toTypedArray()
+    }
+
+    companion object {
+        private val courseProductFromEnrollment =
+            com.sclass.domain.domains.product.domain
+                .QCourseProduct("courseProductFromEnrollment")
     }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
@@ -17,6 +17,9 @@ class CourseProduct(
 
     @Column(columnDefinition = "TEXT")
     var curriculum: String? = null,
+
+    @Column(name = "matching_enabled", nullable = false)
+    var matchingEnabled: Boolean = false,
 ) : Product(
         name = name,
         priceWon = priceWon,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
@@ -18,7 +18,7 @@ class CourseProduct(
     @Column(columnDefinition = "TEXT")
     var curriculum: String? = null,
 
-    @Column(name = "matching_enabled", nullable = true)
+    @Column(name = "requires_matching", nullable = true)
     var requiresMatching: Boolean = false,
 ) : Product(
         name = name,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
@@ -19,7 +19,7 @@ class CourseProduct(
     var curriculum: String? = null,
 
     @Column(name = "matching_enabled", nullable = true)
-    var matchingEnabled: Boolean = false,
+    var requiresMatching: Boolean = false,
 ) : Product(
         name = name,
         priceWon = priceWon,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/domain/CourseProduct.kt
@@ -18,7 +18,7 @@ class CourseProduct(
     @Column(columnDefinition = "TEXT")
     var curriculum: String? = null,
 
-    @Column(name = "matching_enabled", nullable = false)
+    @Column(name = "matching_enabled", nullable = true)
     var matchingEnabled: Boolean = false,
 ) : Product(
         name = name,

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/enrollment/domain/EnrollmentTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/enrollment/domain/EnrollmentTest.kt
@@ -1,0 +1,42 @@
+package com.sclass.domain.domains.enrollment.domain
+
+import com.sclass.domain.domains.enrollment.exception.EnrollmentInvalidStatusTransitionException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class EnrollmentTest {
+    @Test
+    fun `assignCourse는 PENDING_PAYMENT enrollment에 대해 실패한다`() {
+        val enrollment =
+            Enrollment.createForPurchase(
+                productId = "product-id-00000000001",
+                studentUserId = "student-id-00000000001",
+                tuitionAmountWon = 300000,
+                paymentId = "payment-id-000000000001",
+            )
+
+        assertThatThrownBy { enrollment.assignCourse(1L) }
+            .isInstanceOf(EnrollmentInvalidStatusTransitionException::class.java)
+
+        assertThat(enrollment.courseId).isNull()
+        assertThat(enrollment.status).isEqualTo(EnrollmentStatus.PENDING_PAYMENT)
+    }
+
+    @Test
+    fun `assignCourse는 PENDING_MATCH enrollment에 대해 ACTIVE로 전이한다`() {
+        val enrollment =
+            Enrollment.createForPurchase(
+                productId = "product-id-00000000001",
+                studentUserId = "student-id-00000000001",
+                tuitionAmountWon = 300000,
+                paymentId = "payment-id-000000000001",
+            )
+
+        enrollment.markPendingMatch()
+        enrollment.assignCourse(1L)
+
+        assertThat(enrollment.courseId).isEqualTo(1L)
+        assertThat(enrollment.status).isEqualTo(EnrollmentStatus.ACTIVE)
+    }
+}


### PR DESCRIPTION
## 관련 링크
- 이전 PR: #274
- 이슈: #250

## 요약
- 매칭형 코스상품 구매를 위한 `PENDING_MATCH` 상태를 추가했습니다.
- 코스상품 구매 준비 시 일반 코스와 매칭형 코스를 분기하도록 정리했습니다.
- 매칭형 코스상품 결제 완료 시 수강 등록을 바로 `ACTIVE`로 올리지 않고 `PENDING_MATCH`로 유지하도록 변경했습니다.

## 상세 변경
- `EnrollmentStatus`에 `PENDING_MATCH` 추가
- `Enrollment.courseId` nullable purchase 허용
- `CourseProduct.matchingEnabled` 추가
- `Course`에 운영용 `curriculum`, `totalLessons` 추가
- `PrepareEnrollmentUseCase`에서 일반 코스와 매칭형 코스상품 분기
- 매칭형 코스상품은 `Payment + Enrollment(courseId = null)` 생성
- NicePay webhook/return 처리에서 매칭형 코스상품은 `PENDING_MATCH`로 전이
- 코스형 enrollment에 `courseId`가 필요한 경우 도메인 예외 추가

## 포함하지 않은 범위
- 관리자 매칭 완료 API
- `Course` 생성 및 `Enrollment.courseId` 연결
- `teacher_assignment` 생성
- lesson 생성 시점 이동
- 조회 DTO / Querydsl 보정
- 매칭형 코스상품 관리 API 및 public catalog 노출

## 테스트
- `PrepareEnrollmentUseCaseTest`
- `HandleNicePayWebhookUseCaseTest`
- `HandleNicePayReturnUseCaseTest`