### PR TITLE
feat(payment): add NicePay abandon handling

### DIFF
--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareEnrollmentUseCase.kt
@@ -16,7 +16,7 @@ class PrepareEnrollmentUseCase(
     private val prepareRegularEnrollmentUseCase: PrepareRegularEnrollmentUseCase,
     private val prepareMatchingEnrollmentUseCase: PrepareMatchingEnrollmentUseCase,
 ) {
-    @DistributedLock(prefix = "course-product")
+    @DistributedLock(prefix = "course-product", waitTime = 30)
     fun execute(
         studentUserId: String,
         @LockKey productId: String,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareMatchingEnrollmentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/enrollment/usecase/PrepareMatchingEnrollmentUseCase.kt
@@ -22,7 +22,7 @@ class PrepareMatchingEnrollmentUseCase(
     private val paymentAdaptor: PaymentAdaptor,
 ) {
     @Transactional
-    @DistributedLock(prefix = "course-product")
+    @DistributedLock(prefix = "course-product", waitTime = 30)
     fun execute(
         @LockKey productId: String,
         studentUserId: String,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/controller/PaymentController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/controller/PaymentController.kt
@@ -6,6 +6,7 @@ import com.sclass.common.dto.ApiResponse
 import com.sclass.infrastructure.nicepay.dto.NicePayWebhookPayload
 import com.sclass.supporters.payment.dto.PreparePaymentRequest
 import com.sclass.supporters.payment.dto.PreparePaymentResponse
+import com.sclass.supporters.payment.usecase.AbandonPaymentUseCase
 import com.sclass.supporters.payment.usecase.HandleNicePayReturnUseCase
 import com.sclass.supporters.payment.usecase.HandleNicePayWebhookUseCase
 import com.sclass.supporters.payment.usecase.PreparePaymentUseCase
@@ -13,6 +14,8 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -26,12 +29,22 @@ class PaymentController(
     private val preparePaymentUseCase: PreparePaymentUseCase,
     private val handleNicePayWebhookUseCase: HandleNicePayWebhookUseCase,
     private val handleNicePayReturnUseCase: HandleNicePayReturnUseCase,
+    private val abandonPaymentUseCase: AbandonPaymentUseCase,
 ) {
     @PostMapping
     fun prepare(
         @CurrentUserId userId: String,
         @Valid @RequestBody request: PreparePaymentRequest,
     ): ApiResponse<PreparePaymentResponse> = ApiResponse.success(preparePaymentUseCase.execute(userId, request))
+
+    @PatchMapping("/{paymentId}/abandon")
+    fun abandon(
+        @CurrentUserId userId: String,
+        @PathVariable paymentId: String,
+    ): ApiResponse<Unit> {
+        abandonPaymentUseCase.execute(userId, paymentId)
+        return ApiResponse.success(Unit)
+    }
 
     @Public
     @PostMapping("/nicepay/webhook", produces = [MediaType.TEXT_HTML_VALUE])

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCase.kt
@@ -7,6 +7,7 @@ import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.exception.PaymentUnauthorizedException
+import com.sclass.infrastructure.nicepay.PgGateway
 import com.sclass.infrastructure.redis.DistributedLock
 import com.sclass.infrastructure.redis.LockKey
 import jakarta.transaction.Transactional
@@ -15,6 +16,7 @@ import jakarta.transaction.Transactional
 class AbandonPaymentLockedUseCase(
     private val paymentAdaptor: PaymentAdaptor,
     private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val pgGateway: PgGateway,
 ) {
     @Transactional
     @DistributedLock(prefix = "payment")
@@ -31,6 +33,10 @@ class AbandonPaymentLockedUseCase(
 
         when (payment.status) {
             PaymentStatus.PENDING -> {
+                val inquiryResult = pgGateway.inquiry(pgOrderId)
+                if (inquiryResult.approved) {
+                    return
+                }
                 payment.markCancelled()
                 paymentAdaptor.save(payment)
                 cancelPendingEnrollment(enrollment)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCase.kt
@@ -36,6 +36,31 @@ class AbandonPaymentLockedUseCase(
             PaymentStatus.PENDING -> {
                 val inquiryResult = pgGateway.inquiry(pgOrderId)
                 if (inquiryResult.approved) {
+                    val tid = inquiryResult.tid
+                    if (tid == null) {
+                        payment.markPgCancelFailed(PaymentCancelSource.USER_ABANDONED)
+                        paymentAdaptor.save(payment)
+                        return
+                    }
+
+                    val cancelSuccess =
+                        runCatching {
+                            pgGateway.cancel(
+                                tid,
+                                payment.amount,
+                                PaymentCancelSource.USER_ABANDONED.compensationReason(),
+                            )
+                        }.isSuccess
+
+                    if (cancelSuccess) {
+                        payment.markCancelled(PaymentCancelSource.USER_ABANDONED)
+                        payment.markCancelCompensated(PaymentCancelSource.USER_ABANDONED)
+                        paymentAdaptor.save(payment)
+                        cancelPendingEnrollment(enrollment)
+                    } else {
+                        payment.markPgCancelFailed(PaymentCancelSource.USER_ABANDONED)
+                        paymentAdaptor.save(payment)
+                    }
                     return
                 }
                 payment.markCancelled(PaymentCancelSource.USER_ABANDONED)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCase.kt
@@ -40,6 +40,7 @@ class AbandonPaymentLockedUseCase(
                     if (tid == null) {
                         payment.markPgCancelFailed(PaymentCancelSource.USER_ABANDONED)
                         paymentAdaptor.save(payment)
+                        cancelPendingEnrollment(enrollment)
                         return
                     }
 
@@ -60,6 +61,7 @@ class AbandonPaymentLockedUseCase(
                     } else {
                         payment.markPgCancelFailed(PaymentCancelSource.USER_ABANDONED)
                         paymentAdaptor.save(payment)
+                        cancelPendingEnrollment(enrollment)
                     }
                     return
                 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCase.kt
@@ -1,0 +1,53 @@
+package com.sclass.supporters.payment.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.PaymentStatus
+import com.sclass.domain.domains.payment.exception.PaymentUnauthorizedException
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import jakarta.transaction.Transactional
+
+@UseCase
+class AbandonPaymentLockedUseCase(
+    private val paymentAdaptor: PaymentAdaptor,
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+) {
+    @Transactional
+    @DistributedLock(prefix = "payment")
+    fun execute(
+        userId: String,
+        paymentId: String,
+        @LockKey pgOrderId: String,
+    ) {
+        val payment = paymentAdaptor.findById(paymentId)
+
+        if (payment.userId != userId) throw PaymentUnauthorizedException()
+
+        val enrollment = enrollmentAdaptor.findByPaymentIdOrNull(payment.id)
+
+        when (payment.status) {
+            PaymentStatus.PENDING -> {
+                payment.markCancelled()
+                paymentAdaptor.save(payment)
+                cancelPendingEnrollment(enrollment)
+            }
+
+            PaymentStatus.CANCELLED -> {
+                cancelPendingEnrollment(enrollment)
+            }
+            else -> return
+        }
+    }
+
+    private fun cancelPendingEnrollment(enrollment: Enrollment?) {
+        if (enrollment?.status != EnrollmentStatus.PENDING_PAYMENT) {
+            return
+        }
+        enrollment.cancel("사용자 결제 포기")
+        enrollmentAdaptor.save(enrollment)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCase.kt
@@ -5,6 +5,7 @@ import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.PaymentCancelSource
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.exception.PaymentUnauthorizedException
 import com.sclass.infrastructure.nicepay.PgGateway
@@ -37,7 +38,7 @@ class AbandonPaymentLockedUseCase(
                 if (inquiryResult.approved) {
                     return
                 }
-                payment.markCancelled()
+                payment.markCancelled(PaymentCancelSource.USER_ABANDONED)
                 paymentAdaptor.save(payment)
                 cancelPendingEnrollment(enrollment)
             }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentUseCase.kt
@@ -1,0 +1,54 @@
+package com.sclass.supporters.payment.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.PaymentStatus
+import com.sclass.domain.domains.payment.exception.PaymentUnauthorizedException
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import jakarta.transaction.Transactional
+
+@UseCase
+class AbandonPaymentUseCase(
+    private val paymentAdaptor: PaymentAdaptor,
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+) {
+    @Transactional
+    @DistributedLock("payment")
+    fun execute(
+        userId: String,
+        @LockKey paymentId: String,
+    ) {
+        val payment = paymentAdaptor.findById(paymentId)
+
+        if (payment.userId != userId) throw PaymentUnauthorizedException()
+
+        val enrollment = enrollmentAdaptor.findByPaymentIdOrNull(payment.id)
+
+        when (payment.status) {
+            PaymentStatus.PENDING -> {
+                payment.markCancelled()
+                paymentAdaptor.save(payment)
+                cancelPendingEnrollment(enrollment)
+            }
+
+            PaymentStatus.CANCELLED -> {
+                cancelPendingEnrollment(enrollment)
+            }
+            else -> return
+        }
+    }
+
+    private fun cancelPendingEnrollment(enrollment: Enrollment?) {
+        if (enrollment?.status !=
+            EnrollmentStatus.PENDING_PAYMENT
+        ) {
+            return
+        }
+        enrollment.cancel("사용자 결제 포기")
+        enrollmentAdaptor.save(enrollment)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentUseCase.kt
@@ -1,54 +1,21 @@
 package com.sclass.supporters.payment.usecase
 
 import com.sclass.common.annotation.UseCase
-import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
-import com.sclass.domain.domains.enrollment.domain.Enrollment
-import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
-import com.sclass.domain.domains.payment.domain.PaymentStatus
-import com.sclass.domain.domains.payment.exception.PaymentUnauthorizedException
-import com.sclass.infrastructure.redis.DistributedLock
-import com.sclass.infrastructure.redis.LockKey
-import jakarta.transaction.Transactional
 
 @UseCase
 class AbandonPaymentUseCase(
     private val paymentAdaptor: PaymentAdaptor,
-    private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val abandonPaymentLockedUseCase: AbandonPaymentLockedUseCase,
 ) {
-    @Transactional
-    @DistributedLock("payment")
     fun execute(
         userId: String,
-        @LockKey paymentId: String,
-    ) {
-        val payment = paymentAdaptor.findById(paymentId)
-
-        if (payment.userId != userId) throw PaymentUnauthorizedException()
-
-        val enrollment = enrollmentAdaptor.findByPaymentIdOrNull(payment.id)
-
-        when (payment.status) {
-            PaymentStatus.PENDING -> {
-                payment.markCancelled()
-                paymentAdaptor.save(payment)
-                cancelPendingEnrollment(enrollment)
-            }
-
-            PaymentStatus.CANCELLED -> {
-                cancelPendingEnrollment(enrollment)
-            }
-            else -> return
-        }
-    }
-
-    private fun cancelPendingEnrollment(enrollment: Enrollment?) {
-        if (enrollment?.status !=
-            EnrollmentStatus.PENDING_PAYMENT
-        ) {
-            return
-        }
-        enrollment.cancel("사용자 결제 포기")
-        enrollmentAdaptor.save(enrollment)
+        paymentId: String,
+    ) = paymentAdaptor.findById(paymentId).let { payment ->
+        abandonPaymentLockedUseCase.execute(
+            userId = userId,
+            paymentId = payment.id,
+            pgOrderId = payment.pgOrderId,
+        )
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
@@ -73,7 +73,7 @@ class HandleNicePayReturnUseCase(
         }
 
         val pendingCancelSource = payment.pendingCancelSource()
-        if (payment.status == PaymentStatus.CANCELLED && pendingCancelSource != null) {
+        if (payment.status in setOf(PaymentStatus.CANCELLED, PaymentStatus.PG_CANCEL_FAILED) && pendingCancelSource != null) {
             compensateApprovedCancelledPayment(payment, tid, pendingCancelSource)
             return failureUrl()
         }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
@@ -7,6 +7,8 @@ import com.sclass.domain.domains.coin.service.CoinDomainService
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.exception.EnrollmentCourseRequiredException
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.Payment
+import com.sclass.domain.domains.payment.domain.PaymentCancelSource
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
@@ -67,6 +69,12 @@ class HandleNicePayReturnUseCase(
 
         if (payment.amount != amount) {
             log.warn("결제 금액 불일치: expected={}, actual={}, orderId={}", payment.amount, amount, orderId)
+            return failureUrl()
+        }
+
+        val pendingCancelSource = payment.pendingCancelSource()
+        if (payment.status == PaymentStatus.CANCELLED && pendingCancelSource != null) {
+            compensateApprovedCancelledPayment(payment, tid, pendingCancelSource)
             return failureUrl()
         }
 
@@ -182,6 +190,27 @@ class HandleNicePayReturnUseCase(
     }
 
     private fun baseUrl() = frontendUrl.trimEnd('/')
+
+    private fun compensateApprovedCancelledPayment(
+        payment: Payment,
+        tid: String,
+        cancelSource: PaymentCancelSource,
+    ) {
+        val cancelSuccess =
+            runCatching { pgGateway.cancel(tid, payment.amount, cancelSource.compensationReason()) }
+                .onFailure { e -> log.error("자동 승인취소 실패: orderId={}", payment.pgOrderId, e) }
+                .isSuccess
+
+        txTemplate.execute {
+            val fresh = paymentAdaptor.findById(payment.id)
+            if (cancelSuccess) {
+                fresh.markCancelCompensated(cancelSource)
+            } else {
+                fresh.markPgCancelFailed()
+            }
+            paymentAdaptor.save(fresh)
+        }
+    }
 
     private fun successUrl(issuedCoinAmount: Int?) =
         if (issuedCoinAmount != null) {

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
@@ -74,7 +74,7 @@ class HandleNicePayReturnUseCase(
 
         val pendingCancelSource = payment.pendingCancelSource()
         if (payment.status in setOf(PaymentStatus.CANCELLED, PaymentStatus.PG_CANCEL_FAILED) && pendingCancelSource != null) {
-            compensateApprovedCancelledPayment(payment, tid, pendingCancelSource)
+            compensateApprovedCancelledPayment(payment, orderId, tid, pendingCancelSource)
             return failureUrl()
         }
 
@@ -193,11 +193,31 @@ class HandleNicePayReturnUseCase(
 
     private fun compensateApprovedCancelledPayment(
         payment: Payment,
-        tid: String,
+        orderId: String,
+        requestedTid: String,
         cancelSource: PaymentCancelSource,
     ) {
+        val inquiryResult =
+            runCatching { pgGateway.inquiry(orderId) }
+                .onFailure { e -> log.error("자동 승인취소 전 조회 실패: orderId={}", orderId, e) }
+                .getOrNull()
+                ?: return
+
+        val verifiedTid = inquiryResult.tid
+        if (!inquiryResult.approved || verifiedTid == null) {
+            log.warn("자동 승인취소 불가: approved={}, tid={}, orderId={}", inquiryResult.approved, verifiedTid, orderId)
+            return
+        }
+        if (inquiryResult.amount != payment.amount) {
+            log.warn("자동 승인취소 조회 금액 불일치: expected={}, actual={}, orderId={}", payment.amount, inquiryResult.amount, orderId)
+            return
+        }
+        if (verifiedTid != requestedTid) {
+            log.warn("리턴 tid 불일치 - 조회 결과 tid 사용: requestedTid={}, verifiedTid={}, orderId={}", requestedTid, verifiedTid, orderId)
+        }
+
         val cancelSuccess =
-            runCatching { pgGateway.cancel(tid, payment.amount, cancelSource.compensationReason()) }
+            runCatching { pgGateway.cancel(verifiedTid, payment.amount, cancelSource.compensationReason()) }
                 .onFailure { e -> log.error("자동 승인취소 실패: orderId={}", payment.pgOrderId, e) }
                 .isSuccess
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCase.kt
@@ -206,7 +206,7 @@ class HandleNicePayReturnUseCase(
             if (cancelSuccess) {
                 fresh.markCancelCompensated(cancelSource)
             } else {
-                fresh.markPgCancelFailed()
+                fresh.markPgCancelFailed(cancelSource)
             }
             paymentAdaptor.save(fresh)
         }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -76,7 +76,7 @@ class HandleNicePayWebhookUseCase(
 
         val pendingCancelSource = payment.pendingCancelSource()
         if (payment.status in setOf(PaymentStatus.CANCELLED, PaymentStatus.PG_CANCEL_FAILED) && pendingCancelSource != null) {
-            compensateApprovedCancelledPayment(payment, payload.tid, pendingCancelSource)
+            compensateApprovedCancelledPayment(payment, orderId, payload.tid, pendingCancelSource)
             return
         }
 
@@ -239,11 +239,31 @@ class HandleNicePayWebhookUseCase(
 
     private fun compensateApprovedCancelledPayment(
         payment: Payment,
-        tid: String,
+        orderId: String,
+        requestedTid: String,
         cancelSource: PaymentCancelSource,
     ) {
+        val inquiryResult =
+            runCatching { pgGateway.inquiry(orderId) }
+                .onFailure { e -> log.error("웹훅 수신: 자동 승인취소 전 조회 실패 orderId={}", orderId, e) }
+                .getOrNull()
+                ?: return
+
+        val verifiedTid = inquiryResult.tid
+        if (!inquiryResult.approved || verifiedTid == null) {
+            log.warn("웹훅 수신: 자동 승인취소 불가 approved={}, tid={}, orderId={}", inquiryResult.approved, verifiedTid, orderId)
+            return
+        }
+        if (inquiryResult.amount != payment.amount) {
+            log.warn("웹훅 수신: 자동 승인취소 조회 금액 불일치 expected={}, actual={}, orderId={}", payment.amount, inquiryResult.amount, orderId)
+            return
+        }
+        if (verifiedTid != requestedTid) {
+            log.warn("웹훅 tid 불일치 - 조회 결과 tid 사용: requestedTid={}, verifiedTid={}, orderId={}", requestedTid, verifiedTid, orderId)
+        }
+
         val cancelSuccess =
-            runCatching { pgGateway.cancel(tid, payment.amount, cancelSource.compensationReason()) }
+            runCatching { pgGateway.cancel(verifiedTid, payment.amount, cancelSource.compensationReason()) }
                 .onFailure { e -> log.error("웹훅 수신: 자동 승인취소 실패 paymentId={}", payment.id, e) }
                 .isSuccess
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -252,7 +252,7 @@ class HandleNicePayWebhookUseCase(
             if (cancelSuccess) {
                 fresh.markCancelCompensated(cancelSource)
             } else {
-                fresh.markPgCancelFailed()
+                fresh.markPgCancelFailed(cancelSource)
             }
             paymentAdaptor.save(fresh)
         }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -75,7 +75,7 @@ class HandleNicePayWebhookUseCase(
         }
 
         val pendingCancelSource = payment.pendingCancelSource()
-        if (payment.status == PaymentStatus.CANCELLED && pendingCancelSource != null) {
+        if (payment.status in setOf(PaymentStatus.CANCELLED, PaymentStatus.PG_CANCEL_FAILED) && pendingCancelSource != null) {
             compensateApprovedCancelledPayment(payment, payload.tid, pendingCancelSource)
             return
         }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCase.kt
@@ -10,6 +10,8 @@ import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.exception.EnrollmentCourseRequiredException
 import com.sclass.domain.domains.lesson.service.LessonDomainService
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.Payment
+import com.sclass.domain.domains.payment.domain.PaymentCancelSource
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
@@ -69,6 +71,12 @@ class HandleNicePayWebhookUseCase(
                 payload.resultCode,
                 orderId,
             )
+            return
+        }
+
+        val pendingCancelSource = payment.pendingCancelSource()
+        if (payment.status == PaymentStatus.CANCELLED && pendingCancelSource != null) {
+            compensateApprovedCancelledPayment(payment, payload.tid, pendingCancelSource)
             return
         }
 
@@ -226,6 +234,27 @@ class HandleNicePayWebhookUseCase(
                     }
                 }
             }
+        }
+    }
+
+    private fun compensateApprovedCancelledPayment(
+        payment: Payment,
+        tid: String,
+        cancelSource: PaymentCancelSource,
+    ) {
+        val cancelSuccess =
+            runCatching { pgGateway.cancel(tid, payment.amount, cancelSource.compensationReason()) }
+                .onFailure { e -> log.error("웹훅 수신: 자동 승인취소 실패 paymentId={}", payment.id, e) }
+                .isSuccess
+
+        txTemplate.execute {
+            val fresh = paymentAdaptor.findById(payment.id)
+            if (cancelSuccess) {
+                fresh.markCancelCompensated(cancelSource)
+            } else {
+                fresh.markPgCancelFailed()
+            }
+            paymentAdaptor.save(fresh)
         }
     }
 

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCaseTest.kt
@@ -8,6 +8,8 @@ import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
 import com.sclass.domain.domains.payment.domain.PgType
 import com.sclass.domain.domains.payment.exception.PaymentUnauthorizedException
+import com.sclass.infrastructure.nicepay.PgGateway
+import com.sclass.infrastructure.nicepay.dto.PgInquiryResult
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -19,13 +21,15 @@ import org.junit.jupiter.api.Test
 class AbandonPaymentLockedUseCaseTest {
     private lateinit var paymentAdaptor: PaymentAdaptor
     private lateinit var enrollmentAdaptor: EnrollmentAdaptor
+    private lateinit var pgGateway: PgGateway
     private lateinit var useCase: AbandonPaymentLockedUseCase
 
     @BeforeEach
     fun setUp() {
         paymentAdaptor = mockk()
         enrollmentAdaptor = mockk()
-        useCase = AbandonPaymentLockedUseCase(paymentAdaptor, enrollmentAdaptor)
+        pgGateway = mockk()
+        useCase = AbandonPaymentLockedUseCase(paymentAdaptor, enrollmentAdaptor, pgGateway)
     }
 
     private fun pendingPayment(userId: String = "user-id-1") =
@@ -52,6 +56,7 @@ class AbandonPaymentLockedUseCaseTest {
 
         every { paymentAdaptor.findById(payment.id) } returns payment
         every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns enrollment
+        every { pgGateway.inquiry(payment.pgOrderId) } returns PgInquiryResult(approved = false, tid = null, amount = payment.amount)
         every { paymentAdaptor.save(any()) } answers { firstArg() }
         every { enrollmentAdaptor.save(any()) } answers { firstArg() }
 
@@ -62,6 +67,21 @@ class AbandonPaymentLockedUseCaseTest {
         assertThat(enrollment.cancelReason).isEqualTo("사용자 결제 포기")
         verify(exactly = 1) { paymentAdaptor.save(payment) }
         verify(exactly = 1) { enrollmentAdaptor.save(enrollment) }
+    }
+
+    @Test
+    fun `PG 조회 결과 이미 승인된 거래면 abandon 처리하지 않는다`() {
+        val payment = pendingPayment()
+
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns null
+        every { pgGateway.inquiry(payment.pgOrderId) } returns PgInquiryResult(approved = true, tid = "tid-1", amount = payment.amount)
+
+        useCase.execute(payment.userId, payment.id, payment.pgOrderId)
+
+        assertThat(payment.status).isEqualTo(PaymentStatus.PENDING)
+        verify(exactly = 0) { paymentAdaptor.save(any()) }
+        verify(exactly = 0) { enrollmentAdaptor.save(any()) }
     }
 
     @Test
@@ -115,6 +135,7 @@ class AbandonPaymentLockedUseCaseTest {
 
         every { paymentAdaptor.findById(payment.id) } returns payment
         every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns null
+        every { pgGateway.inquiry(payment.pgOrderId) } returns PgInquiryResult(approved = false, tid = null, amount = payment.amount)
         every { paymentAdaptor.save(any()) } answers { firstArg() }
 
         useCase.execute(payment.userId, payment.id, payment.pgOrderId)

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCaseTest.kt
@@ -16,16 +16,16 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class AbandonPaymentUseCaseTest {
+class AbandonPaymentLockedUseCaseTest {
     private lateinit var paymentAdaptor: PaymentAdaptor
     private lateinit var enrollmentAdaptor: EnrollmentAdaptor
-    private lateinit var useCase: AbandonPaymentUseCase
+    private lateinit var useCase: AbandonPaymentLockedUseCase
 
     @BeforeEach
     fun setUp() {
         paymentAdaptor = mockk()
         enrollmentAdaptor = mockk()
-        useCase = AbandonPaymentUseCase(paymentAdaptor, enrollmentAdaptor)
+        useCase = AbandonPaymentLockedUseCase(paymentAdaptor, enrollmentAdaptor)
     }
 
     private fun pendingPayment(userId: String = "user-id-1") =
@@ -55,7 +55,7 @@ class AbandonPaymentUseCaseTest {
         every { paymentAdaptor.save(any()) } answers { firstArg() }
         every { enrollmentAdaptor.save(any()) } answers { firstArg() }
 
-        useCase.execute(payment.userId, payment.id)
+        useCase.execute(payment.userId, payment.id, payment.pgOrderId)
 
         assertThat(payment.status).isEqualTo(PaymentStatus.CANCELLED)
         assertThat(enrollment.status.name).isEqualTo("CANCELLED")
@@ -71,7 +71,7 @@ class AbandonPaymentUseCaseTest {
         every { paymentAdaptor.findById(payment.id) } returns payment
         every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns null
 
-        useCase.execute(payment.userId, payment.id)
+        useCase.execute(payment.userId, payment.id, payment.pgOrderId)
 
         verify(exactly = 0) { paymentAdaptor.save(any()) }
         verify(exactly = 0) { enrollmentAdaptor.save(any()) }
@@ -84,7 +84,7 @@ class AbandonPaymentUseCaseTest {
         every { paymentAdaptor.findById(payment.id) } returns payment
         every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns null
 
-        useCase.execute(payment.userId, payment.id)
+        useCase.execute(payment.userId, payment.id, payment.pgOrderId)
 
         verify(exactly = 0) { paymentAdaptor.save(any()) }
         verify(exactly = 0) { enrollmentAdaptor.save(any()) }
@@ -97,7 +97,7 @@ class AbandonPaymentUseCaseTest {
         every { paymentAdaptor.findById(payment.id) } returns payment
 
         assertThatThrownBy {
-            useCase.execute("other-user-id", payment.id)
+            useCase.execute("other-user-id", payment.id, payment.pgOrderId)
         }.isInstanceOf(PaymentUnauthorizedException::class.java)
     }
 
@@ -117,7 +117,7 @@ class AbandonPaymentUseCaseTest {
         every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns null
         every { paymentAdaptor.save(any()) } answers { firstArg() }
 
-        useCase.execute(payment.userId, payment.id)
+        useCase.execute(payment.userId, payment.id, payment.pgOrderId)
 
         assertThat(payment.status).isEqualTo(PaymentStatus.CANCELLED)
         verify(exactly = 1) { paymentAdaptor.save(payment) }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCaseTest.kt
@@ -72,17 +72,43 @@ class AbandonPaymentLockedUseCaseTest {
     }
 
     @Test
-    fun `PG 조회 결과 이미 승인된 거래면 abandon 처리하지 않는다`() {
+    fun `PG 조회 결과 이미 승인된 거래면 즉시 승인취소하고 local 취소 처리한다`() {
         val payment = pendingPayment()
 
         every { paymentAdaptor.findById(payment.id) } returns payment
         every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns null
         every { pgGateway.inquiry(payment.pgOrderId) } returns PgInquiryResult(approved = true, tid = "tid-1", amount = payment.amount)
+        every { pgGateway.cancel("tid-1", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) } returns mockk()
+        every { paymentAdaptor.save(any()) } answers { firstArg() }
 
         useCase.execute(payment.userId, payment.id, payment.pgOrderId)
 
-        assertThat(payment.status).isEqualTo(PaymentStatus.PENDING)
-        verify(exactly = 0) { paymentAdaptor.save(any()) }
+        assertThat(payment.status).isEqualTo(PaymentStatus.CANCELLED)
+        assertThat(payment.metadata).isEqualTo(PaymentCancelSource.USER_ABANDONED.compensatedMetadata())
+        verify(exactly = 1) {
+            pgGateway.cancel("tid-1", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason())
+        }
+        verify(exactly = 1) { paymentAdaptor.save(payment) }
+        verify(exactly = 0) { enrollmentAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `PG 조회 결과 이미 승인된 거래의 승인취소가 실패하면 PG_CANCEL_FAILED로 마킹한다`() {
+        val payment = pendingPayment()
+
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns null
+        every { pgGateway.inquiry(payment.pgOrderId) } returns PgInquiryResult(approved = true, tid = "tid-1", amount = payment.amount)
+        every {
+            pgGateway.cancel("tid-1", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason())
+        } throws RuntimeException("PG cancel failed")
+        every { paymentAdaptor.save(any()) } answers { firstArg() }
+
+        useCase.execute(payment.userId, payment.id, payment.pgOrderId)
+
+        assertThat(payment.status).isEqualTo(PaymentStatus.PG_CANCEL_FAILED)
+        assertThat(payment.metadata).isEqualTo(PaymentCancelSource.USER_ABANDONED.pendingMetadata())
+        verify(exactly = 1) { paymentAdaptor.save(payment) }
         verify(exactly = 0) { enrollmentAdaptor.save(any()) }
     }
 

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.Payment
+import com.sclass.domain.domains.payment.domain.PaymentCancelSource
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
 import com.sclass.domain.domains.payment.domain.PgType
@@ -63,6 +64,7 @@ class AbandonPaymentLockedUseCaseTest {
         useCase.execute(payment.userId, payment.id, payment.pgOrderId)
 
         assertThat(payment.status).isEqualTo(PaymentStatus.CANCELLED)
+        assertThat(payment.metadata).isEqualTo(PaymentCancelSource.USER_ABANDONED.pendingMetadata())
         assertThat(enrollment.status.name).isEqualTo("CANCELLED")
         assertThat(enrollment.cancelReason).isEqualTo("사용자 결제 포기")
         verify(exactly = 1) { paymentAdaptor.save(payment) }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentLockedUseCaseTest.kt
@@ -95,21 +95,60 @@ class AbandonPaymentLockedUseCaseTest {
     @Test
     fun `PG 조회 결과 이미 승인된 거래의 승인취소가 실패하면 PG_CANCEL_FAILED로 마킹한다`() {
         val payment = pendingPayment()
+        val enrollment =
+            Enrollment.createForPurchase(
+                productId = "product-id-1",
+                studentUserId = payment.userId,
+                tuitionAmountWon = 300000,
+                paymentId = payment.id,
+                courseId = 1L,
+            )
 
         every { paymentAdaptor.findById(payment.id) } returns payment
-        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns null
+        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns enrollment
         every { pgGateway.inquiry(payment.pgOrderId) } returns PgInquiryResult(approved = true, tid = "tid-1", amount = payment.amount)
         every {
             pgGateway.cancel("tid-1", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason())
         } throws RuntimeException("PG cancel failed")
         every { paymentAdaptor.save(any()) } answers { firstArg() }
+        every { enrollmentAdaptor.save(any()) } answers { firstArg() }
 
         useCase.execute(payment.userId, payment.id, payment.pgOrderId)
 
         assertThat(payment.status).isEqualTo(PaymentStatus.PG_CANCEL_FAILED)
         assertThat(payment.metadata).isEqualTo(PaymentCancelSource.USER_ABANDONED.pendingMetadata())
+        assertThat(enrollment.status.name).isEqualTo("CANCELLED")
+        assertThat(enrollment.cancelReason).isEqualTo("사용자 결제 포기")
         verify(exactly = 1) { paymentAdaptor.save(payment) }
-        verify(exactly = 0) { enrollmentAdaptor.save(any()) }
+        verify(exactly = 1) { enrollmentAdaptor.save(enrollment) }
+    }
+
+    @Test
+    fun `PG 조회 결과 승인됐지만 tid가 없으면 enrollment를 취소하고 PG_CANCEL_FAILED로 마킹한다`() {
+        val payment = pendingPayment()
+        val enrollment =
+            Enrollment.createForPurchase(
+                productId = "product-id-1",
+                studentUserId = payment.userId,
+                tuitionAmountWon = 300000,
+                paymentId = payment.id,
+                courseId = 1L,
+            )
+
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns enrollment
+        every { pgGateway.inquiry(payment.pgOrderId) } returns PgInquiryResult(approved = true, tid = null, amount = payment.amount)
+        every { paymentAdaptor.save(any()) } answers { firstArg() }
+        every { enrollmentAdaptor.save(any()) } answers { firstArg() }
+
+        useCase.execute(payment.userId, payment.id, payment.pgOrderId)
+
+        assertThat(payment.status).isEqualTo(PaymentStatus.PG_CANCEL_FAILED)
+        assertThat(payment.metadata).isEqualTo(PaymentCancelSource.USER_ABANDONED.pendingMetadata())
+        assertThat(enrollment.status.name).isEqualTo("CANCELLED")
+        assertThat(enrollment.cancelReason).isEqualTo("사용자 결제 포기")
+        verify(exactly = 1) { paymentAdaptor.save(payment) }
+        verify(exactly = 1) { enrollmentAdaptor.save(enrollment) }
     }
 
     @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentUseCaseFacadeTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentUseCaseFacadeTest.kt
@@ -1,0 +1,57 @@
+package com.sclass.supporters.payment.usecase
+
+import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.Payment
+import com.sclass.domain.domains.payment.domain.PaymentTargetType
+import com.sclass.domain.domains.payment.domain.PgType
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AbandonPaymentUseCaseFacadeTest {
+    private lateinit var paymentAdaptor: PaymentAdaptor
+    private lateinit var abandonPaymentLockedUseCase: AbandonPaymentLockedUseCase
+    private lateinit var useCase: AbandonPaymentUseCase
+
+    @BeforeEach
+    fun setUp() {
+        paymentAdaptor = mockk()
+        abandonPaymentLockedUseCase = mockk()
+        useCase = AbandonPaymentUseCase(paymentAdaptor, abandonPaymentLockedUseCase)
+    }
+
+    @Test
+    fun `paymentId로 pgOrderId를 해석한 뒤 locked use case에 위임한다`() {
+        val payment =
+            Payment(
+                userId = "user-id-1",
+                targetType = PaymentTargetType.COURSE_PRODUCT,
+                targetId = "product-id-1",
+                amount = 300000,
+                pgType = PgType.NICEPAY,
+                pgOrderId = "order-id-1",
+            )
+
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every {
+            abandonPaymentLockedUseCase.execute(
+                userId = payment.userId,
+                paymentId = payment.id,
+                pgOrderId = payment.pgOrderId,
+            )
+        } returns Unit
+
+        useCase.execute(payment.userId, payment.id)
+
+        verify(exactly = 1) { paymentAdaptor.findById(payment.id) }
+        verify(exactly = 1) {
+            abandonPaymentLockedUseCase.execute(
+                userId = payment.userId,
+                paymentId = payment.id,
+                pgOrderId = payment.pgOrderId,
+            )
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/AbandonPaymentUseCaseTest.kt
@@ -1,0 +1,125 @@
+package com.sclass.supporters.payment.usecase
+
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.Payment
+import com.sclass.domain.domains.payment.domain.PaymentStatus
+import com.sclass.domain.domains.payment.domain.PaymentTargetType
+import com.sclass.domain.domains.payment.domain.PgType
+import com.sclass.domain.domains.payment.exception.PaymentUnauthorizedException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AbandonPaymentUseCaseTest {
+    private lateinit var paymentAdaptor: PaymentAdaptor
+    private lateinit var enrollmentAdaptor: EnrollmentAdaptor
+    private lateinit var useCase: AbandonPaymentUseCase
+
+    @BeforeEach
+    fun setUp() {
+        paymentAdaptor = mockk()
+        enrollmentAdaptor = mockk()
+        useCase = AbandonPaymentUseCase(paymentAdaptor, enrollmentAdaptor)
+    }
+
+    private fun pendingPayment(userId: String = "user-id-1") =
+        Payment(
+            userId = userId,
+            targetType = PaymentTargetType.COURSE_PRODUCT,
+            targetId = "product-id-1",
+            amount = 300000,
+            pgType = PgType.NICEPAY,
+            pgOrderId = "order-id-1",
+        )
+
+    @Test
+    fun `PENDING payment abandon 시 payment와 enrollment를 함께 취소한다`() {
+        val payment = pendingPayment()
+        val enrollment =
+            Enrollment.createForPurchase(
+                productId = "product-id-1",
+                studentUserId = payment.userId,
+                tuitionAmountWon = 300000,
+                paymentId = payment.id,
+                courseId = 1L,
+            )
+
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns enrollment
+        every { paymentAdaptor.save(any()) } answers { firstArg() }
+        every { enrollmentAdaptor.save(any()) } answers { firstArg() }
+
+        useCase.execute(payment.userId, payment.id)
+
+        assertThat(payment.status).isEqualTo(PaymentStatus.CANCELLED)
+        assertThat(enrollment.status.name).isEqualTo("CANCELLED")
+        assertThat(enrollment.cancelReason).isEqualTo("사용자 결제 포기")
+        verify(exactly = 1) { paymentAdaptor.save(payment) }
+        verify(exactly = 1) { enrollmentAdaptor.save(enrollment) }
+    }
+
+    @Test
+    fun `이미 CANCELLED면 idempotent 하게 종료한다`() {
+        val payment = pendingPayment().apply { markCancelled() }
+
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns null
+
+        useCase.execute(payment.userId, payment.id)
+
+        verify(exactly = 0) { paymentAdaptor.save(any()) }
+        verify(exactly = 0) { enrollmentAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `PG_APPROVED 이후 상태면 아무 작업도 하지 않는다`() {
+        val payment = pendingPayment().apply { markPgApproved("tid-1") }
+
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns null
+
+        useCase.execute(payment.userId, payment.id)
+
+        verify(exactly = 0) { paymentAdaptor.save(any()) }
+        verify(exactly = 0) { enrollmentAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `다른 사용자 결제면 PaymentUnauthorizedException이 발생한다`() {
+        val payment = pendingPayment(userId = "owner-id")
+
+        every { paymentAdaptor.findById(payment.id) } returns payment
+
+        assertThatThrownBy {
+            useCase.execute("other-user-id", payment.id)
+        }.isInstanceOf(PaymentUnauthorizedException::class.java)
+    }
+
+    @Test
+    fun `coin package payment도 payment만 취소할 수 있다`() {
+        val payment =
+            Payment(
+                userId = "user-id-1",
+                targetType = PaymentTargetType.COIN_PACKAGE,
+                targetId = "coin-package-id-1",
+                amount = 10000,
+                pgType = PgType.NICEPAY,
+                pgOrderId = "order-id-2",
+            )
+
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { enrollmentAdaptor.findByPaymentIdOrNull(payment.id) } returns null
+        every { paymentAdaptor.save(any()) } answers { firstArg() }
+
+        useCase.execute(payment.userId, payment.id)
+
+        assertThat(payment.status).isEqualTo(PaymentStatus.CANCELLED)
+        verify(exactly = 1) { paymentAdaptor.save(payment) }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCaseTest.kt
@@ -266,6 +266,37 @@ class HandleNicePayReturnUseCaseTest {
     }
 
     @Test
+    fun `PG_CANCEL_FAILED 상태여도 성공 콜백이 오면 자동 승인취소를 재시도한다`() {
+        val payment =
+            pendingPayment(amount = 1000).apply {
+                markPgCancelFailed(PaymentCancelSource.USER_ABANDONED)
+            }
+
+        every { pgGateway.verifyReturnSignature(any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(payment.pgOrderId) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) } returns mockk()
+
+        val result =
+            useCase.execute(
+                authResultCode = "0000",
+                tid = "tid-001",
+                orderId = payment.pgOrderId,
+                amount = 1000,
+                authToken = "token",
+                signature = "sig",
+            )
+
+        assertAll(
+            { assertTrue(result.contains("status=FAILED")) },
+            { assertEquals(PaymentStatus.PG_CANCEL_FAILED, payment.status) },
+            { assertEquals(PaymentCancelSource.USER_ABANDONED.compensatedMetadata(), payment.metadata) },
+        )
+        verify(exactly = 1) { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) }
+        verify(exactly = 1) { paymentAdaptor.save(payment) }
+    }
+
+    @Test
     fun `필수 파라미터가 null이면 FAILED 콜백 URL을 반환한다`() {
         val result =
             useCase.execute(

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCaseTest.kt
@@ -9,6 +9,7 @@ import com.sclass.domain.domains.enrollment.domain.Enrollment
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.Payment
+import com.sclass.domain.domains.payment.domain.PaymentCancelSource
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
 import com.sclass.domain.domains.payment.domain.PgType
@@ -231,6 +232,37 @@ class HandleNicePayReturnUseCaseTest {
             { assertTrue(result.contains("status=COMPLETED")) },
             { assertTrue(!result.contains("issuedCoinAmount")) },
         )
+    }
+
+    @Test
+    fun `사용자 결제 포기로 취소된 결제에 성공 콜백이 오면 자동 승인취소한다`() {
+        val payment =
+            pendingPayment(amount = 1000).apply {
+                markCancelled(PaymentCancelSource.USER_ABANDONED)
+            }
+
+        every { pgGateway.verifyReturnSignature(any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(payment.pgOrderId) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) } returns mockk()
+
+        val result =
+            useCase.execute(
+                authResultCode = "0000",
+                tid = "tid-001",
+                orderId = payment.pgOrderId,
+                amount = 1000,
+                authToken = "token",
+                signature = "sig",
+            )
+
+        assertAll(
+            { assertTrue(result.contains("status=FAILED")) },
+            { assertEquals(PaymentStatus.CANCELLED, payment.status) },
+            { assertEquals(PaymentCancelSource.USER_ABANDONED.compensatedMetadata(), payment.metadata) },
+        )
+        verify(exactly = 1) { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) }
+        verify(exactly = 1) { paymentAdaptor.save(payment) }
     }
 
     @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayReturnUseCaseTest.kt
@@ -18,6 +18,7 @@ import com.sclass.domain.domains.product.domain.CourseProduct
 import com.sclass.domain.domains.product.domain.RollingMembershipProduct
 import com.sclass.infrastructure.nicepay.PgGateway
 import com.sclass.infrastructure.nicepay.dto.PgApproveResult
+import com.sclass.infrastructure.nicepay.dto.PgInquiryResult
 import com.sclass.infrastructure.nicepay.exception.NicePayException
 import io.mockk.every
 import io.mockk.mockk
@@ -244,6 +245,7 @@ class HandleNicePayReturnUseCaseTest {
         every { pgGateway.verifyReturnSignature(any(), any(), any()) } returns true
         every { paymentAdaptor.findByPgOrderIdOrNull(payment.pgOrderId) } returns payment
         every { paymentAdaptor.findById(payment.id) } returns payment
+        every { pgGateway.inquiry(payment.pgOrderId) } returns PgInquiryResult(approved = true, tid = "tid-001", amount = payment.amount)
         every { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) } returns mockk()
 
         val result =
@@ -275,6 +277,7 @@ class HandleNicePayReturnUseCaseTest {
         every { pgGateway.verifyReturnSignature(any(), any(), any()) } returns true
         every { paymentAdaptor.findByPgOrderIdOrNull(payment.pgOrderId) } returns payment
         every { paymentAdaptor.findById(payment.id) } returns payment
+        every { pgGateway.inquiry(payment.pgOrderId) } returns PgInquiryResult(approved = true, tid = "tid-001", amount = payment.amount)
         every { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) } returns mockk()
 
         val result =
@@ -294,6 +297,39 @@ class HandleNicePayReturnUseCaseTest {
         )
         verify(exactly = 1) { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) }
         verify(exactly = 1) { paymentAdaptor.save(payment) }
+    }
+
+    @Test
+    fun `사용자 결제 포기 보상 취소 시 리턴 tid가 달라도 조회된 tid로 취소한다`() {
+        val payment =
+            pendingPayment(amount = 1000).apply {
+                markCancelled(PaymentCancelSource.USER_ABANDONED)
+            }
+
+        every { pgGateway.verifyReturnSignature(any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(payment.pgOrderId) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { pgGateway.inquiry(payment.pgOrderId) } returns
+            PgInquiryResult(approved = true, tid = "verified-tid", amount = payment.amount)
+        every { pgGateway.cancel("verified-tid", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) } returns mockk()
+
+        val result =
+            useCase.execute(
+                authResultCode = "0000",
+                tid = "forged-tid",
+                orderId = payment.pgOrderId,
+                amount = 1000,
+                authToken = "token",
+                signature = "sig",
+            )
+
+        assertAll(
+            { assertTrue(result.contains("status=FAILED")) },
+            { assertEquals(PaymentStatus.CANCELLED, payment.status) },
+            { assertEquals(PaymentCancelSource.USER_ABANDONED.compensatedMetadata(), payment.metadata) },
+        )
+        verify(exactly = 0) { pgGateway.cancel("forged-tid", any(), any()) }
+        verify(exactly = 1) { pgGateway.cancel("verified-tid", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) }
     }
 
     @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
@@ -13,6 +13,7 @@ import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.lesson.service.LessonDomainService
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
 import com.sclass.domain.domains.payment.domain.Payment
+import com.sclass.domain.domains.payment.domain.PaymentCancelSource
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import com.sclass.domain.domains.payment.domain.PaymentTargetType
 import com.sclass.domain.domains.payment.domain.PgType
@@ -142,6 +143,30 @@ class HandleNicePayWebhookUseCaseTest {
 
         useCase.execute(payment.pgOrderId, successPayload(payment.pgOrderId))
 
+        verify(exactly = 0) { coinDomainService.issue(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `사용자 결제 포기로 취소된 결제에 성공 웹훅이 오면 자동 승인취소한다`() {
+        val payment =
+            pendingPayment().apply {
+                markCancelled(PaymentCancelSource.USER_ABANDONED)
+            }
+
+        every { pgGateway.verifyWebhookSignature(any(), any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(any()) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { paymentAdaptor.save(any()) } answers { firstArg() }
+        every { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) } returns mockk()
+
+        useCase.execute(payment.pgOrderId, successPayload(payment.pgOrderId))
+
+        assertAll(
+            { assertEquals(PaymentStatus.CANCELLED, payment.status) },
+            { assertEquals(PaymentCancelSource.USER_ABANDONED.compensatedMetadata(), payment.metadata) },
+        )
+        verify(exactly = 1) { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) }
+        verify(exactly = 1) { paymentAdaptor.save(payment) }
         verify(exactly = 0) { coinDomainService.issue(any(), any(), any(), any()) }
     }
 

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
@@ -21,6 +21,7 @@ import com.sclass.domain.domains.product.adaptor.ProductAdaptor
 import com.sclass.domain.domains.product.domain.CourseProduct
 import com.sclass.infrastructure.nicepay.PgGateway
 import com.sclass.infrastructure.nicepay.dto.NicePayWebhookPayload
+import com.sclass.infrastructure.nicepay.dto.PgInquiryResult
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -157,6 +158,7 @@ class HandleNicePayWebhookUseCaseTest {
         every { paymentAdaptor.findByPgOrderIdOrNull(any()) } returns payment
         every { paymentAdaptor.findById(payment.id) } returns payment
         every { paymentAdaptor.save(any()) } answers { firstArg() }
+        every { pgGateway.inquiry(payment.pgOrderId) } returns PgInquiryResult(approved = true, tid = "tid-001", amount = payment.amount)
         every { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) } returns mockk()
 
         useCase.execute(payment.pgOrderId, successPayload(payment.pgOrderId))
@@ -181,6 +183,7 @@ class HandleNicePayWebhookUseCaseTest {
         every { paymentAdaptor.findByPgOrderIdOrNull(any()) } returns payment
         every { paymentAdaptor.findById(payment.id) } returns payment
         every { paymentAdaptor.save(any()) } answers { firstArg() }
+        every { pgGateway.inquiry(payment.pgOrderId) } returns PgInquiryResult(approved = true, tid = "tid-001", amount = payment.amount)
         every { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) } returns mockk()
 
         useCase.execute(payment.pgOrderId, successPayload(payment.pgOrderId))
@@ -192,6 +195,31 @@ class HandleNicePayWebhookUseCaseTest {
         verify(exactly = 1) { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) }
         verify(exactly = 1) { paymentAdaptor.save(payment) }
         verify(exactly = 0) { coinDomainService.issue(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `사용자 결제 포기 보상 취소 시 웹훅 tid가 달라도 조회된 tid로 취소한다`() {
+        val payment =
+            pendingPayment().apply {
+                markCancelled(PaymentCancelSource.USER_ABANDONED)
+            }
+
+        every { pgGateway.verifyWebhookSignature(any(), any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(any()) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { paymentAdaptor.save(any()) } answers { firstArg() }
+        every { pgGateway.inquiry(payment.pgOrderId) } returns
+            PgInquiryResult(approved = true, tid = "verified-tid", amount = payment.amount)
+        every { pgGateway.cancel("verified-tid", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) } returns mockk()
+
+        useCase.execute(payment.pgOrderId, successPayload(payment.pgOrderId).copy(tid = "forged-tid"))
+
+        assertAll(
+            { assertEquals(PaymentStatus.CANCELLED, payment.status) },
+            { assertEquals(PaymentCancelSource.USER_ABANDONED.compensatedMetadata(), payment.metadata) },
+        )
+        verify(exactly = 0) { pgGateway.cancel("forged-tid", any(), any()) }
+        verify(exactly = 1) { pgGateway.cancel("verified-tid", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) }
     }
 
     @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/HandleNicePayWebhookUseCaseTest.kt
@@ -171,6 +171,30 @@ class HandleNicePayWebhookUseCaseTest {
     }
 
     @Test
+    fun `PG_CANCEL_FAILED 상태여도 성공 웹훅이 오면 자동 승인취소를 재시도한다`() {
+        val payment =
+            pendingPayment().apply {
+                markPgCancelFailed(PaymentCancelSource.USER_ABANDONED)
+            }
+
+        every { pgGateway.verifyWebhookSignature(any(), any(), any(), any()) } returns true
+        every { paymentAdaptor.findByPgOrderIdOrNull(any()) } returns payment
+        every { paymentAdaptor.findById(payment.id) } returns payment
+        every { paymentAdaptor.save(any()) } answers { firstArg() }
+        every { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) } returns mockk()
+
+        useCase.execute(payment.pgOrderId, successPayload(payment.pgOrderId))
+
+        assertAll(
+            { assertEquals(PaymentStatus.PG_CANCEL_FAILED, payment.status) },
+            { assertEquals(PaymentCancelSource.USER_ABANDONED.compensatedMetadata(), payment.metadata) },
+        )
+        verify(exactly = 1) { pgGateway.cancel("tid-001", payment.amount, PaymentCancelSource.USER_ABANDONED.compensationReason()) }
+        verify(exactly = 1) { paymentAdaptor.save(payment) }
+        verify(exactly = 0) { coinDomainService.issue(any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `존재하지 않는 orderId면 무시한다`() {
         every { pgGateway.verifyWebhookSignature(any(), any(), any(), any()) } returns true
         every { paymentAdaptor.findByPgOrderIdOrNull(any()) } returns null

--- a/SClass-Batch/src/main/kotlin/com/sclass/batch/enrollment/CleanupStalePendingEnrollmentsJob.kt
+++ b/SClass-Batch/src/main/kotlin/com/sclass/batch/enrollment/CleanupStalePendingEnrollmentsJob.kt
@@ -4,6 +4,7 @@ import com.sclass.common.annotation.BatchJob
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
 import com.sclass.domain.domains.payment.adaptor.PaymentAdaptor
+import com.sclass.domain.domains.payment.domain.PaymentCancelSource
 import com.sclass.domain.domains.payment.domain.PaymentStatus
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
@@ -40,7 +41,7 @@ class CleanupStalePendingEnrollmentsJob(
                     val payment = paymentAdaptor.findById(paymentId)
                     when (payment.status) {
                         PaymentStatus.PENDING -> {
-                            payment.markCancelled()
+                            payment.markCancelled(PaymentCancelSource.PAYMENT_TIMEOUT)
                             paymentAdaptor.save(payment)
                         }
                         PaymentStatus.CANCELLED -> {}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/payment/domain/Payment.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/payment/domain/Payment.kt
@@ -113,6 +113,11 @@ class Payment(
         this.status = PaymentStatus.PG_CANCEL_FAILED
     }
 
+    fun markPgCancelFailed(cancelSource: PaymentCancelSource) {
+        markPgCancelFailed()
+        this.metadata = cancelSource.pendingMetadata()
+    }
+
     fun markCoinRefundFailed() {
         this.status = PaymentStatus.COIN_REFUND_FAILED
     }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/payment/domain/Payment.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/payment/domain/Payment.kt
@@ -98,6 +98,17 @@ class Payment(
         this.status = PaymentStatus.CANCELLED
     }
 
+    fun markCancelled(cancelSource: PaymentCancelSource) {
+        markCancelled()
+        this.metadata = cancelSource.pendingMetadata()
+    }
+
+    fun pendingCancelSource(): PaymentCancelSource? = PaymentCancelSource.fromPendingMetadata(metadata)
+
+    fun markCancelCompensated(cancelSource: PaymentCancelSource) {
+        this.metadata = cancelSource.compensatedMetadata()
+    }
+
     fun markPgCancelFailed() {
         this.status = PaymentStatus.PG_CANCEL_FAILED
     }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/payment/domain/PaymentCancelSource.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/payment/domain/PaymentCancelSource.kt
@@ -1,0 +1,21 @@
+package com.sclass.domain.domains.payment.domain
+
+enum class PaymentCancelSource {
+    USER_ABANDONED,
+    PAYMENT_TIMEOUT,
+    ;
+
+    fun pendingMetadata(): String = name
+
+    fun compensatedMetadata(): String = "${name}_PG_CANCELLED"
+
+    fun compensationReason(): String =
+        when (this) {
+            USER_ABANDONED -> "사용자 결제 포기 자동 승인취소"
+            PAYMENT_TIMEOUT -> "결제 시간 초과 자동 승인취소"
+        }
+
+    companion object {
+        fun fromPendingMetadata(metadata: String?): PaymentCancelSource? = entries.firstOrNull { it.pendingMetadata() == metadata }
+    }
+}


### PR DESCRIPTION
## 요약
- supporters payment abandon API를 추가했습니다.
- 승인 전 결제 포기 시 `payment`와 연결된 `enrollment`를 즉시 정리하도록 구현했습니다.
- 별도 `ABANDONED` 상태 없이 기존 `CANCELLED` 상태와 stale cleanup fallback을 유지했습니다.

## API 변경
- `PATCH /api/v1/payments/{paymentId}/abandon` 추가

## 동작
- 본인 결제만 abandon 가능
- `payment.status == PENDING`이면 `CANCELLED`로 전이
- 연결된 `enrollment.status == PENDING_PAYMENT`이면 함께 `CANCELLED`로 전이
- 이미 `CANCELLED`면 idempotent no-op
- `PG_APPROVED` 이후 상태면 아무 작업도 하지 않음

## 테스트
- `AbandonPaymentUseCaseTest`

Closes #282