### PR TITLE
feat(commission): add submission and detail APIs

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/controller/CommissionController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/controller/CommissionController.kt
@@ -1,6 +1,8 @@
 package com.sclass.backoffice.commission.controller
 
+import com.sclass.backoffice.commission.dto.CommissionDetailResponse
 import com.sclass.backoffice.commission.dto.CommissionPageResponse
+import com.sclass.backoffice.commission.usecase.GetCommissionDetailUseCase
 import com.sclass.backoffice.commission.usecase.GetCommissionListUseCase
 import com.sclass.common.dto.ApiResponse
 import com.sclass.domain.domains.commission.domain.CommissionStatus
@@ -8,6 +10,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/commissions")
 class CommissionController(
     private val getCommissionListUseCase: GetCommissionListUseCase,
+    private val getCommissionDetailUseCase: GetCommissionDetailUseCase,
 ) {
     @GetMapping
     fun getCommissionList(
@@ -25,4 +29,9 @@ class CommissionController(
         @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
     ): ApiResponse<CommissionPageResponse> =
         ApiResponse.success(getCommissionListUseCase.execute(studentUserId, teacherUserId, status, pageable))
+
+    @GetMapping("/{commissionId}")
+    fun getCommissionDetail(
+        @PathVariable commissionId: Long,
+    ): ApiResponse<CommissionDetailResponse> = ApiResponse.success(getCommissionDetailUseCase.execute(commissionId))
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/dto/CommissionDetailResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/dto/CommissionDetailResponse.kt
@@ -1,0 +1,120 @@
+package com.sclass.backoffice.commission.dto
+
+import com.sclass.domain.domains.commission.domain.ActivityType
+import com.sclass.domain.domains.commission.domain.Commission
+import com.sclass.domain.domains.commission.domain.CommissionFile
+import com.sclass.domain.domains.commission.domain.CommissionStatus
+import com.sclass.domain.domains.commission.domain.CommissionTopic
+import com.sclass.domain.domains.commission.domain.OutputFormat
+import com.sclass.domain.domains.file.domain.FileType
+import java.time.LocalDateTime
+
+data class CommissionDetailResponse(
+    val id: Long,
+    val studentUserId: String,
+    val teacherUserId: String,
+    val commissionPolicyId: String,
+    val outputFormat: OutputFormat,
+    val activityType: ActivityType,
+    val status: CommissionStatus,
+    val guideInfo: CommissionGuideInfoResponse,
+    val selectedTopic: CommissionTopicResponse?,
+    val topics: List<CommissionTopicResponse>,
+    val files: List<CommissionFileResponse>,
+    val acceptedLessonId: Long?,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun from(
+            commission: Commission,
+            topics: List<CommissionTopic>,
+            files: List<CommissionFile>,
+        ) = CommissionDetailResponse(
+            id = commission.id,
+            studentUserId = commission.studentUserId,
+            teacherUserId = commission.teacherUserId,
+            commissionPolicyId = commission.commissionPolicyId,
+            outputFormat = commission.outputFormat,
+            activityType = commission.activityType,
+            status = commission.status,
+            guideInfo = CommissionGuideInfoResponse.from(commission),
+            selectedTopic =
+                topics
+                    .firstOrNull { it.id == commission.selectedTopicId || it.selected }
+                    ?.let { CommissionTopicResponse.from(it) },
+            topics = topics.map { CommissionTopicResponse.from(it) },
+            files = files.map { CommissionFileResponse.from(it) },
+            acceptedLessonId = commission.acceptedLessonId,
+            createdAt = commission.createdAt,
+            updatedAt = commission.updatedAt,
+        )
+    }
+}
+
+data class CommissionGuideInfoResponse(
+    val subject: String,
+    val volume: String,
+    val requiredElements: String?,
+    val gradingCriteria: String,
+    val teacherEmphasis: String,
+) {
+    companion object {
+        fun from(commission: Commission) =
+            with(commission.guideInfo) {
+                CommissionGuideInfoResponse(
+                    subject = subject,
+                    volume = volume,
+                    requiredElements = requiredElements,
+                    gradingCriteria = gradingCriteria,
+                    teacherEmphasis = teacherEmphasis,
+                )
+            }
+    }
+}
+
+data class CommissionTopicResponse(
+    val id: Long,
+    val topicId: String?,
+    val title: String,
+    val description: String?,
+    val selected: Boolean,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(topic: CommissionTopic) =
+            CommissionTopicResponse(
+                id = topic.id,
+                topicId = topic.topicId,
+                title = topic.title,
+                description = topic.description,
+                selected = topic.selected,
+                createdAt = topic.createdAt,
+            )
+    }
+}
+
+data class CommissionFileResponse(
+    val commissionFileId: Long,
+    val fileId: String,
+    val originalFilename: String,
+    val mimeType: String,
+    val fileSize: Long,
+    val fileType: FileType,
+    val uploadedBy: String,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(commissionFile: CommissionFile) =
+            CommissionFileResponse(
+                commissionFileId = commissionFile.id,
+                fileId = commissionFile.file.id,
+                originalFilename = commissionFile.file.originalFilename,
+                mimeType = commissionFile.file.mimeType,
+                fileSize = commissionFile.file.fileSize,
+                fileType = commissionFile.file.fileType,
+                uploadedBy = commissionFile.file.uploadedBy,
+                createdAt = commissionFile.file.createdAt,
+            )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/usecase/GetCommissionDetailUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/usecase/GetCommissionDetailUseCase.kt
@@ -1,0 +1,24 @@
+package com.sclass.backoffice.commission.usecase
+
+import com.sclass.backoffice.commission.dto.CommissionDetailResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
+import com.sclass.domain.domains.commission.adaptor.CommissionFileAdaptor
+import com.sclass.domain.domains.commission.adaptor.CommissionTopicAdaptor
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetCommissionDetailUseCase(
+    private val commissionAdaptor: CommissionAdaptor,
+    private val commissionTopicAdaptor: CommissionTopicAdaptor,
+    private val commissionFileAdaptor: CommissionFileAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(commissionId: Long): CommissionDetailResponse {
+        val commission = commissionAdaptor.findById(commissionId)
+        val topics = commissionTopicAdaptor.findByCommissionId(commission.id)
+        val files = commissionFileAdaptor.findByCommissionId(commission.id)
+
+        return CommissionDetailResponse.from(commission, topics, files)
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/controller/EnrollmentController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/controller/EnrollmentController.kt
@@ -1,6 +1,7 @@
 package com.sclass.backoffice.enrollment.controller
 
 import com.sclass.backoffice.enrollment.dto.CreateCourseFromEnrollmentRequest
+import com.sclass.backoffice.enrollment.dto.EnrollmentDetailResponse
 import com.sclass.backoffice.enrollment.dto.EnrollmentLessonListResponse
 import com.sclass.backoffice.enrollment.dto.EnrollmentPageResponse
 import com.sclass.backoffice.enrollment.dto.EnrollmentResponse
@@ -9,6 +10,7 @@ import com.sclass.backoffice.enrollment.dto.GrantEnrollmentRequest
 import com.sclass.backoffice.enrollment.dto.GrantMembershipEnrollmentRequest
 import com.sclass.backoffice.enrollment.usecase.CreateCourseFromEnrollmentFacade
 import com.sclass.backoffice.enrollment.usecase.ExtendMembershipExpireUseCase
+import com.sclass.backoffice.enrollment.usecase.GetEnrollmentDetailUseCase
 import com.sclass.backoffice.enrollment.usecase.GetEnrollmentLessonListUseCase
 import com.sclass.backoffice.enrollment.usecase.GetEnrollmentListUseCase
 import com.sclass.backoffice.enrollment.usecase.GrantEnrollmentUseCase
@@ -35,6 +37,7 @@ class EnrollmentController(
     private val grantEnrollmentUseCase: GrantEnrollmentUseCase,
     private val grantMembershipEnrollmentUseCase: GrantMembershipEnrollmentUseCase,
     private val extendMembershipExpireUseCase: ExtendMembershipExpireUseCase,
+    private val getEnrollmentDetailUseCase: GetEnrollmentDetailUseCase,
     private val getEnrollmentListUseCase: GetEnrollmentListUseCase,
     private val getEnrollmentLessonListUseCase: GetEnrollmentLessonListUseCase,
     private val createCourseFromEnrollmentFacade: CreateCourseFromEnrollmentFacade,
@@ -61,6 +64,11 @@ class EnrollmentController(
         @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
     ): ApiResponse<EnrollmentPageResponse> =
         ApiResponse.success(getEnrollmentListUseCase.execute(studentUserId, teacherUserId, courseId, status, pageable))
+
+    @GetMapping("/{enrollmentId}")
+    fun getEnrollmentDetail(
+        @PathVariable enrollmentId: Long,
+    ): ApiResponse<EnrollmentDetailResponse> = ApiResponse.success(getEnrollmentDetailUseCase.execute(enrollmentId))
 
     @PatchMapping("/{enrollmentId}/expire-at")
     fun extendMembershipExpire(

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/EnrollmentDetailResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/EnrollmentDetailResponse.kt
@@ -1,0 +1,46 @@
+package com.sclass.backoffice.enrollment.dto
+
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.domain.EnrollmentStatus
+import com.sclass.domain.domains.enrollment.domain.EnrollmentType
+import com.sclass.domain.domains.product.domain.Product
+import com.sclass.domain.domains.product.domain.ProductType
+import com.sclass.domain.domains.product.domain.toProductType
+import java.time.LocalDateTime
+
+data class EnrollmentDetailResponse(
+    val id: Long,
+    val courseId: Long?,
+    val productId: String?,
+    val productName: String?,
+    val productType: ProductType?,
+    val studentUserId: String,
+    val enrollmentType: EnrollmentType,
+    val tuitionAmountWon: Int,
+    val status: EnrollmentStatus,
+    val startAt: LocalDateTime?,
+    val endAt: LocalDateTime?,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun from(
+            enrollment: Enrollment,
+            product: Product?,
+        ) = EnrollmentDetailResponse(
+            id = enrollment.id,
+            courseId = enrollment.courseId,
+            productId = enrollment.productId,
+            productName = product?.name,
+            productType = product?.toProductType(),
+            studentUserId = enrollment.studentUserId,
+            enrollmentType = enrollment.enrollmentType,
+            tuitionAmountWon = enrollment.tuitionAmountWon,
+            status = enrollment.status,
+            startAt = enrollment.startAt,
+            endAt = enrollment.endAt,
+            createdAt = enrollment.createdAt,
+            updatedAt = enrollment.updatedAt,
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentDetailUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentDetailUseCase.kt
@@ -1,0 +1,21 @@
+package com.sclass.backoffice.enrollment.usecase
+
+import com.sclass.backoffice.enrollment.dto.EnrollmentDetailResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetEnrollmentDetailUseCase(
+    private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val productAdaptor: ProductAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(enrollmentId: Long): EnrollmentDetailResponse {
+        val enrollment = enrollmentAdaptor.findById(enrollmentId)
+        val product = enrollment.productId?.let { runCatching { productAdaptor.findById(it) }.getOrNull() }
+
+        return EnrollmentDetailResponse.from(enrollment, product)
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentDetailUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentDetailUseCase.kt
@@ -4,6 +4,8 @@ import com.sclass.backoffice.enrollment.dto.EnrollmentDetailResponse
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.Product
+import com.sclass.domain.domains.product.exception.ProductNotFoundException
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
@@ -14,8 +16,15 @@ class GetEnrollmentDetailUseCase(
     @Transactional(readOnly = true)
     fun execute(enrollmentId: Long): EnrollmentDetailResponse {
         val enrollment = enrollmentAdaptor.findById(enrollmentId)
-        val product = enrollment.productId?.let { runCatching { productAdaptor.findById(it) }.getOrNull() }
+        val product = enrollment.productId?.let { findProductOrNull(it) }
 
         return EnrollmentDetailResponse.from(enrollment, product)
     }
+
+    private fun findProductOrNull(productId: String): Product? =
+        try {
+            productAdaptor.findById(productId)
+        } catch (_: ProductNotFoundException) {
+            null
+        }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentDetailUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentDetailUseCase.kt
@@ -4,8 +4,6 @@ import com.sclass.backoffice.enrollment.dto.EnrollmentDetailResponse
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
 import com.sclass.domain.domains.product.adaptor.ProductAdaptor
-import com.sclass.domain.domains.product.domain.Product
-import com.sclass.domain.domains.product.exception.ProductNotFoundException
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
@@ -16,15 +14,8 @@ class GetEnrollmentDetailUseCase(
     @Transactional(readOnly = true)
     fun execute(enrollmentId: Long): EnrollmentDetailResponse {
         val enrollment = enrollmentAdaptor.findById(enrollmentId)
-        val product = enrollment.productId?.let { findProductOrNull(it) }
+        val product = enrollment.productId?.let { productAdaptor.findByIdOrNull(it) }
 
         return EnrollmentDetailResponse.from(enrollment, product)
     }
-
-    private fun findProductOrNull(productId: String): Product? =
-        try {
-            productAdaptor.findById(productId)
-        } catch (_: ProductNotFoundException) {
-            null
-        }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/controller/LessonController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/controller/LessonController.kt
@@ -2,9 +2,13 @@ package com.sclass.backoffice.lesson.controller
 
 import com.sclass.backoffice.lesson.dto.LessonResponse
 import com.sclass.backoffice.lesson.dto.UpdateSubstituteTeacherRequest
+import com.sclass.backoffice.lesson.usecase.GetLessonDetailUseCase
 import com.sclass.backoffice.lesson.usecase.UpdateSubstituteTeacherUseCase
+import com.sclass.backoffice.lessonReport.dto.LessonReportResponse
+import com.sclass.backoffice.lessonReport.usecase.GetLessonReportUseCase
 import com.sclass.common.dto.ApiResponse
 import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
@@ -15,10 +19,22 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/lessons")
 class LessonController(
     private val updateSubstituteTeacherUseCase: UpdateSubstituteTeacherUseCase,
+    private val getLessonDetailUseCase: GetLessonDetailUseCase,
+    private val getLessonReportUseCase: GetLessonReportUseCase,
 ) {
+    @GetMapping("/{lessonId}")
+    fun getDetail(
+        @PathVariable lessonId: Long,
+    ): ApiResponse<LessonResponse> = ApiResponse.success(getLessonDetailUseCase.execute(lessonId))
+
     @PatchMapping("/{lessonId}/substitute-teacher")
     fun updateSubstitute(
         @PathVariable lessonId: Long,
         @Valid @RequestBody request: UpdateSubstituteTeacherRequest,
     ): ApiResponse<LessonResponse> = ApiResponse.success(updateSubstituteTeacherUseCase.execute(lessonId, request))
+
+    @GetMapping("/{lessonId}/report")
+    fun getReport(
+        @PathVariable lessonId: Long,
+    ): ApiResponse<LessonReportResponse> = ApiResponse.success(getLessonReportUseCase.execute(lessonId))
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/dto/LessonResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/dto/LessonResponse.kt
@@ -9,6 +9,7 @@ data class LessonResponse(
     val id: Long,
     val name: String,
     val lessonType: LessonType,
+    val lessonNumber: Int?,
     val enrollmentId: Long?,
     val sourceCommissionId: Long?,
     val studentUserId: String,
@@ -19,6 +20,8 @@ data class LessonResponse(
     val scheduledAt: LocalDateTime?,
     val startedAt: LocalDateTime?,
     val completedAt: LocalDateTime?,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
 ) {
     companion object {
         fun from(lesson: Lesson) =
@@ -26,6 +29,7 @@ data class LessonResponse(
                 id = lesson.id,
                 name = lesson.name,
                 lessonType = lesson.lessonType,
+                lessonNumber = lesson.lessonNumber,
                 enrollmentId = lesson.enrollmentId,
                 sourceCommissionId = lesson.sourceCommissionId,
                 studentUserId = lesson.studentUserId,
@@ -36,6 +40,8 @@ data class LessonResponse(
                 scheduledAt = lesson.scheduledAt,
                 startedAt = lesson.startedAt,
                 completedAt = lesson.completedAt,
+                createdAt = lesson.createdAt,
+                updatedAt = lesson.updatedAt,
             )
     }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/GetLessonDetailUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/GetLessonDetailUseCase.kt
@@ -1,0 +1,17 @@
+package com.sclass.backoffice.lesson.usecase
+
+import com.sclass.backoffice.lesson.dto.LessonResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetLessonDetailUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(lessonId: Long): LessonResponse {
+        val lesson = lessonAdaptor.findById(lessonId)
+        return LessonResponse.from(lesson)
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lessonReport/usecase/GetLessonReportUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lessonReport/usecase/GetLessonReportUseCase.kt
@@ -1,0 +1,20 @@
+package com.sclass.backoffice.lessonReport.usecase
+
+import com.sclass.backoffice.lessonReport.dto.LessonReportResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.lessonReport.adaptor.LessonReportAdaptor
+import com.sclass.domain.domains.lessonReport.adaptor.LessonReportFileAdaptor
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetLessonReportUseCase(
+    private val lessonReportAdaptor: LessonReportAdaptor,
+    private val lessonReportFileAdaptor: LessonReportFileAdaptor,
+) {
+    @Transactional(readOnly = true)
+    fun execute(lessonId: Long): LessonReportResponse {
+        val report = lessonReportAdaptor.findByLesson(lessonId)
+        val fileIds = lessonReportFileAdaptor.findByLessonReportId(report.id).map { it.file.id }
+        return LessonReportResponse.of(report, fileIds)
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentDetailUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/enrollment/usecase/GetEnrollmentDetailUseCaseTest.kt
@@ -1,0 +1,77 @@
+package com.sclass.backoffice.enrollment.usecase
+
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.product.adaptor.ProductAdaptor
+import com.sclass.domain.domains.product.domain.ProductType
+import com.sclass.domain.domains.product.domain.RollingMembershipProduct
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class GetEnrollmentDetailUseCaseTest {
+    private lateinit var enrollmentAdaptor: EnrollmentAdaptor
+    private lateinit var productAdaptor: ProductAdaptor
+    private lateinit var useCase: GetEnrollmentDetailUseCase
+
+    @BeforeEach
+    fun setUp() {
+        enrollmentAdaptor = mockk()
+        productAdaptor = mockk()
+        useCase = GetEnrollmentDetailUseCase(enrollmentAdaptor, productAdaptor)
+    }
+
+    @Test
+    fun `상품이 존재하면 enrollment 상세에 상품 정보를 포함한다`() {
+        val enrollment = createMembershipEnrollment()
+        val product =
+            RollingMembershipProduct(
+                name = "30일 멤버십",
+                priceWon = 99000,
+                coinPackageId = "coin-package-id-0000000001",
+                periodDays = 30,
+            )
+
+        every { enrollmentAdaptor.findById(1L) } returns enrollment
+        every { productAdaptor.findByIdOrNull("product-id-000000000000000001") } returns product
+
+        val result = useCase.execute(1L)
+
+        assertAll(
+            { assertEquals("product-id-000000000000000001", result.productId) },
+            { assertEquals("30일 멤버십", result.productName) },
+            { assertEquals(ProductType.ROLLING_MEMBERSHIP, result.productType) },
+        )
+    }
+
+    @Test
+    fun `상품이 없어도 enrollment 상세를 반환한다`() {
+        val enrollment = createMembershipEnrollment()
+
+        every { enrollmentAdaptor.findById(1L) } returns enrollment
+        every { productAdaptor.findByIdOrNull("product-id-000000000000000001") } returns null
+
+        val result = useCase.execute(1L)
+
+        assertAll(
+            { assertEquals("product-id-000000000000000001", result.productId) },
+            { assertNull(result.productName) },
+            { assertNull(result.productType) },
+        )
+    }
+
+    private fun createMembershipEnrollment(): Enrollment =
+        Enrollment.createMembershipByGrant(
+            productId = "product-id-000000000000000001",
+            studentUserId = "student-id-000000000000000001",
+            grantedByUserId = "admin-id-00000000000000000001",
+            grantReason = "테스트 지급",
+            startAt = LocalDateTime.of(2026, 1, 1, 0, 0),
+            endAt = LocalDateTime.of(2026, 1, 31, 23, 59),
+        )
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/product/course/controller/CourseProductControllerIntegrationTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/product/course/controller/CourseProductControllerIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.common.jwt.JwtTokenProvider
 import com.sclass.domain.domains.product.domain.CourseProduct
 import com.sclass.domain.domains.product.repository.ProductRepository
+import com.sclass.domain.domains.teacher.repository.TeacherRepository
 import com.sclass.domain.domains.user.domain.AuthProvider
 import com.sclass.domain.domains.user.domain.User
 import com.sclass.domain.domains.user.repository.UserRepository
@@ -38,6 +39,9 @@ class CourseProductControllerIntegrationTest {
     private lateinit var userRoleRepository: UserRoleRepository
 
     @Autowired
+    private lateinit var teacherRepository: TeacherRepository
+
+    @Autowired
     private lateinit var jwtTokenProvider: JwtTokenProvider
 
     @Autowired
@@ -49,6 +53,7 @@ class CourseProductControllerIntegrationTest {
     @BeforeEach
     fun setUp() {
         productRepository.deleteAll()
+        teacherRepository.deleteAll()
         userRoleRepository.deleteAll()
         userRepository.deleteAll()
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/controller/CommissionController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/controller/CommissionController.kt
@@ -10,6 +10,7 @@ import com.sclass.supporters.commission.dto.CommissionTopicListResponse
 import com.sclass.supporters.commission.dto.CommissionTopicResponse
 import com.sclass.supporters.commission.dto.CreateCommissionRequest
 import com.sclass.supporters.commission.dto.CreateSupportTicketRequest
+import com.sclass.supporters.commission.dto.DeliverSubmissionRequest
 import com.sclass.supporters.commission.dto.ProposeTopicsRequest
 import com.sclass.supporters.commission.dto.SelectTopicRequest
 import com.sclass.supporters.commission.dto.SupportTicketListResponse
@@ -17,6 +18,8 @@ import com.sclass.supporters.commission.dto.SupportTicketResponse
 import com.sclass.supporters.commission.dto.TransitionStatusRequest
 import com.sclass.supporters.commission.usecase.CreateCommissionUseCase
 import com.sclass.supporters.commission.usecase.CreateSupportTicketUseCase
+import com.sclass.supporters.commission.usecase.DeleteCommissionFileUseCase
+import com.sclass.supporters.commission.usecase.DeliverSubmissionUseCase
 import com.sclass.supporters.commission.usecase.GetCommissionDetailUseCase
 import com.sclass.supporters.commission.usecase.GetCommissionLessonUseCase
 import com.sclass.supporters.commission.usecase.GetCommissionListUseCase
@@ -27,6 +30,7 @@ import com.sclass.supporters.commission.usecase.SelectTopicUseCase
 import com.sclass.supporters.commission.usecase.TransitionCommissionStatusUseCase
 import com.sclass.supporters.lesson.dto.LessonResponse
 import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -48,6 +52,8 @@ class CommissionController(
     private val createSupportTicketUseCase: CreateSupportTicketUseCase,
     private val getSupportTicketsUseCase: GetSupportTicketsUseCase,
     private val getCommissionLessonUseCase: GetCommissionLessonUseCase,
+    private val deliverSubmissionUseCase: DeliverSubmissionUseCase,
+    private val deleteCommissionFileUseCase: DeleteCommissionFileUseCase,
 ) {
     @PostMapping
     fun create(
@@ -120,4 +126,25 @@ class CommissionController(
         @CurrentUserId userId: String,
         @PathVariable commissionId: Long,
     ): ApiResponse<LessonResponse> = ApiResponse.success(getCommissionLessonUseCase.execute(userId, commissionId))
+
+    @PostMapping("/{commissionId}/submissions")
+    fun deliverSubmission(
+        @CurrentUserId userId: String,
+        @PathVariable commissionId: Long,
+        @Valid @RequestBody request: DeliverSubmissionRequest,
+    ): ApiResponse<CommissionResponse> = ApiResponse.success(deliverSubmissionUseCase.execute(userId, commissionId, request))
+
+    @DeleteMapping("/{commissionId}/files/{commissionFileId}")
+    fun deleteFile(
+        @CurrentUserId userId: String,
+        @PathVariable commissionId: Long,
+        @PathVariable commissionFileId: Long,
+    ): ApiResponse<CommissionResponse> =
+        ApiResponse.success(
+            deleteCommissionFileUseCase.execute(
+                userId,
+                commissionId,
+                commissionFileId,
+            ),
+        )
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/dto/DeliverSubmissionRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/dto/DeliverSubmissionRequest.kt
@@ -1,0 +1,8 @@
+package com.sclass.supporters.commission.dto
+
+import jakarta.validation.constraints.NotEmpty
+
+data class DeliverSubmissionRequest(
+    @field:NotEmpty
+    val fileIds: List<String>,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/CreateCommissionUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/CreateCommissionUseCase.kt
@@ -19,6 +19,8 @@ import com.sclass.supporters.commission.event.CommissionAssignedEvent
 import com.sclass.supporters.commission.scheduler.CommissionReminderScheduler
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @UseCase
@@ -32,13 +34,16 @@ class CreateCommissionUseCase(
     private val coinDomainService: CoinDomainService,
     private val commissionPolicyAdaptor: CommissionPolicyAdaptor,
     private val enrollmentAdaptor: EnrollmentAdaptor,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     @Transactional
     fun execute(
         studentUserId: String,
         request: CreateCommissionRequest,
     ): CommissionResponse {
-        if (!enrollmentAdaptor.hasActiveMembershipEnrollment(studentUserId)) throw NoActiveMembershipException()
+        if (!enrollmentAdaptor.hasActiveMembershipEnrollment(studentUserId, LocalDateTime.now(clock))) {
+            throw NoActiveMembershipException()
+        }
 
         val assignment =
             teacherAssignmentAdaptor.findActiveByStudentUserIdAndPlatformAndOrganizationId(

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/DeleteCommissionFileUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/DeleteCommissionFileUseCase.kt
@@ -1,0 +1,51 @@
+package com.sclass.supporters.commission.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.BusinessException
+import com.sclass.common.exception.GlobalErrorCode
+import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
+import com.sclass.domain.domains.commission.adaptor.CommissionFileAdaptor
+import com.sclass.domain.domains.commission.exception.CommissionErrorCode
+import com.sclass.domain.domains.file.domain.FileType
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.exception.LessonAlreadyCompletedException
+import com.sclass.supporters.commission.dto.CommissionResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class DeleteCommissionFileUseCase(
+    private val commissionAdaptor: CommissionAdaptor,
+    private val commissionFileAdaptor: CommissionFileAdaptor,
+    private val lessonAdaptor: LessonAdaptor,
+) {
+    @Transactional
+    fun execute(
+        teacherUserId: String,
+        commissionId: Long,
+        commissionFileId: Long,
+    ): CommissionResponse {
+        val commission = commissionAdaptor.findById(commissionId)
+        if (commission.teacherUserId != teacherUserId) {
+            throw BusinessException(CommissionErrorCode.UNAUTHORIZED_ACCESS)
+        }
+
+        commission.acceptedLessonId?.let { lessonId ->
+            val lesson = lessonAdaptor.findById(lessonId)
+            if (lesson.status == LessonStatus.COMPLETED) throw LessonAlreadyCompletedException()
+        }
+
+        val commissionFile = commissionFileAdaptor.findById(commissionFileId)
+        if (commissionFile.commission.id != commissionId) {
+            throw BusinessException(CommissionErrorCode.COMMISSION_FILE_NOT_FOUND)
+        }
+        if (commissionFile.file.fileType != FileType.TASK_SUBMISSION) {
+            throw BusinessException(GlobalErrorCode.INVALID_INPUT)
+        }
+
+        commissionFileAdaptor.delete(commissionFile)
+
+        val commissionFiles = commissionFileAdaptor.findByCommissionId(commissionId)
+        return CommissionResponse.from(commission, commissionFiles)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/DeleteCommissionFileUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/DeleteCommissionFileUseCase.kt
@@ -6,6 +6,7 @@ import com.sclass.common.exception.GlobalErrorCode
 import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
 import com.sclass.domain.domains.commission.adaptor.CommissionFileAdaptor
 import com.sclass.domain.domains.commission.exception.CommissionErrorCode
+import com.sclass.domain.domains.commission.exception.CommissionUnauthorizedAccessException
 import com.sclass.domain.domains.file.domain.FileType
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.domain.LessonStatus
@@ -26,14 +27,7 @@ class DeleteCommissionFileUseCase(
         commissionFileId: Long,
     ): CommissionResponse {
         val commission = commissionAdaptor.findById(commissionId)
-        if (commission.teacherUserId != teacherUserId) {
-            throw BusinessException(CommissionErrorCode.UNAUTHORIZED_ACCESS)
-        }
-
-        commission.acceptedLessonId?.let { lessonId ->
-            val lesson = lessonAdaptor.findById(lessonId)
-            if (lesson.status == LessonStatus.COMPLETED) throw LessonAlreadyCompletedException()
-        }
+        authorizeTeacher(teacherUserId, commission)
 
         val commissionFile = commissionFileAdaptor.findById(commissionFileId)
         if (commissionFile.commission.id != commissionId) {
@@ -47,5 +41,24 @@ class DeleteCommissionFileUseCase(
 
         val commissionFiles = commissionFileAdaptor.findByCommissionId(commissionId)
         return CommissionResponse.from(commission, commissionFiles)
+    }
+
+    private fun authorizeTeacher(
+        teacherUserId: String,
+        commission: com.sclass.domain.domains.commission.domain.Commission,
+    ) {
+        val lessonId = commission.acceptedLessonId
+        if (lessonId == null) {
+            if (commission.teacherUserId != teacherUserId) {
+                throw CommissionUnauthorizedAccessException()
+            }
+            return
+        }
+
+        val lesson = lessonAdaptor.findById(lessonId)
+        if (!lesson.isTeacher(teacherUserId)) {
+            throw CommissionUnauthorizedAccessException()
+        }
+        if (lesson.status == LessonStatus.COMPLETED) throw LessonAlreadyCompletedException()
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/DeliverSubmissionUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/DeliverSubmissionUseCase.kt
@@ -44,9 +44,6 @@ class DeliverSubmissionUseCase(
         request: DeliverSubmissionRequest,
     ): CommissionResponse {
         val commission = commissionAdaptor.findById(commissionId)
-        if (commission.teacherUserId != teacherUserId) {
-            throw BusinessException(CommissionErrorCode.UNAUTHORIZED_ACCESS)
-        }
         val lesson = resolveDeliverableLesson(teacherUserId, commission.acceptedLessonId)
         val files = findDeliverableFiles(teacherUserId, request.fileIds)
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/DeliverSubmissionUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/DeliverSubmissionUseCase.kt
@@ -1,0 +1,232 @@
+package com.sclass.supporters.commission.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.BusinessException
+import com.sclass.common.exception.GlobalErrorCode
+import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
+import com.sclass.domain.domains.commission.adaptor.CommissionFileAdaptor
+import com.sclass.domain.domains.commission.domain.Commission
+import com.sclass.domain.domains.commission.domain.CommissionFile
+import com.sclass.domain.domains.commission.exception.CommissionErrorCode
+import com.sclass.domain.domains.file.adaptor.FileAdaptor
+import com.sclass.domain.domains.file.domain.File
+import com.sclass.domain.domains.file.domain.FileType
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.exception.LessonInvalidStatusTransitionException
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.domain.domains.lessonReport.adaptor.LessonReportAdaptor
+import com.sclass.domain.domains.lessonReport.adaptor.LessonReportFileAdaptor
+import com.sclass.domain.domains.lessonReport.domain.LessonReport
+import com.sclass.domain.domains.lessonReport.domain.LessonReportFile
+import com.sclass.domain.domains.lessonReport.domain.LessonReportStatus
+import com.sclass.domain.domains.lessonReport.exception.LessonReportAlreadyApprovedException
+import com.sclass.supporters.commission.dto.CommissionResponse
+import com.sclass.supporters.commission.dto.DeliverSubmissionRequest
+import com.sclass.supporters.commission.scheduler.CommissionReminderScheduler
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class DeliverSubmissionUseCase(
+    private val commissionAdaptor: CommissionAdaptor,
+    private val commissionFileAdaptor: CommissionFileAdaptor,
+    private val fileAdaptor: FileAdaptor,
+    private val commissionReminderScheduler: CommissionReminderScheduler,
+    private val lessonAdaptor: LessonAdaptor,
+    private val lessonReportAdaptor: LessonReportAdaptor,
+    private val lessonReportFileAdaptor: LessonReportFileAdaptor,
+) {
+    @Transactional
+    fun execute(
+        teacherUserId: String,
+        commissionId: Long,
+        request: DeliverSubmissionRequest,
+    ): CommissionResponse {
+        val commission = commissionAdaptor.findById(commissionId)
+        if (commission.teacherUserId != teacherUserId) {
+            throw BusinessException(CommissionErrorCode.UNAUTHORIZED_ACCESS)
+        }
+        val lesson = resolveDeliverableLesson(teacherUserId, commission.acceptedLessonId)
+        val files = findDeliverableFiles(teacherUserId, request.fileIds)
+
+        submitLessonReportForReview(
+            teacherUserId = teacherUserId,
+            lesson = lesson,
+            commissionId = commission.id,
+            subject = commission.guideInfo.subject,
+            files = files,
+        )
+
+        val commissionFiles = replaceSubmissionCommissionFiles(commission, files)
+        commissionReminderScheduler.cancelAllReminders(commissionId)
+
+        return CommissionResponse.from(commission, commissionFiles)
+    }
+
+    private fun findDeliverableFiles(
+        teacherUserId: String,
+        fileIds: List<String>,
+    ): List<File> {
+        if (fileIds.size != fileIds.toSet().size) {
+            throw BusinessException(GlobalErrorCode.INVALID_INPUT)
+        }
+
+        val files = fileAdaptor.findAllByIds(fileIds)
+        if (files.size != fileIds.size) {
+            throw BusinessException(GlobalErrorCode.INVALID_INPUT)
+        }
+
+        val filesById = files.associateBy { it.id }
+        val orderedFiles =
+            fileIds.map { fileId ->
+                filesById[fileId] ?: throw BusinessException(GlobalErrorCode.INVALID_INPUT)
+            }
+        if (orderedFiles.any { it.uploadedBy != teacherUserId || it.fileType != FileType.TASK_SUBMISSION }) {
+            throw BusinessException(GlobalErrorCode.INVALID_INPUT)
+        }
+
+        return orderedFiles
+    }
+
+    private fun replaceSubmissionCommissionFiles(
+        commission: Commission,
+        files: List<File>,
+    ): List<CommissionFile> {
+        val existingCommissionFiles = commissionFileAdaptor.findByCommissionId(commission.id)
+        val existingSubmissionFiles = existingCommissionFiles.filter { it.file.fileType == FileType.TASK_SUBMISSION }
+        val existingSubmissionFilesByFileId = existingSubmissionFiles.groupBy { it.file.id }
+        val requestedFileIds = files.map { it.id }.toSet()
+        val retainedSubmissionFilesByFileId =
+            existingSubmissionFilesByFileId
+                .filterKeys { it in requestedFileIds }
+                .mapValues { (_, commissionFiles) -> commissionFiles.first() }
+
+        val obsoleteSubmissionFiles =
+            existingSubmissionFiles.filterNot { it.file.id in requestedFileIds } +
+                existingSubmissionFilesByFileId
+                    .filterKeys { it in requestedFileIds }
+                    .values
+                    .flatMap { commissionFiles -> commissionFiles.drop(1) }
+        if (obsoleteSubmissionFiles.isNotEmpty()) {
+            commissionFileAdaptor.deleteAll(obsoleteSubmissionFiles)
+        }
+
+        val newFiles = files.filterNot { it.id in retainedSubmissionFilesByFileId }
+        val savedSubmissionFiles =
+            if (newFiles.isEmpty()) {
+                emptyList()
+            } else {
+                commissionFileAdaptor.saveAll(
+                    newFiles.map { file -> CommissionFile(commission = commission, file = file) },
+                )
+            }
+
+        val savedSubmissionFilesByFileId = savedSubmissionFiles.associateBy { it.file.id }
+        val orderedSubmissionFiles =
+            files.map { file ->
+                retainedSubmissionFilesByFileId[file.id]
+                    ?: savedSubmissionFilesByFileId[file.id]
+                    ?: error("Saved commission file is missing for fileId=${file.id}")
+            }
+
+        return existingCommissionFiles.filter { it.file.fileType != FileType.TASK_SUBMISSION } + orderedSubmissionFiles
+    }
+
+    private fun resolveDeliverableLesson(
+        teacherUserId: String,
+        lessonId: Long?,
+    ): Lesson {
+        val lesson =
+            lessonId?.let { lessonAdaptor.findById(it) }
+                ?: throw BusinessException(CommissionErrorCode.INVALID_STATUS_TRANSITION)
+        if (!lesson.isTeacher(teacherUserId)) throw LessonUnauthorizedAccessException()
+
+        when (lesson.status) {
+            LessonStatus.SCHEDULED, LessonStatus.IN_PROGRESS, LessonStatus.COMPLETED -> Unit
+            LessonStatus.CANCELLED -> throw LessonInvalidStatusTransitionException()
+        }
+        return lesson
+    }
+
+    private fun submitLessonReportForReview(
+        teacherUserId: String,
+        lesson: Lesson,
+        commissionId: Long,
+        subject: String,
+        files: List<File>,
+    ) {
+        when (lesson.status) {
+            LessonStatus.SCHEDULED, LessonStatus.IN_PROGRESS -> {
+                lesson.complete(teacherUserId)
+                lessonAdaptor.save(lesson)
+            }
+            LessonStatus.COMPLETED -> Unit
+            LessonStatus.CANCELLED -> throw LessonInvalidStatusTransitionException()
+        }
+
+        val content =
+            buildAutoLessonReportContent(
+                commissionId = commissionId,
+                subject = subject,
+                files = files,
+            )
+        val report = lessonReportAdaptor.findByLessonOrNull(lesson.id)
+
+        when (report?.status) {
+            null -> {
+                val savedReport =
+                    lessonReportAdaptor.save(
+                        LessonReport(
+                            lessonId = lesson.id,
+                            submittedByUserId = teacherUserId,
+                            content = content,
+                        ),
+                    )
+                replaceLessonReportFiles(savedReport, files)
+            }
+            LessonReportStatus.PENDING_REVIEW -> {
+                report.content = content
+                lessonReportAdaptor.save(report)
+                replaceLessonReportFiles(report, files)
+            }
+            LessonReportStatus.REJECTED -> {
+                report.resubmit(content)
+                lessonReportAdaptor.save(report)
+                replaceLessonReportFiles(report, files)
+            }
+            LessonReportStatus.APPROVED -> throw LessonReportAlreadyApprovedException()
+        }
+    }
+
+    private fun replaceLessonReportFiles(
+        report: LessonReport,
+        files: List<File>,
+    ) {
+        lessonReportFileAdaptor.deleteAllByLessonReportId(report.id)
+        if (files.isNotEmpty()) {
+            lessonReportFileAdaptor.saveAll(
+                files.map { file -> LessonReportFile(lessonReport = report, file = file) },
+            )
+        }
+    }
+
+    private fun buildAutoLessonReportContent(
+        commissionId: Long,
+        subject: String,
+        files: List<File>,
+    ): String {
+        val fileLines =
+            files.joinToString("\n") { file ->
+                "- ${file.originalFilename}"
+            }
+        return """
+            수행평가 수업이 완료되어 자동 생성된 수업 완료 기록입니다.
+
+            의뢰 ID: $commissionId
+            과목: $subject
+            최종 전달 파일:
+            $fileLines
+            """.trimIndent()
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/SelectTopicUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/SelectTopicUseCase.kt
@@ -16,6 +16,8 @@ import com.sclass.supporters.commission.dto.CommissionTopicResponse
 import com.sclass.supporters.commission.dto.SelectTopicRequest
 import com.sclass.supporters.commission.scheduler.CommissionReminderScheduler
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
 
 @UseCase
 class SelectTopicUseCase(
@@ -24,6 +26,7 @@ class SelectTopicUseCase(
     private val lessonAdaptor: LessonAdaptor,
     private val enrollmentAdaptor: EnrollmentAdaptor,
     private val commissionReminderScheduler: CommissionReminderScheduler,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     @Transactional
     fun execute(
@@ -53,7 +56,10 @@ class SelectTopicUseCase(
         }
 
         val membershipEnrollment =
-            enrollmentAdaptor.findActiveMembershipEnrollment(commission.studentUserId)
+            enrollmentAdaptor.findActiveMembershipEnrollment(
+                studentUserId = commission.studentUserId,
+                now = LocalDateTime.now(clock),
+            )
                 ?: throw NoActiveMembershipException()
 
         val lesson =

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/SelectTopicUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/SelectTopicUseCase.kt
@@ -5,7 +5,10 @@ import com.sclass.common.exception.BusinessException
 import com.sclass.common.exception.GlobalErrorCode
 import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
 import com.sclass.domain.domains.commission.adaptor.CommissionTopicAdaptor
+import com.sclass.domain.domains.commission.domain.CommissionStatus
 import com.sclass.domain.domains.commission.exception.CommissionErrorCode
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.exception.NoActiveMembershipException
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.lesson.domain.LessonType
@@ -19,6 +22,7 @@ class SelectTopicUseCase(
     private val commissionAdaptor: CommissionAdaptor,
     private val commissionTopicAdaptor: CommissionTopicAdaptor,
     private val lessonAdaptor: LessonAdaptor,
+    private val enrollmentAdaptor: EnrollmentAdaptor,
     private val commissionReminderScheduler: CommissionReminderScheduler,
 ) {
     @Transactional
@@ -44,10 +48,19 @@ class SelectTopicUseCase(
             throw BusinessException(CommissionErrorCode.COMMISSION_TOPIC_NOT_FOUND)
         }
 
+        if (commission.status != CommissionStatus.TOPIC_PROPOSED) {
+            throw BusinessException(CommissionErrorCode.INVALID_STATUS_TRANSITION)
+        }
+
+        val membershipEnrollment =
+            enrollmentAdaptor.findActiveMembershipEnrollment(commission.studentUserId)
+                ?: throw NoActiveMembershipException()
+
         val lesson =
             lessonAdaptor.save(
                 Lesson(
                     lessonType = LessonType.COMMISSION,
+                    enrollmentId = membershipEnrollment.id,
                     sourceCommissionId = commission.id,
                     studentUserId = commission.studentUserId,
                     assignedTeacherUserId = commission.teacherUserId,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/PreparePaymentUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/payment/usecase/PreparePaymentUseCase.kt
@@ -11,19 +11,24 @@ import com.sclass.domain.domains.payment.domain.PaymentTargetType
 import com.sclass.supporters.payment.dto.PreparePaymentRequest
 import com.sclass.supporters.payment.dto.PreparePaymentResponse
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
 
 @UseCase
 class PreparePaymentUseCase(
     private val coinPackageAdaptor: CoinPackageAdaptor,
     private val enrollmentAdaptor: EnrollmentAdaptor,
     private val paymentAdaptor: PaymentAdaptor,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     @Transactional
     fun execute(
         userId: String,
         request: PreparePaymentRequest,
     ): PreparePaymentResponse {
-        if (!enrollmentAdaptor.hasActiveMembershipEnrollment(userId)) throw NoActiveMembershipException()
+        if (!enrollmentAdaptor.hasActiveMembershipEnrollment(userId, LocalDateTime.now(clock))) {
+            throw NoActiveMembershipException()
+        }
         val coinPackage = coinPackageAdaptor.findById(request.coinPackageId)
 
         val payment =

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/CreateCommissionUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/CreateCommissionUseCaseTest.kt
@@ -31,6 +31,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.context.ApplicationEventPublisher
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 
 class CreateCommissionUseCaseTest {
     private lateinit var commissionAdaptor: CommissionAdaptor
@@ -43,6 +46,7 @@ class CreateCommissionUseCaseTest {
     private lateinit var commissionPolicyAdaptor: CommissionPolicyAdaptor
     private lateinit var enrollmentAdaptor: EnrollmentAdaptor
     private lateinit var useCase: CreateCommissionUseCase
+    private val fixedClock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneId.of("UTC"))
 
     @BeforeEach
     fun setUp() {
@@ -55,7 +59,7 @@ class CreateCommissionUseCaseTest {
         coinDomainService = mockk(relaxed = true)
         commissionPolicyAdaptor = mockk()
         enrollmentAdaptor = mockk()
-        every { enrollmentAdaptor.hasActiveMembershipEnrollment(any()) } returns true
+        every { enrollmentAdaptor.hasActiveMembershipEnrollment(any(), any()) } returns true
         useCase =
             CreateCommissionUseCase(
                 commissionAdaptor,
@@ -67,6 +71,7 @@ class CreateCommissionUseCaseTest {
                 coinDomainService,
                 commissionPolicyAdaptor,
                 enrollmentAdaptor,
+                fixedClock,
             )
     }
 
@@ -127,7 +132,7 @@ class CreateCommissionUseCaseTest {
 
     @Test
     fun `활성 멤버십이 없으면 의뢰 생성이 거부된다`() {
-        every { enrollmentAdaptor.hasActiveMembershipEnrollment(any()) } returns false
+        every { enrollmentAdaptor.hasActiveMembershipEnrollment(any(), any()) } returns false
 
         assertThrows<NoActiveMembershipException> {
             useCase.execute("student-user-id-0000000001", createRequest())

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/DeleteCommissionFileUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/DeleteCommissionFileUseCaseTest.kt
@@ -1,0 +1,165 @@
+package com.sclass.supporters.commission.usecase
+
+import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
+import com.sclass.domain.domains.commission.adaptor.CommissionFileAdaptor
+import com.sclass.domain.domains.commission.domain.ActivityType
+import com.sclass.domain.domains.commission.domain.Commission
+import com.sclass.domain.domains.commission.domain.CommissionFile
+import com.sclass.domain.domains.commission.domain.CommissionStatus
+import com.sclass.domain.domains.commission.domain.GuideInfo
+import com.sclass.domain.domains.commission.domain.OutputFormat
+import com.sclass.domain.domains.commission.exception.CommissionUnauthorizedAccessException
+import com.sclass.domain.domains.file.domain.File
+import com.sclass.domain.domains.file.domain.FileType
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonAlreadyCompletedException
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DeleteCommissionFileUseCaseTest {
+    private lateinit var commissionAdaptor: CommissionAdaptor
+    private lateinit var commissionFileAdaptor: CommissionFileAdaptor
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var useCase: DeleteCommissionFileUseCase
+
+    private val commissionId = 1L
+    private val lessonId = 100L
+    private val commissionFileId = 10L
+    private val studentUserId = "student-user-id-0000000001"
+    private val teacherUserId = "teacher-user-id-00000000001"
+    private val substituteTeacherUserId = "teacher-user-id-00000000002"
+
+    @BeforeEach
+    fun setUp() {
+        commissionAdaptor = mockk()
+        commissionFileAdaptor = mockk()
+        lessonAdaptor = mockk()
+        useCase = DeleteCommissionFileUseCase(commissionAdaptor, commissionFileAdaptor, lessonAdaptor)
+    }
+
+    private fun commission(acceptedLessonId: Long? = lessonId) =
+        Commission(
+            id = commissionId,
+            studentUserId = studentUserId,
+            teacherUserId = teacherUserId,
+            commissionPolicyId = "policy-id-00000000000001",
+            outputFormat = OutputFormat.REPORT,
+            activityType = ActivityType.CAREER_EXPLORATION,
+            status = CommissionStatus.ACCEPTED,
+            guideInfo =
+                GuideInfo(
+                    subject = "미시경제학",
+                    volume = "A4 3매",
+                    gradingCriteria = "평가기준",
+                    teacherEmphasis = "강조사항",
+                ),
+            selectedTopicId = 10L,
+            acceptedLessonId = acceptedLessonId,
+        )
+
+    private fun lesson(
+        status: LessonStatus = LessonStatus.SCHEDULED,
+        substituteTeacherUserId: String? = null,
+    ) = Lesson(
+        id = lessonId,
+        lessonType = LessonType.COMMISSION,
+        enrollmentId = 20L,
+        sourceCommissionId = commissionId,
+        studentUserId = studentUserId,
+        assignedTeacherUserId = teacherUserId,
+        substituteTeacherUserId = substituteTeacherUserId,
+        name = "미시경제학",
+        status = status,
+    )
+
+    private fun file(id: String = "task-submit-file-00000001") =
+        File.create(
+            id = id,
+            originalFilename = "$id.pdf",
+            storedFilename = "commissions/$id.pdf",
+            mimeType = "application/pdf",
+            fileSize = 1024L,
+            fileType = FileType.TASK_SUBMISSION,
+            uploadedBy = teacherUserId,
+        )
+
+    @Test
+    fun `대체 선생님이 배정된 수업이면 대체 선생님이 제출 파일을 삭제할 수 있다`() {
+        val commission = commission()
+        val lesson = lesson(substituteTeacherUserId = substituteTeacherUserId)
+        val commissionFile = CommissionFile(id = commissionFileId, commission = commission, file = file())
+
+        every { commissionAdaptor.findById(commissionId) } returns commission
+        every { lessonAdaptor.findById(lessonId) } returns lesson
+        every { commissionFileAdaptor.findById(commissionFileId) } returns commissionFile
+        every { commissionFileAdaptor.delete(commissionFile) } just runs
+        every { commissionFileAdaptor.findByCommissionId(commissionId) } returns emptyList()
+
+        val result = useCase.execute(substituteTeacherUserId, commissionId, commissionFileId)
+
+        assertAll(
+            { assertEquals(commissionId, result.id) },
+            { assertEquals(emptyList<Long>(), result.commissionFiles.map { it.id }) },
+        )
+        verify { commissionFileAdaptor.delete(commissionFile) }
+    }
+
+    @Test
+    fun `대체 선생님이 배정된 수업이면 원래 선생님은 제출 파일을 삭제할 수 없다`() {
+        val commission = commission()
+        val lesson = lesson(substituteTeacherUserId = substituteTeacherUserId)
+
+        every { commissionAdaptor.findById(commissionId) } returns commission
+        every { lessonAdaptor.findById(lessonId) } returns lesson
+
+        assertThrows<CommissionUnauthorizedAccessException> {
+            useCase.execute(teacherUserId, commissionId, commissionFileId)
+        }
+
+        verify(exactly = 0) { commissionFileAdaptor.findById(any()) }
+        verify(exactly = 0) { commissionFileAdaptor.delete(any()) }
+    }
+
+    @Test
+    fun `accepted lesson이 없으면 기존 commission 담당 선생님이 제출 파일을 삭제할 수 있다`() {
+        val commission = commission(acceptedLessonId = null)
+        val commissionFile = CommissionFile(id = commissionFileId, commission = commission, file = file())
+
+        every { commissionAdaptor.findById(commissionId) } returns commission
+        every { commissionFileAdaptor.findById(commissionFileId) } returns commissionFile
+        every { commissionFileAdaptor.delete(commissionFile) } just runs
+        every { commissionFileAdaptor.findByCommissionId(commissionId) } returns emptyList()
+
+        useCase.execute(teacherUserId, commissionId, commissionFileId)
+
+        verify(exactly = 0) { lessonAdaptor.findById(any()) }
+        verify { commissionFileAdaptor.delete(commissionFile) }
+    }
+
+    @Test
+    fun `완료된 수업이면 제출 파일 삭제가 불가하다`() {
+        val commission = commission()
+        val lesson = lesson(status = LessonStatus.COMPLETED)
+
+        every { commissionAdaptor.findById(commissionId) } returns commission
+        every { lessonAdaptor.findById(lessonId) } returns lesson
+
+        assertThrows<LessonAlreadyCompletedException> {
+            useCase.execute(teacherUserId, commissionId, commissionFileId)
+        }
+
+        verify(exactly = 0) { commissionFileAdaptor.findById(any()) }
+        verify(exactly = 0) { commissionFileAdaptor.delete(any()) }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/DeliverSubmissionUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/DeliverSubmissionUseCaseTest.kt
@@ -1,0 +1,256 @@
+package com.sclass.supporters.commission.usecase
+
+import com.sclass.common.exception.BusinessException
+import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
+import com.sclass.domain.domains.commission.adaptor.CommissionFileAdaptor
+import com.sclass.domain.domains.commission.domain.ActivityType
+import com.sclass.domain.domains.commission.domain.Commission
+import com.sclass.domain.domains.commission.domain.CommissionFile
+import com.sclass.domain.domains.commission.domain.CommissionStatus
+import com.sclass.domain.domains.commission.domain.GuideInfo
+import com.sclass.domain.domains.commission.domain.OutputFormat
+import com.sclass.domain.domains.file.adaptor.FileAdaptor
+import com.sclass.domain.domains.file.domain.File
+import com.sclass.domain.domains.file.domain.FileType
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lessonReport.adaptor.LessonReportAdaptor
+import com.sclass.domain.domains.lessonReport.adaptor.LessonReportFileAdaptor
+import com.sclass.domain.domains.lessonReport.domain.LessonReport
+import com.sclass.domain.domains.lessonReport.domain.LessonReportFile
+import com.sclass.domain.domains.lessonReport.domain.LessonReportStatus
+import com.sclass.domain.domains.lessonReport.exception.LessonReportAlreadyApprovedException
+import com.sclass.supporters.commission.dto.DeliverSubmissionRequest
+import com.sclass.supporters.commission.scheduler.CommissionReminderScheduler
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DeliverSubmissionUseCaseTest {
+    private lateinit var commissionAdaptor: CommissionAdaptor
+    private lateinit var commissionFileAdaptor: CommissionFileAdaptor
+    private lateinit var fileAdaptor: FileAdaptor
+    private lateinit var commissionReminderScheduler: CommissionReminderScheduler
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var lessonReportAdaptor: LessonReportAdaptor
+    private lateinit var lessonReportFileAdaptor: LessonReportFileAdaptor
+    private lateinit var useCase: DeliverSubmissionUseCase
+
+    private val commissionId = 1L
+    private val lessonId = 100L
+    private val studentUserId = "student-user-id-0000000001"
+    private val teacherUserId = "teacher-user-id-00000000001"
+
+    @BeforeEach
+    fun setUp() {
+        commissionAdaptor = mockk()
+        commissionFileAdaptor = mockk()
+        fileAdaptor = mockk()
+        commissionReminderScheduler = mockk(relaxed = true)
+        lessonAdaptor = mockk()
+        lessonReportAdaptor = mockk()
+        lessonReportFileAdaptor = mockk(relaxed = true)
+        useCase =
+            DeliverSubmissionUseCase(
+                commissionAdaptor,
+                commissionFileAdaptor,
+                fileAdaptor,
+                commissionReminderScheduler,
+                lessonAdaptor,
+                lessonReportAdaptor,
+                lessonReportFileAdaptor,
+            )
+    }
+
+    private fun commission() =
+        Commission(
+            id = commissionId,
+            studentUserId = studentUserId,
+            teacherUserId = teacherUserId,
+            commissionPolicyId = "policy-id-00000000000001",
+            outputFormat = OutputFormat.REPORT,
+            activityType = ActivityType.CAREER_EXPLORATION,
+            status = CommissionStatus.ACCEPTED,
+            guideInfo =
+                GuideInfo(
+                    subject = "미시경제학",
+                    volume = "A4 3매",
+                    gradingCriteria = "평가기준",
+                    teacherEmphasis = "강조사항",
+                ),
+            selectedTopicId = 10L,
+            acceptedLessonId = lessonId,
+        )
+
+    private fun lesson(status: LessonStatus = LessonStatus.SCHEDULED) =
+        Lesson(
+            id = lessonId,
+            lessonType = LessonType.COMMISSION,
+            enrollmentId = 20L,
+            sourceCommissionId = commissionId,
+            studentUserId = studentUserId,
+            assignedTeacherUserId = teacherUserId,
+            name = "미시경제학",
+            status = status,
+        )
+
+    private fun file(
+        id: String,
+        fileType: FileType = FileType.TASK_SUBMISSION,
+        uploadedBy: String = teacherUserId,
+    ) = File.create(
+        id = id,
+        originalFilename = "$id.pdf",
+        storedFilename = "commissions/$id.pdf",
+        mimeType = "application/pdf",
+        fileSize = 1024L,
+        fileType = fileType,
+        uploadedBy = uploadedBy,
+    )
+
+    @Test
+    fun `최종 전달 파일을 제출하면 수업 리포트를 만들고 기존 제출 파일을 현재 요청 기준으로 치환한다`() {
+        val commission = commission()
+        val lesson = lesson()
+        val originalFile = file("original-file-id-0000000001", FileType.REPORT, studentUserId)
+        val oldSubmissionFile = file("old-submit-file-000000001")
+        val firstSubmissionFile = file("new-submit-file-000000001")
+        val secondSubmissionFile = file("new-submit-file-000000002")
+        val originalCommissionFile = CommissionFile(id = 1L, commission = commission, file = originalFile)
+        val oldSubmissionCommissionFile = CommissionFile(id = 2L, commission = commission, file = oldSubmissionFile)
+        val savedCommissionFiles = slot<List<CommissionFile>>()
+        val savedReport = slot<LessonReport>()
+        val savedReportFiles = slot<List<LessonReportFile>>()
+
+        every { commissionAdaptor.findById(commissionId) } returns commission
+        every { lessonAdaptor.findById(lessonId) } returns lesson
+        every { fileAdaptor.findAllByIds(listOf(firstSubmissionFile.id, secondSubmissionFile.id)) } returns
+            listOf(secondSubmissionFile, firstSubmissionFile)
+        every { lessonAdaptor.save(lesson) } returns lesson
+        every { lessonReportAdaptor.findByLessonOrNull(lessonId) } returns null
+        every { lessonReportAdaptor.save(capture(savedReport)) } answers { savedReport.captured }
+        every { lessonReportFileAdaptor.saveAll(capture(savedReportFiles)) } answers { savedReportFiles.captured }
+        every { commissionFileAdaptor.findByCommissionId(commissionId) } returns
+            listOf(originalCommissionFile, oldSubmissionCommissionFile)
+        every { commissionFileAdaptor.deleteAll(listOf(oldSubmissionCommissionFile)) } returns Unit
+        every { commissionFileAdaptor.saveAll(capture(savedCommissionFiles)) } answers { savedCommissionFiles.captured }
+
+        val result =
+            useCase.execute(
+                teacherUserId,
+                commissionId,
+                DeliverSubmissionRequest(fileIds = listOf(firstSubmissionFile.id, secondSubmissionFile.id)),
+            )
+
+        assertAll(
+            { assertEquals(LessonStatus.COMPLETED, lesson.status) },
+            { assertEquals(teacherUserId, lesson.actualTeacherUserId) },
+            { assertEquals(2, savedCommissionFiles.captured.size) },
+            {
+                assertEquals(
+                    listOf(firstSubmissionFile.id, secondSubmissionFile.id),
+                    savedCommissionFiles.captured.map { it.file.id },
+                )
+            },
+            {
+                assertEquals(
+                    listOf(firstSubmissionFile.id, secondSubmissionFile.id),
+                    savedReportFiles.captured.map { it.file.id },
+                )
+            },
+            {
+                assertEquals(
+                    listOf(originalFile.id, firstSubmissionFile.id, secondSubmissionFile.id),
+                    result.commissionFiles.map { it.fileMeta.id },
+                )
+            },
+        )
+        verify { commissionFileAdaptor.deleteAll(listOf(oldSubmissionCommissionFile)) }
+        verify { commissionReminderScheduler.cancelAllReminders(commissionId) }
+    }
+
+    @Test
+    fun `반려된 리포트가 있으면 완료된 수업에도 최종 전달 파일을 재제출할 수 있다`() {
+        val commission = commission()
+        val lesson = lesson(status = LessonStatus.COMPLETED)
+        val submissionFile = file("new-submit-file-000000001")
+        val report =
+            LessonReport(
+                id = 200L,
+                lessonId = lessonId,
+                submittedByUserId = teacherUserId,
+                content = "기존 내용",
+                status = LessonReportStatus.REJECTED,
+                reviewedByUserId = "admin-user-id-000000000001",
+                rejectReason = "수정 필요",
+            )
+
+        every { commissionAdaptor.findById(commissionId) } returns commission
+        every { lessonAdaptor.findById(lessonId) } returns lesson
+        every { fileAdaptor.findAllByIds(listOf(submissionFile.id)) } returns listOf(submissionFile)
+        every { lessonReportAdaptor.findByLessonOrNull(lessonId) } returns report
+        every { lessonReportAdaptor.save(report) } returns report
+        every { commissionFileAdaptor.findByCommissionId(commissionId) } returns emptyList()
+        every { commissionFileAdaptor.saveAll(any()) } answers { firstArg() }
+
+        val result = useCase.execute(teacherUserId, commissionId, DeliverSubmissionRequest(fileIds = listOf(submissionFile.id)))
+
+        assertAll(
+            { assertEquals(LessonStatus.COMPLETED, lesson.status) },
+            { assertEquals(LessonReportStatus.PENDING_REVIEW, report.status) },
+            { assertEquals(null, report.reviewedByUserId) },
+            { assertEquals(null, report.rejectReason) },
+            { assertEquals(listOf(submissionFile.id), result.commissionFiles.map { it.fileMeta.id }) },
+        )
+        verify(exactly = 0) { lessonAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `승인된 리포트가 있으면 최종 전달 파일을 다시 제출할 수 없다`() {
+        val commission = commission()
+        val lesson = lesson(status = LessonStatus.COMPLETED)
+        val submissionFile = file("new-submit-file-000000001")
+        val report =
+            LessonReport(
+                id = 200L,
+                lessonId = lessonId,
+                submittedByUserId = teacherUserId,
+                content = "승인된 내용",
+                status = LessonReportStatus.APPROVED,
+            )
+
+        every { commissionAdaptor.findById(commissionId) } returns commission
+        every { lessonAdaptor.findById(lessonId) } returns lesson
+        every { fileAdaptor.findAllByIds(listOf(submissionFile.id)) } returns listOf(submissionFile)
+        every { lessonReportAdaptor.findByLessonOrNull(lessonId) } returns report
+
+        assertThrows<LessonReportAlreadyApprovedException> {
+            useCase.execute(teacherUserId, commissionId, DeliverSubmissionRequest(fileIds = listOf(submissionFile.id)))
+        }
+        verify(exactly = 0) { commissionFileAdaptor.findByCommissionId(any()) }
+        verify(exactly = 0) { commissionFileAdaptor.saveAll(any()) }
+    }
+
+    @Test
+    fun `중복 파일 ID로 제출하면 파일 조회 전에 예외가 발생한다`() {
+        val commission = commission()
+        val lesson = lesson()
+        val fileId = "new-submit-file-000000001"
+
+        every { commissionAdaptor.findById(commissionId) } returns commission
+        every { lessonAdaptor.findById(lessonId) } returns lesson
+
+        assertThrows<BusinessException> {
+            useCase.execute(teacherUserId, commissionId, DeliverSubmissionRequest(fileIds = listOf(fileId, fileId)))
+        }
+        verify(exactly = 0) { fileAdaptor.findAllByIds(any()) }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/DeliverSubmissionUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/DeliverSubmissionUseCaseTest.kt
@@ -16,6 +16,7 @@ import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.lesson.domain.LessonStatus
 import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
 import com.sclass.domain.domains.lessonReport.adaptor.LessonReportAdaptor
 import com.sclass.domain.domains.lessonReport.adaptor.LessonReportFileAdaptor
 import com.sclass.domain.domains.lessonReport.domain.LessonReport
@@ -48,6 +49,7 @@ class DeliverSubmissionUseCaseTest {
     private val lessonId = 100L
     private val studentUserId = "student-user-id-0000000001"
     private val teacherUserId = "teacher-user-id-00000000001"
+    private val substituteTeacherUserId = "teacher-user-id-00000000002"
 
     @BeforeEach
     fun setUp() {
@@ -90,17 +92,20 @@ class DeliverSubmissionUseCaseTest {
             acceptedLessonId = lessonId,
         )
 
-    private fun lesson(status: LessonStatus = LessonStatus.SCHEDULED) =
-        Lesson(
-            id = lessonId,
-            lessonType = LessonType.COMMISSION,
-            enrollmentId = 20L,
-            sourceCommissionId = commissionId,
-            studentUserId = studentUserId,
-            assignedTeacherUserId = teacherUserId,
-            name = "미시경제학",
-            status = status,
-        )
+    private fun lesson(
+        status: LessonStatus = LessonStatus.SCHEDULED,
+        substituteTeacherUserId: String? = null,
+    ) = Lesson(
+        id = lessonId,
+        lessonType = LessonType.COMMISSION,
+        enrollmentId = 20L,
+        sourceCommissionId = commissionId,
+        studentUserId = studentUserId,
+        assignedTeacherUserId = teacherUserId,
+        substituteTeacherUserId = substituteTeacherUserId,
+        name = "미시경제학",
+        status = status,
+    )
 
     private fun file(
         id: String,
@@ -211,6 +216,54 @@ class DeliverSubmissionUseCaseTest {
             { assertEquals(listOf(submissionFile.id), result.commissionFiles.map { it.fileMeta.id }) },
         )
         verify(exactly = 0) { lessonAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `대체 선생님이 배정된 수업이면 대체 선생님이 최종 전달 파일을 제출할 수 있다`() {
+        val commission = commission()
+        val lesson = lesson(substituteTeacherUserId = substituteTeacherUserId)
+        val submissionFile = file("new-submit-file-000000001", uploadedBy = substituteTeacherUserId)
+        val savedReport = slot<LessonReport>()
+
+        every { commissionAdaptor.findById(commissionId) } returns commission
+        every { lessonAdaptor.findById(lessonId) } returns lesson
+        every { fileAdaptor.findAllByIds(listOf(submissionFile.id)) } returns listOf(submissionFile)
+        every { lessonAdaptor.save(lesson) } returns lesson
+        every { lessonReportAdaptor.findByLessonOrNull(lessonId) } returns null
+        every { lessonReportAdaptor.save(capture(savedReport)) } answers { savedReport.captured }
+        every { commissionFileAdaptor.findByCommissionId(commissionId) } returns emptyList()
+        every { commissionFileAdaptor.saveAll(any()) } answers { firstArg() }
+
+        val result =
+            useCase.execute(
+                substituteTeacherUserId,
+                commissionId,
+                DeliverSubmissionRequest(fileIds = listOf(submissionFile.id)),
+            )
+
+        assertAll(
+            { assertEquals(LessonStatus.COMPLETED, lesson.status) },
+            { assertEquals(substituteTeacherUserId, lesson.actualTeacherUserId) },
+            { assertEquals(substituteTeacherUserId, savedReport.captured.submittedByUserId) },
+            { assertEquals(listOf(submissionFile.id), result.commissionFiles.map { it.fileMeta.id }) },
+        )
+    }
+
+    @Test
+    fun `대체 선생님이 배정된 수업이면 원래 선생님은 최종 전달 파일을 제출할 수 없다`() {
+        val commission = commission()
+        val lesson = lesson(substituteTeacherUserId = substituteTeacherUserId)
+        val submissionFile = file("new-submit-file-000000001")
+
+        every { commissionAdaptor.findById(commissionId) } returns commission
+        every { lessonAdaptor.findById(lessonId) } returns lesson
+        every { fileAdaptor.findAllByIds(listOf(submissionFile.id)) } returns listOf(submissionFile)
+
+        assertThrows<LessonUnauthorizedAccessException> {
+            useCase.execute(teacherUserId, commissionId, DeliverSubmissionRequest(fileIds = listOf(submissionFile.id)))
+        }
+        verify(exactly = 0) { lessonAdaptor.save(any()) }
+        verify(exactly = 0) { lessonReportAdaptor.save(any()) }
     }
 
     @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/SelectTopicUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/SelectTopicUseCaseTest.kt
@@ -9,6 +9,9 @@ import com.sclass.domain.domains.commission.domain.CommissionStatus
 import com.sclass.domain.domains.commission.domain.CommissionTopic
 import com.sclass.domain.domains.commission.domain.GuideInfo
 import com.sclass.domain.domains.commission.domain.OutputFormat
+import com.sclass.domain.domains.enrollment.adaptor.EnrollmentAdaptor
+import com.sclass.domain.domains.enrollment.domain.Enrollment
+import com.sclass.domain.domains.enrollment.exception.NoActiveMembershipException
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.lesson.domain.LessonType
@@ -17,17 +20,20 @@ import com.sclass.supporters.commission.scheduler.CommissionReminderScheduler
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
 
 class SelectTopicUseCaseTest {
     private lateinit var commissionAdaptor: CommissionAdaptor
     private lateinit var commissionTopicAdaptor: CommissionTopicAdaptor
     private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var enrollmentAdaptor: EnrollmentAdaptor
     private lateinit var commissionReminderScheduler: CommissionReminderScheduler
     private lateinit var useCase: SelectTopicUseCase
 
@@ -39,8 +45,16 @@ class SelectTopicUseCaseTest {
         commissionAdaptor = mockk()
         commissionTopicAdaptor = mockk()
         lessonAdaptor = mockk()
+        enrollmentAdaptor = mockk()
         commissionReminderScheduler = mockk(relaxed = true)
-        useCase = SelectTopicUseCase(commissionAdaptor, commissionTopicAdaptor, lessonAdaptor, commissionReminderScheduler)
+        useCase =
+            SelectTopicUseCase(
+                commissionAdaptor,
+                commissionTopicAdaptor,
+                lessonAdaptor,
+                enrollmentAdaptor,
+                commissionReminderScheduler,
+            )
     }
 
     private fun createCommission(
@@ -84,14 +98,26 @@ class SelectTopicUseCaseTest {
             name = "미시경제학",
         )
 
+    private fun activeMembershipEnrollment() =
+        Enrollment.createMembershipByGrant(
+            productId = "membership-product-id-0001",
+            studentUserId = studentUserId,
+            grantedByUserId = "admin-user-id-000000000001",
+            grantReason = "테스트 멤버십",
+            startAt = LocalDateTime.now().minusDays(1),
+            endAt = LocalDateTime.now().plusDays(1),
+        )
+
     @Test
     fun `학생이 주제를 선택하면 Lesson이 생성되고 Commission이 ACCEPTED 상태가 된다`() {
         val commission = createCommission()
         val topic = createTopic(commission = commission)
+        val membershipEnrollment = activeMembershipEnrollment()
         val lessonSlot = slot<Lesson>()
 
         every { commissionAdaptor.findById(1L) } returns commission
         every { commissionTopicAdaptor.findById(10L) } returns topic
+        every { enrollmentAdaptor.findActiveMembershipEnrollment(studentUserId) } returns membershipEnrollment
         every { lessonAdaptor.save(capture(lessonSlot)) } returns savedLesson(1L)
 
         val result = useCase.execute(studentUserId, 1L, 10L, SelectTopicRequest(isSelected = true))
@@ -106,6 +132,7 @@ class SelectTopicUseCaseTest {
             { assertTrue(topic.selected) },
             { assertEquals(LessonType.COMMISSION, lessonSlot.captured.lessonType) },
             { assertEquals(1L, lessonSlot.captured.sourceCommissionId) },
+            { assertEquals(membershipEnrollment.id, lessonSlot.captured.enrollmentId) },
         )
     }
 
@@ -138,6 +165,8 @@ class SelectTopicUseCaseTest {
         assertThrows<BusinessException> {
             useCase.execute(studentUserId, 1L, 10L, SelectTopicRequest(isSelected = true))
         }
+        verify(exactly = 0) { enrollmentAdaptor.findActiveMembershipEnrollment(any()) }
+        verify(exactly = 0) { lessonAdaptor.save(any()) }
     }
 
     @Test
@@ -147,10 +176,24 @@ class SelectTopicUseCaseTest {
 
         every { commissionAdaptor.findById(1L) } returns commission
         every { commissionTopicAdaptor.findById(10L) } returns topic
-        every { lessonAdaptor.save(any()) } returns savedLesson(1L)
 
-        assertThrows<IllegalArgumentException> {
+        assertThrows<BusinessException> {
             useCase.execute(studentUserId, 1L, 10L, SelectTopicRequest(isSelected = true))
         }
+    }
+
+    @Test
+    fun `활성 멤버십이 없으면 레슨을 생성하지 않고 예외가 발생한다`() {
+        val commission = createCommission()
+        val topic = createTopic(commission = commission)
+
+        every { commissionAdaptor.findById(1L) } returns commission
+        every { commissionTopicAdaptor.findById(10L) } returns topic
+        every { enrollmentAdaptor.findActiveMembershipEnrollment(studentUserId) } returns null
+
+        assertThrows<NoActiveMembershipException> {
+            useCase.execute(studentUserId, 1L, 10L, SelectTopicRequest(isSelected = true))
+        }
+        verify(exactly = 0) { lessonAdaptor.save(any()) }
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/SelectTopicUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/SelectTopicUseCaseTest.kt
@@ -117,7 +117,7 @@ class SelectTopicUseCaseTest {
 
         every { commissionAdaptor.findById(1L) } returns commission
         every { commissionTopicAdaptor.findById(10L) } returns topic
-        every { enrollmentAdaptor.findActiveMembershipEnrollment(studentUserId) } returns membershipEnrollment
+        every { enrollmentAdaptor.findActiveMembershipEnrollment(studentUserId, any()) } returns membershipEnrollment
         every { lessonAdaptor.save(capture(lessonSlot)) } returns savedLesson(1L)
 
         val result = useCase.execute(studentUserId, 1L, 10L, SelectTopicRequest(isSelected = true))
@@ -165,7 +165,7 @@ class SelectTopicUseCaseTest {
         assertThrows<BusinessException> {
             useCase.execute(studentUserId, 1L, 10L, SelectTopicRequest(isSelected = true))
         }
-        verify(exactly = 0) { enrollmentAdaptor.findActiveMembershipEnrollment(any()) }
+        verify(exactly = 0) { enrollmentAdaptor.findActiveMembershipEnrollment(any(), any()) }
         verify(exactly = 0) { lessonAdaptor.save(any()) }
     }
 
@@ -189,7 +189,7 @@ class SelectTopicUseCaseTest {
 
         every { commissionAdaptor.findById(1L) } returns commission
         every { commissionTopicAdaptor.findById(10L) } returns topic
-        every { enrollmentAdaptor.findActiveMembershipEnrollment(studentUserId) } returns null
+        every { enrollmentAdaptor.findActiveMembershipEnrollment(studentUserId, any()) } returns null
 
         assertThrows<NoActiveMembershipException> {
             useCase.execute(studentUserId, 1L, 10L, SelectTopicRequest(isSelected = true))

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/PreparePaymentUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/payment/usecase/PreparePaymentUseCaseTest.kt
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 
 class PreparePaymentUseCaseTest {
     private lateinit var coinPackageAdaptor: CoinPackageAdaptor
@@ -26,19 +29,20 @@ class PreparePaymentUseCaseTest {
     private lateinit var useCase: PreparePaymentUseCase
 
     private val userId = "user-id-00000000000000000000000001"
+    private val fixedClock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneId.of("UTC"))
 
     @BeforeEach
     fun setUp() {
         coinPackageAdaptor = mockk()
         enrollmentAdaptor = mockk()
         paymentAdaptor = mockk()
-        useCase = PreparePaymentUseCase(coinPackageAdaptor, enrollmentAdaptor, paymentAdaptor)
+        useCase = PreparePaymentUseCase(coinPackageAdaptor, enrollmentAdaptor, paymentAdaptor, fixedClock)
     }
 
     @Test
     fun `결제 준비 성공 시 paymentId와 pgOrderId를 반환한다`() {
         val coinPackage = CoinPackage(name = "코인 100", priceWon = 1000, coinAmount = 100)
-        every { enrollmentAdaptor.hasActiveMembershipEnrollment(userId) } returns true
+        every { enrollmentAdaptor.hasActiveMembershipEnrollment(userId, any()) } returns true
         every { coinPackageAdaptor.findById(any()) } returns coinPackage
 
         val paymentSlot = slot<Payment>()
@@ -61,7 +65,7 @@ class PreparePaymentUseCaseTest {
 
     @Test
     fun `활성 멤버십이 없으면 NoActiveMembershipException이 발생한다`() {
-        every { enrollmentAdaptor.hasActiveMembershipEnrollment(userId) } returns false
+        every { enrollmentAdaptor.hasActiveMembershipEnrollment(userId, any()) } returns false
 
         assertThrows<NoActiveMembershipException> {
             useCase.execute(
@@ -73,7 +77,7 @@ class PreparePaymentUseCaseTest {
 
     @Test
     fun `존재하지 않는 코인 패키지면 예외가 발생한다`() {
-        every { enrollmentAdaptor.hasActiveMembershipEnrollment(userId) } returns true
+        every { enrollmentAdaptor.hasActiveMembershipEnrollment(userId, any()) } returns true
         every { coinPackageAdaptor.findById(any()) } throws CoinPackageNotFoundException()
 
         assertThrows<CoinPackageNotFoundException> {

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/adaptor/CommissionFileAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/adaptor/CommissionFileAdaptor.kt
@@ -1,8 +1,11 @@
 package com.sclass.domain.domains.commission.adaptor
 
 import com.sclass.common.annotation.Adaptor
+import com.sclass.common.exception.BusinessException
 import com.sclass.domain.domains.commission.domain.CommissionFile
+import com.sclass.domain.domains.commission.exception.CommissionErrorCode
 import com.sclass.domain.domains.commission.repository.CommissionFileRepository
+import org.springframework.data.repository.findByIdOrNull
 
 @Adaptor
 class CommissionFileAdaptor(
@@ -10,5 +13,17 @@ class CommissionFileAdaptor(
 ) {
     fun findByCommissionId(commissionId: Long): List<CommissionFile> = commissionFileRepository.findByCommissionId(commissionId)
 
+    fun findById(id: Long): CommissionFile =
+        commissionFileRepository.findByIdOrNull(id)
+            ?: throw BusinessException(CommissionErrorCode.COMMISSION_FILE_NOT_FOUND)
+
     fun saveAll(files: List<CommissionFile>): List<CommissionFile> = commissionFileRepository.saveAll(files)
+
+    fun delete(file: CommissionFile) {
+        commissionFileRepository.delete(file)
+    }
+
+    fun deleteAll(files: List<CommissionFile>) {
+        commissionFileRepository.deleteAll(files)
+    }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/adaptor/CommissionFileAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/adaptor/CommissionFileAdaptor.kt
@@ -5,7 +5,6 @@ import com.sclass.common.exception.BusinessException
 import com.sclass.domain.domains.commission.domain.CommissionFile
 import com.sclass.domain.domains.commission.exception.CommissionErrorCode
 import com.sclass.domain.domains.commission.repository.CommissionFileRepository
-import org.springframework.data.repository.findByIdOrNull
 
 @Adaptor
 class CommissionFileAdaptor(
@@ -14,7 +13,7 @@ class CommissionFileAdaptor(
     fun findByCommissionId(commissionId: Long): List<CommissionFile> = commissionFileRepository.findByCommissionId(commissionId)
 
     fun findById(id: Long): CommissionFile =
-        commissionFileRepository.findByIdOrNull(id)
+        commissionFileRepository.findByIdWithFile(id)
             ?: throw BusinessException(CommissionErrorCode.COMMISSION_FILE_NOT_FOUND)
 
     fun saveAll(files: List<CommissionFile>): List<CommissionFile> = commissionFileRepository.saveAll(files)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/exception/CommissionErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/exception/CommissionErrorCode.kt
@@ -14,4 +14,5 @@ enum class CommissionErrorCode(
     SUPPORT_TICKET_NOT_FOUND("COMMISSION_005", "지원 티켓을 찾을 수 없습니다", 404),
     COMMISSION_POLICY_NOT_CONFIGURED("COMMISSION_006", "활성화된 의뢰 정책이 없습니다", 500),
     COMMISSION_POLICY_NOT_FOUND("COMMISSION_007", "의뢰 정책을 찾을 수 없습니다", 404),
+    COMMISSION_FILE_NOT_FOUND("COMMISSION_008", "의뢰 파일을 찾을 수 없습니다", 404),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/repository/CommissionFileCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/repository/CommissionFileCustomRepository.kt
@@ -4,4 +4,6 @@ import com.sclass.domain.domains.commission.domain.CommissionFile
 
 interface CommissionFileCustomRepository {
     fun findByCommissionId(commissionId: Long): List<CommissionFile>
+
+    fun findByIdWithFile(id: Long): CommissionFile?
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/repository/CommissionFileCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/commission/repository/CommissionFileCustomRepositoryImpl.kt
@@ -15,4 +15,12 @@ class CommissionFileCustomRepositoryImpl(
             .fetchJoin()
             .where(commissionFile.commission.id.eq(commissionId))
             .fetch()
+
+    override fun findByIdWithFile(id: Long): CommissionFile? =
+        queryFactory
+            .selectFrom(commissionFile)
+            .join(commissionFile.file, file)
+            .fetchJoin()
+            .where(commissionFile.id.eq(id))
+            .fetchOne()
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
@@ -121,6 +121,12 @@ class EnrollmentAdaptor(
             now = java.time.LocalDateTime.now(),
         )
 
+    fun findActiveMembershipEnrollment(studentUserId: String): Enrollment? =
+        enrollmentRepository.findActiveMembershipEnrollment(
+            studentUserId = studentUserId,
+            now = java.time.LocalDateTime.now(),
+        )
+
     fun hasPendingUnassignedMatchingEnrollment(productId: String): Boolean =
         enrollmentRepository.existsByProductIdAndCourseIdIsNullAndStatusIn(
             productId,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
@@ -13,10 +13,13 @@ import com.sclass.domain.domains.enrollment.repository.EnrollmentRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
+import java.time.Clock
+import java.time.LocalDateTime
 
 @Adaptor
 class EnrollmentAdaptor(
     private val enrollmentRepository: EnrollmentRepository,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     fun save(enrollment: Enrollment): Enrollment = enrollmentRepository.save(enrollment)
 
@@ -118,13 +121,13 @@ class EnrollmentAdaptor(
     fun hasActiveMembershipEnrollment(studentUserId: String): Boolean =
         enrollmentRepository.hasActiveMembershipEnrollment(
             studentUserId = studentUserId,
-            now = java.time.LocalDateTime.now(),
+            now = LocalDateTime.now(clock),
         )
 
     fun findActiveMembershipEnrollment(studentUserId: String): Enrollment? =
         enrollmentRepository.findActiveMembershipEnrollment(
             studentUserId = studentUserId,
-            now = java.time.LocalDateTime.now(),
+            now = LocalDateTime.now(clock),
         )
 
     fun hasPendingUnassignedMatchingEnrollment(productId: String): Boolean =

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/adaptor/EnrollmentAdaptor.kt
@@ -13,13 +13,11 @@ import com.sclass.domain.domains.enrollment.repository.EnrollmentRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
-import java.time.Clock
 import java.time.LocalDateTime
 
 @Adaptor
 class EnrollmentAdaptor(
     private val enrollmentRepository: EnrollmentRepository,
-    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     fun save(enrollment: Enrollment): Enrollment = enrollmentRepository.save(enrollment)
 
@@ -118,16 +116,22 @@ class EnrollmentAdaptor(
     fun findPendingPaymentOlderThan(threshold: java.time.LocalDateTime): List<Enrollment> =
         enrollmentRepository.findAllByStatusAndCreatedAtBefore(EnrollmentStatus.PENDING_PAYMENT, threshold)
 
-    fun hasActiveMembershipEnrollment(studentUserId: String): Boolean =
+    fun hasActiveMembershipEnrollment(
+        studentUserId: String,
+        now: LocalDateTime,
+    ): Boolean =
         enrollmentRepository.hasActiveMembershipEnrollment(
             studentUserId = studentUserId,
-            now = LocalDateTime.now(clock),
+            now = now,
         )
 
-    fun findActiveMembershipEnrollment(studentUserId: String): Enrollment? =
+    fun findActiveMembershipEnrollment(
+        studentUserId: String,
+        now: LocalDateTime,
+    ): Enrollment? =
         enrollmentRepository.findActiveMembershipEnrollment(
             studentUserId = studentUserId,
-            now = LocalDateTime.now(clock),
+            now = now,
         )
 
     fun hasPendingUnassignedMatchingEnrollment(productId: String): Boolean =

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepository.kt
@@ -29,6 +29,11 @@ interface EnrollmentCustomRepository {
         now: java.time.LocalDateTime,
     ): Boolean
 
+    fun findActiveMembershipEnrollment(
+        studentUserId: String,
+        now: java.time.LocalDateTime,
+    ): Enrollment?
+
     fun findResumableCourseProductEnrollment(
         productId: String,
         studentUserId: String,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/enrollment/repository/EnrollmentCustomRepositoryImpl.kt
@@ -159,6 +159,22 @@ class EnrollmentCustomRepositoryImpl(
                 enrollment.endAt.isNull.or(enrollment.endAt.gt(now)),
             ).fetchFirst() != null
 
+    override fun findActiveMembershipEnrollment(
+        studentUserId: String,
+        now: LocalDateTime,
+    ): Enrollment? =
+        queryFactory
+            .selectFrom(enrollment)
+            .leftJoin(membershipProduct)
+            .on(membershipProduct.id.eq(enrollment.productId))
+            .where(
+                enrollment.studentUserId.eq(studentUserId),
+                membershipProduct.id.isNotNull,
+                enrollment.status.eq(EnrollmentStatus.ACTIVE),
+                enrollment.endAt.isNull.or(enrollment.endAt.gt(now)),
+            ).orderBy(enrollment.createdAt.desc())
+            .fetchFirst()
+
     override fun findResumableCourseProductEnrollment(
         productId: String,
         studentUserId: String,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonErrorCode.kt
@@ -13,4 +13,5 @@ enum class LessonErrorCode(
     LESSON_UNAUTHORIZED_ACCESS("LESSON_004", "해당 수업에 대한 권한이 없습니다", 403),
     LESSON_SUBSTITUTE_ASSIGN_NOT_ALLOWED("LESSON_005", "예정 상태의 수업만 대타 배정이 가능합니다", 400),
     LESSON_SUBSTITUTE_SAME_AS_ASSIGNED("LESSON_006", "기존 담당 선생님은 대타로 배정할 수 없습니다", 400),
+    LESSON_ALREADY_COMPLETED("LESSON_007", "이미 완료 처리된 수업입니다", 400),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonExceptions.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonExceptions.kt
@@ -7,3 +7,5 @@ class LessonNotFoundException : BusinessException(LessonErrorCode.LESSON_NOT_FOU
 class LessonInvalidStatusTransitionException : BusinessException(LessonErrorCode.LESSON_INVALID_STATUS_TRANSITION)
 
 class LessonNotCompletedException : BusinessException(LessonErrorCode.LESSON_NOT_COMPLETED)
+
+class LessonAlreadyCompletedException : BusinessException(LessonErrorCode.LESSON_ALREADY_COMPLETED)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/adaptor/ProductAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/product/adaptor/ProductAdaptor.kt
@@ -18,6 +18,8 @@ class ProductAdaptor(
 ) {
     fun findById(id: String): Product = productRepository.findById(id).orElseThrow { ProductNotFoundException() }
 
+    fun findByIdOrNull(id: String): Product? = productRepository.findById(id).orElse(null)
+
     fun findCourseProductById(id: String): CourseProduct =
         findById(id) as? CourseProduct
             ?: throw ProductTypeMismatchException()


### PR DESCRIPTION
## 요약
- Supporters 의뢰 최종 제출 API를 추가하고 제출 파일을 현재 요청 기준으로 치환하도록 정리했습니다.
- Backoffice 의뢰/등록/수업/수업 리포트 상세 조회 API를 추가했습니다.
- 의뢰 주제 선택 시 활성 멤버십 enrollment를 Lesson에 연결하고 상태 검증 순서를 보강했습니다.

## 개선 사항
- 최종 제출 fileIds 중복을 사전에 차단합니다.
- 기존 TASK_SUBMISSION 파일은 새 제출본 기준으로 정리하고 LessonReport 첨부와 동기화합니다.
- 반려된 리포트는 재제출 가능하게, 승인된 리포트는 재제출 불가하게 처리했습니다.

## 테스트
- `./gradlew :SClass-Api-Supporters:ktlintCheck :SClass-Domain:ktlintCheck :SClass-Api-Backoffice:ktlintCheck`
- `./gradlew :SClass-Api-Supporters:test --tests 'com.sclass.supporters.commission.usecase.SelectTopicUseCaseTest' --tests 'com.sclass.supporters.commission.usecase.DeliverSubmissionUseCaseTest' :SClass-Api-Backoffice:test`
- pre-commit build