### PR TITLE
feat(backoffice): pending-match enrollment로 course 생성 추가

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/usecase/ChangeCourseStatusUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/course/usecase/ChangeCourseStatusUseCase.kt
@@ -30,15 +30,21 @@ class ChangeCourseStatusUseCase(
         when (targetStatus) {
             CourseStatus.LISTED -> {
                 course.list()
-                product.show()
+                if (!product.requiresMatching) {
+                    product.show()
+                }
             }
             CourseStatus.UNLISTED -> {
                 course.unlist()
-                product.hide()
+                if (!product.requiresMatching) {
+                    product.hide()
+                }
             }
             CourseStatus.ARCHIVED -> {
                 course.archive()
-                product.hide()
+                if (!product.requiresMatching) {
+                    product.hide()
+                }
             }
             CourseStatus.DRAFT -> throw CourseInvalidStatusTransitionException()
         }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/controller/EnrollmentController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/controller/EnrollmentController.kt
@@ -7,7 +7,7 @@ import com.sclass.backoffice.enrollment.dto.EnrollmentResponse
 import com.sclass.backoffice.enrollment.dto.ExtendMembershipExpireRequest
 import com.sclass.backoffice.enrollment.dto.GrantEnrollmentRequest
 import com.sclass.backoffice.enrollment.dto.GrantMembershipEnrollmentRequest
-import com.sclass.backoffice.enrollment.usecase.CreateCourseFromEnrollmentUseCase
+import com.sclass.backoffice.enrollment.usecase.CreateCourseFromEnrollmentFacade
 import com.sclass.backoffice.enrollment.usecase.ExtendMembershipExpireUseCase
 import com.sclass.backoffice.enrollment.usecase.GetEnrollmentLessonListUseCase
 import com.sclass.backoffice.enrollment.usecase.GetEnrollmentListUseCase
@@ -37,7 +37,7 @@ class EnrollmentController(
     private val extendMembershipExpireUseCase: ExtendMembershipExpireUseCase,
     private val getEnrollmentListUseCase: GetEnrollmentListUseCase,
     private val getEnrollmentLessonListUseCase: GetEnrollmentLessonListUseCase,
-    private val createCourseFromEnrollmentUseCase: CreateCourseFromEnrollmentUseCase,
+    private val createCourseFromEnrollmentFacade: CreateCourseFromEnrollmentFacade,
 ) {
     @PostMapping("/membership")
     fun grantMembershipEnrollment(
@@ -77,5 +77,5 @@ class EnrollmentController(
     fun createCourseFromEnrollment(
         @PathVariable enrollmentId: Long,
         @RequestBody @Valid request: CreateCourseFromEnrollmentRequest,
-    ): ApiResponse<EnrollmentResponse> = ApiResponse.success(createCourseFromEnrollmentUseCase.execute(enrollmentId, request.teacherUserId))
+    ): ApiResponse<EnrollmentResponse> = ApiResponse.success(createCourseFromEnrollmentFacade.execute(enrollmentId, request.teacherUserId))
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/controller/EnrollmentController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/controller/EnrollmentController.kt
@@ -1,11 +1,13 @@
 package com.sclass.backoffice.enrollment.controller
 
+import com.sclass.backoffice.enrollment.dto.CreateCourseFromEnrollmentRequest
 import com.sclass.backoffice.enrollment.dto.EnrollmentLessonListResponse
 import com.sclass.backoffice.enrollment.dto.EnrollmentPageResponse
 import com.sclass.backoffice.enrollment.dto.EnrollmentResponse
 import com.sclass.backoffice.enrollment.dto.ExtendMembershipExpireRequest
 import com.sclass.backoffice.enrollment.dto.GrantEnrollmentRequest
 import com.sclass.backoffice.enrollment.dto.GrantMembershipEnrollmentRequest
+import com.sclass.backoffice.enrollment.usecase.CreateCourseFromEnrollmentUseCase
 import com.sclass.backoffice.enrollment.usecase.ExtendMembershipExpireUseCase
 import com.sclass.backoffice.enrollment.usecase.GetEnrollmentLessonListUseCase
 import com.sclass.backoffice.enrollment.usecase.GetEnrollmentListUseCase
@@ -35,6 +37,7 @@ class EnrollmentController(
     private val extendMembershipExpireUseCase: ExtendMembershipExpireUseCase,
     private val getEnrollmentListUseCase: GetEnrollmentListUseCase,
     private val getEnrollmentLessonListUseCase: GetEnrollmentLessonListUseCase,
+    private val createCourseFromEnrollmentUseCase: CreateCourseFromEnrollmentUseCase,
 ) {
     @PostMapping("/membership")
     fun grantMembershipEnrollment(
@@ -69,4 +72,10 @@ class EnrollmentController(
     fun getEnrollmentLessonList(
         @PathVariable enrollmentId: Long,
     ): ApiResponse<EnrollmentLessonListResponse> = ApiResponse.success(getEnrollmentLessonListUseCase.execute(enrollmentId))
+
+    @PostMapping("/{enrollmentId}/course")
+    fun createCourseFromEnrollment(
+        @PathVariable enrollmentId: Long,
+        @RequestBody @Valid request: CreateCourseFromEnrollmentRequest,
+    ): ApiResponse<EnrollmentResponse> = ApiResponse.success(createCourseFromEnrollmentUseCase.execute(enrollmentId, request.teacherUserId))
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/CreateCourseFromEnrollmentRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/CreateCourseFromEnrollmentRequest.kt
@@ -1,0 +1,8 @@
+package com.sclass.backoffice.enrollment.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class CreateCourseFromEnrollmentRequest(
+    @field:NotBlank
+    val teacherUserId: String,
+)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/CreateCourseFromEnrollmentFacade.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/CreateCourseFromEnrollmentFacade.kt
@@ -1,0 +1,17 @@
+package com.sclass.backoffice.enrollment.usecase
+
+import com.sclass.backoffice.enrollment.dto.EnrollmentResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+
+@UseCase
+class CreateCourseFromEnrollmentFacade(
+    private val createCourseFromEnrollmentUseCase: CreateCourseFromEnrollmentUseCase,
+) {
+    @DistributedLock(prefix = "enrollment")
+    fun execute(
+        @LockKey enrollmentId: Long,
+        teacherUserId: String,
+    ): EnrollmentResponse = createCourseFromEnrollmentUseCase.execute(enrollmentId, teacherUserId)
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/CreateCourseFromEnrollmentUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/CreateCourseFromEnrollmentUseCase.kt
@@ -15,8 +15,6 @@ import com.sclass.domain.domains.product.adaptor.ProductAdaptor
 import com.sclass.domain.domains.product.domain.CourseProduct
 import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
 import com.sclass.domain.domains.teacher.adaptor.TeacherAdaptor
-import com.sclass.infrastructure.redis.DistributedLock
-import com.sclass.infrastructure.redis.LockKey
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
@@ -28,9 +26,8 @@ class CreateCourseFromEnrollmentUseCase(
     private val lessonDomainService: LessonDomainService,
 ) {
     @Transactional
-    @DistributedLock(prefix = "enrollment")
     fun execute(
-        @LockKey enrollmentId: Long,
+        enrollmentId: Long,
         teacherUserId: String,
     ): EnrollmentResponse {
         val enrollment = enrollmentAdaptor.findById(enrollmentId)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/CreateCourseFromEnrollmentUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/CreateCourseFromEnrollmentUseCase.kt
@@ -1,0 +1,78 @@
+package com.sclass.backoffice.enrollment.usecase
+
+import com.sclass.backoffice.enrollment.dto.EnrollmentResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.enrollment.exception.EnrollmentInvalidPurchaseTargetException
+import com.sclass.domain.domains.enrollment.exception.EnrollmentInvalidStatusTransitionException
+import com.sclass.domain.domains.enrollment.exception.EnrollmentTypeMismatchException
+import com.sclass.domain.domains.lesson.service.LessonDomainService
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
+import com.sclass.domain.domains.teacher.adaptor.TeacherAdaptor
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class CreateCourseFromEnrollmentUseCase(
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val productAdaptor: ProductAdaptor,
+    private val courseAdaptor: CourseAdaptor,
+    private val teacherAdaptor: TeacherAdaptor,
+    private val lessonDomainService: LessonDomainService,
+) {
+    @Transactional
+    @DistributedLock(prefix = "enrollment")
+    fun execute(
+        @LockKey enrollmentId: Long,
+        teacherUserId: String,
+    ): EnrollmentResponse {
+        val enrollment = enrollmentAdaptor.findById(enrollmentId)
+        teacherAdaptor.findByUserId(teacherUserId)
+
+        if (enrollment.status != EnrollmentStatus.PENDING_MATCH || enrollment.courseId != null) {
+            throw EnrollmentInvalidStatusTransitionException()
+        }
+
+        val productId = enrollment.productId ?: throw EnrollmentTypeMismatchException()
+
+        val product =
+            productAdaptor.findById(productId) as?
+                CourseProduct
+                ?: throw ProductTypeMismatchException()
+
+        if (!product.requiresMatching) {
+            throw EnrollmentInvalidPurchaseTargetException()
+        }
+
+        val course =
+            courseAdaptor.save(
+                Course(
+                    productId = product.id,
+                    teacherUserId = teacherUserId,
+                    status = CourseStatus.UNLISTED,
+                    maxEnrollments = 1,
+                    totalLessons = product.totalLessons,
+                    curriculum = product.curriculum,
+                ),
+            )
+
+        enrollment.assignCourse(course.id)
+        enrollmentAdaptor.save(enrollment)
+
+        lessonDomainService.createLessonsForEnrollment(
+            enrollment = enrollment,
+            teacherUserId = teacherUserId,
+            courseName = product.name,
+            totalLessons = course.totalLessons ?: product.totalLessons,
+        )
+
+        return EnrollmentResponse.from(enrollment)
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/CreateCourseFromEnrollmentUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/CreateCourseFromEnrollmentUseCase.kt
@@ -70,7 +70,7 @@ class CreateCourseFromEnrollmentUseCase(
             enrollment = enrollment,
             teacherUserId = teacherUserId,
             courseName = product.name,
-            totalLessons = course.totalLessons ?: product.totalLessons,
+            totalLessons = product.totalLessons,
         )
 
         return EnrollmentResponse.from(enrollment)

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/course/usecase/ChangeCourseStatusUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/course/usecase/ChangeCourseStatusUseCaseTest.kt
@@ -134,6 +134,47 @@ class ChangeCourseStatusUseCaseTest {
     }
 
     @Test
+    fun `requiresMatching 상품의 코스를 LISTED로 전이해도 product visible은 변경하지 않는다`() {
+        val product =
+            product().apply {
+                requiresMatching = true
+            }
+        val course = courseOf(product.id, CourseStatus.DRAFT)
+        every { courseAdaptor.findById(course.id) } returns course
+        every { productAdaptor.findById(product.id) } returns product
+        every { courseAdaptor.save(any()) } answers { firstArg() }
+        every { productAdaptor.save(any()) } answers { firstArg() }
+
+        useCase.execute(course.id, CourseStatus.LISTED)
+
+        assertAll(
+            { assertEquals(CourseStatus.LISTED, course.status) },
+            { assertFalse(product.visible) },
+        )
+    }
+
+    @Test
+    fun `requiresMatching 상품의 코스를 UNLISTED로 전이해도 product visible은 변경하지 않는다`() {
+        val product =
+            product().apply {
+                requiresMatching = true
+                show()
+            }
+        val course = courseOf(product.id, CourseStatus.LISTED)
+        every { courseAdaptor.findById(course.id) } returns course
+        every { productAdaptor.findById(product.id) } returns product
+        every { courseAdaptor.save(any()) } answers { firstArg() }
+        every { productAdaptor.save(any()) } answers { firstArg() }
+
+        useCase.execute(course.id, CourseStatus.UNLISTED)
+
+        assertAll(
+            { assertEquals(CourseStatus.UNLISTED, course.status) },
+            { assertTrue(product.visible) },
+        )
+    }
+
+    @Test
     fun `코스와 상품을 모두 save 한다`() {
         val product = product()
         val course = courseOf(product.id, CourseStatus.DRAFT)

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/controller/EnrollmentControllerIntegrationTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/controller/EnrollmentControllerIntegrationTest.kt
@@ -1,0 +1,198 @@
+package com.sclass.backoffice.enrollment.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.sclass.backoffice.config.ApiIntegrationTest
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.common.jwt.JwtTokenProvider
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.course.repository.CourseRepository
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.enrollment.repository.EnrollmentRepository
+import com.sclass.domain.domains.lesson.repository.LessonRepository
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.product.repository.ProductRepository
+import com.sclass.domain.domains.teacher.domain.Teacher
+import com.sclass.domain.domains.teacher.repository.TeacherRepository
+import com.sclass.domain.domains.user.domain.AuthProvider
+import com.sclass.domain.domains.user.domain.User
+import com.sclass.domain.domains.user.repository.UserRepository
+import com.sclass.domain.domains.user.repository.UserRoleRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@ApiIntegrationTest
+class EnrollmentControllerIntegrationTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var userRoleRepository: UserRoleRepository
+
+    @Autowired
+    private lateinit var teacherRepository: TeacherRepository
+
+    @Autowired
+    private lateinit var productRepository: ProductRepository
+
+    @Autowired
+    private lateinit var enrollmentRepository: EnrollmentRepository
+
+    @Autowired
+    private lateinit var courseRepository: CourseRepository
+
+    @Autowired
+    private lateinit var lessonRepository: LessonRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    @Autowired
+    private lateinit var aesTokenEncryptor: AesTokenEncryptor
+
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+
+    private lateinit var adminToken: String
+    private lateinit var teacherUser: User
+    private lateinit var studentUser: User
+    private lateinit var product: CourseProduct
+    private lateinit var enrollment: Enrollment
+
+    @BeforeEach
+    fun setUp() {
+        lessonRepository.deleteAll()
+        courseRepository.deleteAll()
+        enrollmentRepository.deleteAll()
+        teacherRepository.deleteAll()
+        productRepository.deleteAll()
+        userRoleRepository.deleteAll()
+        userRepository.deleteAll()
+
+        val adminUser =
+            userRepository.save(
+                User(
+                    email = "admin@sclass.com",
+                    name = "관리자",
+                    authProvider = AuthProvider.EMAIL,
+                    hashedPassword = "hashed",
+                ),
+            )
+
+        studentUser =
+            userRepository.save(
+                User(
+                    email = "student@sclass.com",
+                    name = "학생",
+                    authProvider = AuthProvider.EMAIL,
+                    hashedPassword = "hashed",
+                ),
+            )
+
+        teacherUser =
+            userRepository.save(
+                User(
+                    email = "teacher@sclass.com",
+                    name = "선생님",
+                    authProvider = AuthProvider.EMAIL,
+                    hashedPassword = "hashed",
+                ),
+            )
+        teacherRepository.save(Teacher(user = teacherUser))
+
+        product =
+            productRepository.save(
+                CourseProduct(
+                    name = "매칭형 수학 코스",
+                    priceWon = 300000,
+                    totalLessons = 4,
+                    curriculum = "기본 커리큘럼",
+                    requiresMatching = true,
+                ),
+            ) as CourseProduct
+
+        enrollment =
+            enrollmentRepository.save(
+                Enrollment
+                    .createForPurchase(
+                        productId = product.id,
+                        studentUserId = studentUser.id,
+                        tuitionAmountWon = product.priceWon,
+                        paymentId = "payment-id-00000000001",
+                    ).apply {
+                        markPendingMatch()
+                    },
+            )
+
+        val jwt =
+            jwtTokenProvider.generateAccessToken(
+                userId = adminUser.id,
+                role = "ADMIN",
+            )
+        adminToken = "Bearer ${aesTokenEncryptor.encrypt(jwt)}"
+    }
+
+    @Nested
+    inner class CreateCourseFromEnrollment {
+        @Test
+        fun `매칭 대기 enrollment로 course 생성 성공 시 active와 lesson이 생성된다`() {
+            val body =
+                mapOf(
+                    "teacherUserId" to teacherUser.id,
+                )
+
+            mockMvc
+                .perform(
+                    post("/api/v1/enrollments/${enrollment.id}/course")
+                        .header("Authorization", adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)),
+                ).andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(enrollment.id))
+                .andExpect(jsonPath("$.data.productId").value(product.id))
+                .andExpect(jsonPath("$.data.status").value(EnrollmentStatus.ACTIVE.name))
+                .andExpect(jsonPath("$.data.courseId").isNumber)
+
+            val savedEnrollment = enrollmentRepository.findById(enrollment.id).orElseThrow()
+            val savedCourse = courseRepository.findById(savedEnrollment.courseId!!).orElseThrow()
+            val lessons = lessonRepository.findAllByEnrollmentIdOrderByLessonNumberAscCreatedAtAsc(enrollment.id)
+
+            assertThat(savedEnrollment.status).isEqualTo(EnrollmentStatus.ACTIVE)
+            assertThat(savedCourse.productId).isEqualTo(product.id)
+            assertThat(savedCourse.teacherUserId).isEqualTo(teacherUser.id)
+            assertThat(savedCourse.status).isEqualTo(CourseStatus.UNLISTED)
+            assertThat(savedCourse.totalLessons).isEqualTo(4)
+            assertThat(savedCourse.curriculum).isEqualTo("기본 커리큘럼")
+            assertThat(lessons).hasSize(4)
+            assertThat(lessons.map { it.assignedTeacherUserId }).containsOnly(teacherUser.id)
+        }
+
+        @Test
+        fun `teacherUserId가 빈 문자열이면 400을 반환한다`() {
+            val body =
+                mapOf(
+                    "teacherUserId" to "",
+                )
+
+            mockMvc
+                .perform(
+                    post("/api/v1/enrollments/${enrollment.id}/course")
+                        .header("Authorization", adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)),
+                ).andExpect(status().isBadRequest)
+        }
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/usecase/CreateCourseFromEnrollmentUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/usecase/CreateCourseFromEnrollmentUseCaseTest.kt
@@ -1,0 +1,221 @@
+package com.sclass.backoffice.enrollment.usecase
+
+import com.sclass.domain.domains.course.adaptor.CourseAdaptor
+import com.sclass.domain.domains.course.domain.Course
+import com.sclass.domain.domains.course.domain.CourseStatus
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.enrollment.exception.EnrollmentInvalidPurchaseTargetException
+import com.sclass.domain.domains.enrollment.exception.EnrollmentInvalidStatusTransitionException
+import com.sclass.domain.domains.lesson.service.LessonDomainService
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.CourseProduct
+import com.sclass.domain.domains.product.domain.Product
+import com.sclass.domain.domains.product.exception.ProductTypeMismatchException
+import com.sclass.domain.domains.teacher.adaptor.TeacherAdaptor
+import com.sclass.domain.domains.teacher.domain.Teacher
+import com.sclass.domain.domains.teacher.exception.TeacherNotFoundException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class CreateCourseFromEnrollmentUseCaseTest {
+    private lateinit var enrollmentAdaptor: EnrollmentAdaptor
+    private lateinit var productAdaptor: ProductAdaptor
+    private lateinit var courseAdaptor: CourseAdaptor
+    private lateinit var teacherAdaptor: TeacherAdaptor
+    private lateinit var lessonDomainService: LessonDomainService
+    private lateinit var useCase: CreateCourseFromEnrollmentUseCase
+
+    @BeforeEach
+    fun setUp() {
+        enrollmentAdaptor = mockk()
+        productAdaptor = mockk()
+        courseAdaptor = mockk()
+        teacherAdaptor = mockk()
+        lessonDomainService = mockk(relaxed = true)
+        useCase =
+            CreateCourseFromEnrollmentUseCase(
+                enrollmentAdaptor = enrollmentAdaptor,
+                productAdaptor = productAdaptor,
+                courseAdaptor = courseAdaptor,
+                teacherAdaptor = teacherAdaptor,
+                lessonDomainService = lessonDomainService,
+            )
+    }
+
+    private fun pendingMatchEnrollment(): Enrollment =
+        Enrollment
+            .createForPurchase(
+                productId = "product-id-00000000001",
+                studentUserId = "student-id-00000000001",
+                tuitionAmountWon = 300000,
+                paymentId = "payment-id-00000000001",
+            ).apply {
+                markPendingMatch()
+            }
+
+    private fun matchingCourseProduct() =
+        CourseProduct(
+            name = "매칭형 수학 코스",
+            priceWon = 300000,
+            totalLessons = 12,
+            curriculum = "기본 커리큘럼",
+            requiresMatching = true,
+        )
+
+    @Nested
+    inner class Success {
+        @Test
+        fun `pending match enrollment로 course를 생성하고 active로 전이한다`() {
+            val enrollment = pendingMatchEnrollment()
+            val product = matchingCourseProduct()
+            val savedCourse =
+                Course(
+                    id = 10L,
+                    productId = product.id,
+                    teacherUserId = "teacher-user-id-0000001",
+                    status = CourseStatus.UNLISTED,
+                    maxEnrollments = 1,
+                    totalLessons = 12,
+                    curriculum = "기본 커리큘럼",
+                )
+
+            every { enrollmentAdaptor.findById(1L) } returns enrollment
+            every { teacherAdaptor.findByUserId("teacher-user-id-0000001") } returns mockk<Teacher>()
+            every { productAdaptor.findById("product-id-00000000001") } returns product
+            every {
+                courseAdaptor.save(
+                    match {
+                        it.productId == product.id &&
+                            it.teacherUserId == "teacher-user-id-0000001" &&
+                            it.status == CourseStatus.UNLISTED &&
+                            it.maxEnrollments == 1 &&
+                            it.totalLessons == 12 &&
+                            it.curriculum == "기본 커리큘럼"
+                    },
+                )
+            } returns savedCourse
+            every { enrollmentAdaptor.save(enrollment) } returns enrollment
+
+            val result =
+                useCase.execute(
+                    enrollmentId = 1L,
+                    teacherUserId = "teacher-user-id-0000001",
+                )
+
+            assertThat(result.courseId).isEqualTo(10L)
+            assertThat(result.status).isEqualTo(EnrollmentStatus.ACTIVE)
+            verify(exactly = 1) { teacherAdaptor.findByUserId("teacher-user-id-0000001") }
+            verify(exactly = 1) { enrollmentAdaptor.save(enrollment) }
+            verify(exactly = 1) {
+                lessonDomainService.createLessonsForEnrollment(
+                    enrollment = enrollment,
+                    teacherUserId = "teacher-user-id-0000001",
+                    courseName = "매칭형 수학 코스",
+                    totalLessons = 12,
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class Failure {
+        @Test
+        fun `pending match가 아니면 예외가 발생한다`() {
+            val enrollment =
+                Enrollment.createForPurchase(
+                    productId = "product-id-00000000001",
+                    studentUserId = "student-id-00000000001",
+                    tuitionAmountWon = 300000,
+                    paymentId = "payment-id-00000000001",
+                )
+
+            every { enrollmentAdaptor.findById(1L) } returns enrollment
+            every { teacherAdaptor.findByUserId("teacher-user-id-0000001") } returns mockk<Teacher>()
+
+            assertThatThrownBy {
+                useCase.execute(
+                    enrollmentId = 1L,
+                    teacherUserId = "teacher-user-id-0000001",
+                )
+            }.isInstanceOf(EnrollmentInvalidStatusTransitionException::class.java)
+        }
+
+        @Test
+        fun `이미 course가 연결된 enrollment면 예외가 발생한다`() {
+            val enrollment =
+                pendingMatchEnrollment().apply {
+                    courseId = 99L
+                }
+
+            every { enrollmentAdaptor.findById(1L) } returns enrollment
+            every { teacherAdaptor.findByUserId("teacher-user-id-0000001") } returns mockk<Teacher>()
+
+            assertThatThrownBy {
+                useCase.execute(
+                    enrollmentId = 1L,
+                    teacherUserId = "teacher-user-id-0000001",
+                )
+            }.isInstanceOf(EnrollmentInvalidStatusTransitionException::class.java)
+        }
+
+        @Test
+        fun `매칭형 상품이 아니면 예외가 발생한다`() {
+            val enrollment = pendingMatchEnrollment()
+            val product =
+                CourseProduct(
+                    name = "일반 수학 코스",
+                    priceWon = 300000,
+                    totalLessons = 12,
+                    requiresMatching = false,
+                )
+
+            every { enrollmentAdaptor.findById(1L) } returns enrollment
+            every { teacherAdaptor.findByUserId("teacher-user-id-0000001") } returns mockk<Teacher>()
+            every { productAdaptor.findById("product-id-00000000001") } returns product
+
+            assertThatThrownBy {
+                useCase.execute(
+                    enrollmentId = 1L,
+                    teacherUserId = "teacher-user-id-0000001",
+                )
+            }.isInstanceOf(EnrollmentInvalidPurchaseTargetException::class.java)
+        }
+
+        @Test
+        fun `course product가 아니면 예외가 발생한다`() {
+            val enrollment = pendingMatchEnrollment()
+
+            every { enrollmentAdaptor.findById(1L) } returns enrollment
+            every { teacherAdaptor.findByUserId("teacher-user-id-0000001") } returns mockk<Teacher>()
+            every { productAdaptor.findById("product-id-00000000001") } returns mockk<Product>()
+
+            assertThatThrownBy {
+                useCase.execute(
+                    enrollmentId = 1L,
+                    teacherUserId = "teacher-user-id-0000001",
+                )
+            }.isInstanceOf(ProductTypeMismatchException::class.java)
+        }
+
+        @Test
+        fun `존재하지 않는 선생님이면 예외가 발생한다`() {
+            every { enrollmentAdaptor.findById(1L) } returns pendingMatchEnrollment()
+            every { teacherAdaptor.findByUserId("teacher-user-id-0000001") } throws TeacherNotFoundException()
+
+            assertThatThrownBy {
+                useCase.execute(
+                    enrollmentId = 1L,
+                    teacherUserId = "teacher-user-id-0000001",
+                )
+            }.isInstanceOf(TeacherNotFoundException::class.java)
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closes #250
- follow-up: #276
- follow-up: #277

## 요약
- PENDING_MATCH enrollment에서 전용 course를 생성하는 백오피스 API를 추가했습니다.
- 생성된 course를 enrollment에 연결하고 ACTIVE로 전이합니다.
- 매칭 완료 시 lesson을 함께 생성합니다.

## 상세 변경
- POST /api/v1/enrollments/{enrollmentId}/course 추가
- CreateCourseFromEnrollmentRequest 추가
- CreateCourseFromEnrollmentUseCase 추가
- matching course product 검증 및 teacher user 검증 추가
- 생성 course는 UNLISTED, maxEnrollments = 1로 생성
- EnrollmentControllerIntegrationTest 추가
- CreateCourseFromEnrollmentUseCaseTest 추가

## 참고
- 카탈로그를 product 중심으로 전환하는 작업은 별도 이슈 #276에서 진행
- 기존 supporters 담당 선생님 개념 제거는 별도 이슈 #277에서 진행

## 테스트
- gradle :SClass-Api-Backoffice:test --tests com.sclass.backoffice.enrollment.usecase.CreateCourseFromEnrollmentUseCaseTest --tests com.sclass.backoffice.enrollment.controller.EnrollmentControllerIntegrationTest
