### PR TITLE
feat(auth): rotate refresh tokens

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/controller/AuthController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/controller/AuthController.kt
@@ -1,8 +1,11 @@
 package com.sclass.backoffice.auth.controller
 
 import com.sclass.backoffice.auth.dto.LoginRequest
+import com.sclass.backoffice.auth.dto.RefreshRequest
 import com.sclass.backoffice.auth.dto.TokenResponse
 import com.sclass.backoffice.auth.usecase.LoginUseCase
+import com.sclass.backoffice.auth.usecase.LogoutUseCase
+import com.sclass.backoffice.auth.usecase.RefreshUseCase
 import com.sclass.common.dto.ApiResponse
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.PostMapping
@@ -14,9 +17,24 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/auth")
 class AuthController(
     private val loginUseCase: LoginUseCase,
+    private val refreshUseCase: RefreshUseCase,
+    private val logoutUseCase: LogoutUseCase,
 ) {
     @PostMapping("/login")
     fun login(
         @Valid @RequestBody request: LoginRequest,
     ): ApiResponse<TokenResponse> = ApiResponse.success(loginUseCase.execute(request))
+
+    @PostMapping("/refresh")
+    fun refresh(
+        @Valid @RequestBody request: RefreshRequest,
+    ): ApiResponse<TokenResponse> = ApiResponse.success(refreshUseCase.execute(request))
+
+    @PostMapping("/logout")
+    fun logout(
+        @Valid @RequestBody request: RefreshRequest,
+    ): ApiResponse<Nothing> {
+        logoutUseCase.execute(request)
+        return ApiResponse.success()
+    }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/dto/RefreshRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/dto/RefreshRequest.kt
@@ -1,0 +1,8 @@
+package com.sclass.backoffice.auth.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class RefreshRequest(
+    @field:NotBlank
+    val refreshToken: String,
+)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/usecase/LogoutUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/usecase/LogoutUseCase.kt
@@ -11,7 +11,6 @@ class LogoutUseCase(
 ) {
     @Transactional
     fun execute(request: RefreshRequest) {
-        val refreshToken = tokenDomainService.resolveRefreshToken(request.refreshToken)
-        tokenDomainService.revokeAllByUserId(refreshToken.userId)
+        tokenDomainService.revokeRefreshToken(request.refreshToken)
     }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/usecase/LogoutUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/usecase/LogoutUseCase.kt
@@ -1,0 +1,17 @@
+package com.sclass.backoffice.auth.usecase
+
+import com.sclass.backoffice.auth.dto.RefreshRequest
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.token.service.TokenDomainService
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class LogoutUseCase(
+    private val tokenDomainService: TokenDomainService,
+) {
+    @Transactional
+    fun execute(request: RefreshRequest) {
+        val refreshToken = tokenDomainService.resolveRefreshToken(request.refreshToken)
+        tokenDomainService.revokeAllByUserId(refreshToken.userId)
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/usecase/RefreshUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/usecase/RefreshUseCase.kt
@@ -4,18 +4,18 @@ import com.sclass.backoffice.auth.dto.RefreshRequest
 import com.sclass.backoffice.auth.dto.TokenResponse
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.token.service.TokenDomainService
-import com.sclass.domain.domains.user.adaptor.UserAdaptor
+import com.sclass.domain.domains.user.service.UserDomainService
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class RefreshUseCase(
-    private val userAdaptor: UserAdaptor,
+    private val userDomainService: UserDomainService,
     private val tokenDomainService: TokenDomainService,
 ) {
     @Transactional
     fun execute(request: RefreshRequest): TokenResponse {
         val refreshToken = tokenDomainService.consumeRefreshToken(request.refreshToken)
-        userAdaptor.findById(refreshToken.userId)
+        userDomainService.validateUserHasRole(refreshToken.userId, refreshToken.role)
         val tokens = tokenDomainService.issueTokens(refreshToken.userId, refreshToken.role)
         return TokenResponse(
             accessToken = tokens.accessToken,

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/usecase/RefreshUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/auth/usecase/RefreshUseCase.kt
@@ -1,10 +1,10 @@
-package com.sclass.supporters.auth.usecase
+package com.sclass.backoffice.auth.usecase
 
+import com.sclass.backoffice.auth.dto.RefreshRequest
+import com.sclass.backoffice.auth.dto.TokenResponse
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.token.service.TokenDomainService
 import com.sclass.domain.domains.user.adaptor.UserAdaptor
-import com.sclass.supporters.auth.dto.RefreshRequest
-import com.sclass.supporters.auth.dto.TokenResponse
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/auth/controller/AuthControllerIntegrationTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/auth/controller/AuthControllerIntegrationTest.kt
@@ -1,0 +1,71 @@
+package com.sclass.backoffice.auth.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.sclass.backoffice.auth.dto.RefreshRequest
+import com.sclass.backoffice.config.ApiIntegrationTest
+import com.sclass.domain.domains.token.service.TokenDomainService
+import com.sclass.domain.domains.user.domain.AuthProvider
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.domain.domains.user.domain.User
+import com.sclass.domain.domains.user.service.UserDomainService
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+@ApiIntegrationTest
+class AuthControllerIntegrationTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var userDomainService: UserDomainService
+
+    @Autowired
+    private lateinit var tokenDomainService: TokenDomainService
+
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+
+    @Test
+    fun `refresh endpoint는 refresh token을 회전하고 이전 refresh token 재사용을 막는다`() {
+        val user =
+            userDomainService.register(
+                user =
+                    User(
+                        email = "admin-refresh-${UUID.randomUUID()}@example.com",
+                        name = "관리자",
+                        authProvider = AuthProvider.EMAIL,
+                    ),
+                rawPassword = "password123",
+                platform = Platform.BACKOFFICE,
+                role = Role.ADMIN,
+            )
+        val tokens = tokenDomainService.issueTokens(user.id, Role.ADMIN)
+        val request = RefreshRequest(refreshToken = tokens.refreshToken)
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.accessToken").isNotEmpty)
+            .andExpect(jsonPath("$.data.refreshToken").isNotEmpty)
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("TOKEN_004"))
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/auth/usecase/LogoutUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/auth/usecase/LogoutUseCaseTest.kt
@@ -1,0 +1,35 @@
+package com.sclass.backoffice.auth.usecase
+
+import com.sclass.backoffice.auth.dto.RefreshRequest
+import com.sclass.domain.domains.token.dto.ResolvedRefreshToken
+import com.sclass.domain.domains.token.service.TokenDomainService
+import com.sclass.domain.domains.user.domain.Role
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LogoutUseCaseTest {
+    private lateinit var tokenDomainService: TokenDomainService
+    private lateinit var logoutUseCase: LogoutUseCase
+
+    @BeforeEach
+    fun setUp() {
+        tokenDomainService = mockk()
+        logoutUseCase = LogoutUseCase(tokenDomainService)
+    }
+
+    @Test
+    fun `유효한 refresh token이면 해당 유저의 refresh token을 폐기한다`() {
+        every { tokenDomainService.resolveRefreshToken("encrypted-refresh") } returns
+            ResolvedRefreshToken(userId = "admin-id", tokenId = "refresh-token-id", role = Role.ADMIN)
+        every { tokenDomainService.revokeAllByUserId("admin-id") } just runs
+
+        logoutUseCase.execute(RefreshRequest(refreshToken = "encrypted-refresh"))
+
+        verify { tokenDomainService.revokeAllByUserId("admin-id") }
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/auth/usecase/LogoutUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/auth/usecase/LogoutUseCaseTest.kt
@@ -1,9 +1,7 @@
 package com.sclass.backoffice.auth.usecase
 
 import com.sclass.backoffice.auth.dto.RefreshRequest
-import com.sclass.domain.domains.token.dto.ResolvedRefreshToken
 import com.sclass.domain.domains.token.service.TokenDomainService
-import com.sclass.domain.domains.user.domain.Role
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -23,13 +21,11 @@ class LogoutUseCaseTest {
     }
 
     @Test
-    fun `유효한 refresh token이면 해당 유저의 refresh token을 폐기한다`() {
-        every { tokenDomainService.resolveRefreshToken("encrypted-refresh") } returns
-            ResolvedRefreshToken(userId = "admin-id", tokenId = "refresh-token-id", role = Role.ADMIN)
-        every { tokenDomainService.revokeAllByUserId("admin-id") } just runs
+    fun `유효한 refresh token이면 해당 refresh token만 폐기한다`() {
+        every { tokenDomainService.revokeRefreshToken("encrypted-refresh") } just runs
 
         logoutUseCase.execute(RefreshRequest(refreshToken = "encrypted-refresh"))
 
-        verify { tokenDomainService.revokeAllByUserId("admin-id") }
+        verify { tokenDomainService.revokeRefreshToken("encrypted-refresh") }
     }
 }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/auth/usecase/RefreshUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/auth/usecase/RefreshUseCaseTest.kt
@@ -1,0 +1,44 @@
+package com.sclass.backoffice.auth.usecase
+
+import com.sclass.backoffice.auth.dto.RefreshRequest
+import com.sclass.domain.domains.token.dto.ResolvedRefreshToken
+import com.sclass.domain.domains.token.dto.TokenResult
+import com.sclass.domain.domains.token.service.TokenDomainService
+import com.sclass.domain.domains.user.adaptor.UserAdaptor
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.domain.domains.user.domain.User
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class RefreshUseCaseTest {
+    private lateinit var userAdaptor: UserAdaptor
+    private lateinit var tokenDomainService: TokenDomainService
+    private lateinit var refreshUseCase: RefreshUseCase
+
+    @BeforeEach
+    fun setUp() {
+        userAdaptor = mockk()
+        tokenDomainService = mockk()
+        refreshUseCase = RefreshUseCase(userAdaptor, tokenDomainService)
+    }
+
+    @Test
+    fun `유효한 refresh token이면 기존 jti를 폐기하고 새 토큰을 발급한다`() {
+        every { tokenDomainService.consumeRefreshToken("encrypted-refresh") } returns
+            ResolvedRefreshToken(userId = "admin-id", tokenId = "refresh-token-id", role = Role.ADMIN)
+        every { userAdaptor.findById("admin-id") } returns mockk<User>()
+        every { tokenDomainService.issueTokens("admin-id", Role.ADMIN) } returns
+            TokenResult(accessToken = "new-access", refreshToken = "new-refresh")
+
+        val result = refreshUseCase.execute(RefreshRequest(refreshToken = "encrypted-refresh"))
+
+        assertEquals("new-access", result.accessToken)
+        assertEquals("new-refresh", result.refreshToken)
+        verify { tokenDomainService.consumeRefreshToken("encrypted-refresh") }
+        verify { tokenDomainService.issueTokens("admin-id", Role.ADMIN) }
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/auth/usecase/RefreshUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/auth/usecase/RefreshUseCaseTest.kt
@@ -4,33 +4,34 @@ import com.sclass.backoffice.auth.dto.RefreshRequest
 import com.sclass.domain.domains.token.dto.ResolvedRefreshToken
 import com.sclass.domain.domains.token.dto.TokenResult
 import com.sclass.domain.domains.token.service.TokenDomainService
-import com.sclass.domain.domains.user.adaptor.UserAdaptor
 import com.sclass.domain.domains.user.domain.Role
-import com.sclass.domain.domains.user.domain.User
+import com.sclass.domain.domains.user.service.UserDomainService
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class RefreshUseCaseTest {
-    private lateinit var userAdaptor: UserAdaptor
+    private lateinit var userDomainService: UserDomainService
     private lateinit var tokenDomainService: TokenDomainService
     private lateinit var refreshUseCase: RefreshUseCase
 
     @BeforeEach
     fun setUp() {
-        userAdaptor = mockk()
+        userDomainService = mockk()
         tokenDomainService = mockk()
-        refreshUseCase = RefreshUseCase(userAdaptor, tokenDomainService)
+        refreshUseCase = RefreshUseCase(userDomainService, tokenDomainService)
     }
 
     @Test
     fun `유효한 refresh token이면 기존 jti를 폐기하고 새 토큰을 발급한다`() {
         every { tokenDomainService.consumeRefreshToken("encrypted-refresh") } returns
             ResolvedRefreshToken(userId = "admin-id", tokenId = "refresh-token-id", role = Role.ADMIN)
-        every { userAdaptor.findById("admin-id") } returns mockk<User>()
+        every { userDomainService.validateUserHasRole("admin-id", Role.ADMIN) } just runs
         every { tokenDomainService.issueTokens("admin-id", Role.ADMIN) } returns
             TokenResult(accessToken = "new-access", refreshToken = "new-refresh")
 
@@ -39,6 +40,7 @@ class RefreshUseCaseTest {
         assertEquals("new-access", result.accessToken)
         assertEquals("new-refresh", result.refreshToken)
         verify { tokenDomainService.consumeRefreshToken("encrypted-refresh") }
+        verify { userDomainService.validateUserHasRole("admin-id", Role.ADMIN) }
         verify { tokenDomainService.issueTokens("admin-id", Role.ADMIN) }
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/controller/AuthController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/controller/AuthController.kt
@@ -7,6 +7,7 @@ import com.sclass.supporters.auth.dto.RegisterRequest
 import com.sclass.supporters.auth.dto.TokenResponse
 import com.sclass.supporters.auth.usecase.LoginUseCase
 import com.sclass.supporters.auth.usecase.LogoutUseCase
+import com.sclass.supporters.auth.usecase.RefreshUseCase
 import com.sclass.supporters.auth.usecase.RegisterUseCase
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.PostMapping
@@ -20,6 +21,7 @@ class AuthController(
     private val registerUseCase: RegisterUseCase,
     private val loginUseCase: LoginUseCase,
     private val logoutUseCase: LogoutUseCase,
+    private val refreshUseCase: RefreshUseCase,
 ) {
     @PostMapping("/register")
     fun register(
@@ -30,6 +32,11 @@ class AuthController(
     fun login(
         @Valid @RequestBody request: LoginRequest,
     ): ApiResponse<TokenResponse> = ApiResponse.success(loginUseCase.execute(request))
+
+    @PostMapping("/refresh")
+    fun refresh(
+        @Valid @RequestBody request: RefreshRequest,
+    ): ApiResponse<TokenResponse> = ApiResponse.success(refreshUseCase.execute(request))
 
     @PostMapping("/logout")
     fun logout(

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/LogoutUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/LogoutUseCase.kt
@@ -11,7 +11,6 @@ class LogoutUseCase(
 ) {
     @Transactional
     fun execute(request: RefreshRequest) {
-        val refreshToken = tokenService.resolveRefreshToken(request.refreshToken)
-        tokenService.revokeAllByUserId(refreshToken.userId)
+        tokenService.revokeRefreshToken(request.refreshToken)
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/LogoutUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/LogoutUseCase.kt
@@ -11,7 +11,7 @@ class LogoutUseCase(
 ) {
     @Transactional
     fun execute(request: RefreshRequest) {
-        val userId = tokenService.resolveUserId(request.refreshToken)
-        tokenService.revokeAllByUserId(userId)
+        val refreshToken = tokenService.resolveRefreshToken(request.refreshToken)
+        tokenService.revokeAllByUserId(refreshToken.userId)
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/RefreshUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/auth/usecase/RefreshUseCase.kt
@@ -2,20 +2,20 @@ package com.sclass.supporters.auth.usecase
 
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.token.service.TokenDomainService
-import com.sclass.domain.domains.user.adaptor.UserAdaptor
+import com.sclass.domain.domains.user.service.UserDomainService
 import com.sclass.supporters.auth.dto.RefreshRequest
 import com.sclass.supporters.auth.dto.TokenResponse
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class RefreshUseCase(
-    private val userAdaptor: UserAdaptor,
+    private val userDomainService: UserDomainService,
     private val tokenDomainService: TokenDomainService,
 ) {
     @Transactional
     fun execute(request: RefreshRequest): TokenResponse {
         val refreshToken = tokenDomainService.consumeRefreshToken(request.refreshToken)
-        userAdaptor.findById(refreshToken.userId)
+        userDomainService.validateUserHasRole(refreshToken.userId, refreshToken.role)
         val tokens = tokenDomainService.issueTokens(refreshToken.userId, refreshToken.role)
         return TokenResponse(
             accessToken = tokens.accessToken,

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/controller/AuthControllerIntegrationTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/controller/AuthControllerIntegrationTest.kt
@@ -1,0 +1,72 @@
+package com.sclass.supporters.auth.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.sclass.domain.domains.token.service.TokenDomainService
+import com.sclass.domain.domains.user.domain.AuthProvider
+import com.sclass.domain.domains.user.domain.Platform
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.domain.domains.user.domain.User
+import com.sclass.domain.domains.user.service.UserDomainService
+import com.sclass.supporters.auth.dto.RefreshRequest
+import com.sclass.supporters.config.ApiIntegrationTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+@ApiIntegrationTest
+class AuthControllerIntegrationTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var userDomainService: UserDomainService
+
+    @Autowired
+    private lateinit var tokenDomainService: TokenDomainService
+
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+
+    @Test
+    fun `refresh endpoint는 refresh token을 회전하고 이전 refresh token 재사용을 막는다`() {
+        val user =
+            userDomainService.register(
+                user =
+                    User(
+                        email = "refresh-${UUID.randomUUID()}@example.com",
+                        name = "테스트",
+                        authProvider = AuthProvider.EMAIL,
+                        phoneNumber = "010-1234-5678",
+                    ),
+                rawPassword = "password123",
+                platform = Platform.SUPPORTERS,
+                role = Role.STUDENT,
+            )
+        val tokens = tokenDomainService.issueTokens(user.id, Role.STUDENT)
+        val request = RefreshRequest(refreshToken = tokens.refreshToken)
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.accessToken").isNotEmpty)
+            .andExpect(jsonPath("$.data.refreshToken").isNotEmpty)
+
+        mockMvc
+            .perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            ).andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("TOKEN_004"))
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/LogoutUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/LogoutUseCaseTest.kt
@@ -1,0 +1,35 @@
+package com.sclass.supporters.auth.usecase
+
+import com.sclass.domain.domains.token.dto.ResolvedRefreshToken
+import com.sclass.domain.domains.token.service.TokenDomainService
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.supporters.auth.dto.RefreshRequest
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LogoutUseCaseTest {
+    private lateinit var tokenDomainService: TokenDomainService
+    private lateinit var logoutUseCase: LogoutUseCase
+
+    @BeforeEach
+    fun setUp() {
+        tokenDomainService = mockk()
+        logoutUseCase = LogoutUseCase(tokenDomainService)
+    }
+
+    @Test
+    fun `유효한 refresh token이면 해당 유저의 refresh token을 폐기한다`() {
+        every { tokenDomainService.resolveRefreshToken("encrypted-refresh") } returns
+            ResolvedRefreshToken(userId = "user-id", tokenId = "refresh-token-id", role = Role.STUDENT)
+        every { tokenDomainService.revokeAllByUserId("user-id") } just runs
+
+        logoutUseCase.execute(RefreshRequest(refreshToken = "encrypted-refresh"))
+
+        verify { tokenDomainService.revokeAllByUserId("user-id") }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/LogoutUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/LogoutUseCaseTest.kt
@@ -1,8 +1,6 @@
 package com.sclass.supporters.auth.usecase
 
-import com.sclass.domain.domains.token.dto.ResolvedRefreshToken
 import com.sclass.domain.domains.token.service.TokenDomainService
-import com.sclass.domain.domains.user.domain.Role
 import com.sclass.supporters.auth.dto.RefreshRequest
 import io.mockk.every
 import io.mockk.just
@@ -23,13 +21,11 @@ class LogoutUseCaseTest {
     }
 
     @Test
-    fun `유효한 refresh token이면 해당 유저의 refresh token을 폐기한다`() {
-        every { tokenDomainService.resolveRefreshToken("encrypted-refresh") } returns
-            ResolvedRefreshToken(userId = "user-id", tokenId = "refresh-token-id", role = Role.STUDENT)
-        every { tokenDomainService.revokeAllByUserId("user-id") } just runs
+    fun `유효한 refresh token이면 해당 refresh token만 폐기한다`() {
+        every { tokenDomainService.revokeRefreshToken("encrypted-refresh") } just runs
 
         logoutUseCase.execute(RefreshRequest(refreshToken = "encrypted-refresh"))
 
-        verify { tokenDomainService.revokeAllByUserId("user-id") }
+        verify { tokenDomainService.revokeRefreshToken("encrypted-refresh") }
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/RefreshUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/RefreshUseCaseTest.kt
@@ -3,34 +3,35 @@ package com.sclass.supporters.auth.usecase
 import com.sclass.domain.domains.token.dto.ResolvedRefreshToken
 import com.sclass.domain.domains.token.dto.TokenResult
 import com.sclass.domain.domains.token.service.TokenDomainService
-import com.sclass.domain.domains.user.adaptor.UserAdaptor
 import com.sclass.domain.domains.user.domain.Role
-import com.sclass.domain.domains.user.domain.User
+import com.sclass.domain.domains.user.service.UserDomainService
 import com.sclass.supporters.auth.dto.RefreshRequest
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class RefreshUseCaseTest {
-    private lateinit var userAdaptor: UserAdaptor
+    private lateinit var userDomainService: UserDomainService
     private lateinit var tokenDomainService: TokenDomainService
     private lateinit var refreshUseCase: RefreshUseCase
 
     @BeforeEach
     fun setUp() {
-        userAdaptor = mockk()
+        userDomainService = mockk()
         tokenDomainService = mockk()
-        refreshUseCase = RefreshUseCase(userAdaptor, tokenDomainService)
+        refreshUseCase = RefreshUseCase(userDomainService, tokenDomainService)
     }
 
     @Test
     fun `유효한 refresh token이면 기존 jti를 폐기하고 새 토큰을 발급한다`() {
         every { tokenDomainService.consumeRefreshToken("encrypted-refresh") } returns
             ResolvedRefreshToken(userId = "user-id", tokenId = "refresh-token-id", role = Role.STUDENT)
-        every { userAdaptor.findById("user-id") } returns mockk<User>()
+        every { userDomainService.validateUserHasRole("user-id", Role.STUDENT) } just runs
         every { tokenDomainService.issueTokens("user-id", Role.STUDENT) } returns
             TokenResult(accessToken = "new-access", refreshToken = "new-refresh")
 
@@ -39,6 +40,7 @@ class RefreshUseCaseTest {
         assertEquals("new-access", result.accessToken)
         assertEquals("new-refresh", result.refreshToken)
         verify { tokenDomainService.consumeRefreshToken("encrypted-refresh") }
+        verify { userDomainService.validateUserHasRole("user-id", Role.STUDENT) }
         verify { tokenDomainService.issueTokens("user-id", Role.STUDENT) }
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/RefreshUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/auth/usecase/RefreshUseCaseTest.kt
@@ -1,0 +1,44 @@
+package com.sclass.supporters.auth.usecase
+
+import com.sclass.domain.domains.token.dto.ResolvedRefreshToken
+import com.sclass.domain.domains.token.dto.TokenResult
+import com.sclass.domain.domains.token.service.TokenDomainService
+import com.sclass.domain.domains.user.adaptor.UserAdaptor
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.domain.domains.user.domain.User
+import com.sclass.supporters.auth.dto.RefreshRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class RefreshUseCaseTest {
+    private lateinit var userAdaptor: UserAdaptor
+    private lateinit var tokenDomainService: TokenDomainService
+    private lateinit var refreshUseCase: RefreshUseCase
+
+    @BeforeEach
+    fun setUp() {
+        userAdaptor = mockk()
+        tokenDomainService = mockk()
+        refreshUseCase = RefreshUseCase(userAdaptor, tokenDomainService)
+    }
+
+    @Test
+    fun `유효한 refresh token이면 기존 jti를 폐기하고 새 토큰을 발급한다`() {
+        every { tokenDomainService.consumeRefreshToken("encrypted-refresh") } returns
+            ResolvedRefreshToken(userId = "user-id", tokenId = "refresh-token-id", role = Role.STUDENT)
+        every { userAdaptor.findById("user-id") } returns mockk<User>()
+        every { tokenDomainService.issueTokens("user-id", Role.STUDENT) } returns
+            TokenResult(accessToken = "new-access", refreshToken = "new-refresh")
+
+        val result = refreshUseCase.execute(RefreshRequest(refreshToken = "encrypted-refresh"))
+
+        assertEquals("new-access", result.accessToken)
+        assertEquals("new-refresh", result.refreshToken)
+        verify { tokenDomainService.consumeRefreshToken("encrypted-refresh") }
+        verify { tokenDomainService.issueTokens("user-id", Role.STUDENT) }
+    }
+}

--- a/SClass-Common/src/main/kotlin/com/sclass/common/jwt/GeneratedRefreshToken.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/jwt/GeneratedRefreshToken.kt
@@ -1,0 +1,6 @@
+package com.sclass.common.jwt
+
+data class GeneratedRefreshToken(
+    val token: String,
+    val tokenId: String,
+)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/jwt/JwtTokenProvider.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/jwt/JwtTokenProvider.kt
@@ -11,6 +11,7 @@ import io.jsonwebtoken.security.Keys
 import org.springframework.stereotype.Component
 import java.nio.charset.StandardCharsets
 import java.util.Date
+import java.util.UUID
 import javax.crypto.SecretKey
 
 @Component
@@ -80,18 +81,26 @@ class JwtTokenProvider(
             .compact()
     }
 
-    fun generateRefreshToken(userId: String): String {
+    fun generateRefreshToken(
+        userId: String,
+        role: String,
+    ): GeneratedRefreshToken {
         val issuedAt = Date()
         val expiration = Date(issuedAt.time + jwtProperties.refreshExp * MILLI_TO_SECOND)
-        return Jwts
-            .builder()
-            .issuer(TOKEN_ISSUER)
-            .issuedAt(issuedAt)
-            .subject(userId)
-            .claim(TOKEN_TYPE, REFRESH_TOKEN)
-            .expiration(expiration)
-            .signWith(secretKey)
-            .compact()
+        val tokenId = UUID.randomUUID().toString()
+        val token =
+            Jwts
+                .builder()
+                .issuer(TOKEN_ISSUER)
+                .issuedAt(issuedAt)
+                .subject(userId)
+                .id(tokenId)
+                .claim(TOKEN_TYPE, REFRESH_TOKEN)
+                .claim(ROLE, role)
+                .expiration(expiration)
+                .signWith(secretKey)
+                .compact()
+        return GeneratedRefreshToken(token = token, tokenId = tokenId)
     }
 
     fun parseAccessToken(token: String): AccessTokenInfo {
@@ -106,7 +115,7 @@ class JwtTokenProvider(
         )
     }
 
-    fun parseRefreshToken(token: String): String {
+    fun parseRefreshToken(token: String): RefreshTokenInfo {
         val claims =
             try {
                 getJws(token).payload
@@ -116,7 +125,17 @@ class JwtTokenProvider(
         if (claims.get(TOKEN_TYPE) != REFRESH_TOKEN) {
             throw InvalidTokenException()
         }
-        return claims.subject
+        val userId = claims.subject
+        val tokenId = claims.id
+        val role = claims.get(ROLE, String::class.java)
+        if (userId.isNullOrBlank() || tokenId.isNullOrBlank() || role.isNullOrBlank()) {
+            throw InvalidTokenException()
+        }
+        return RefreshTokenInfo(
+            userId = userId,
+            tokenId = tokenId,
+            role = role,
+        )
     }
 
     fun getRefreshTokenTtlSecond(): Long = jwtProperties.refreshExp

--- a/SClass-Common/src/main/kotlin/com/sclass/common/jwt/RefreshTokenInfo.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/jwt/RefreshTokenInfo.kt
@@ -1,0 +1,7 @@
+package com.sclass.common.jwt
+
+data class RefreshTokenInfo(
+    val userId: String,
+    val tokenId: String,
+    val role: String,
+)

--- a/SClass-Common/src/test/kotlin/com/sclass/common/jwt/JwtTokenProviderTest.kt
+++ b/SClass-Common/src/test/kotlin/com/sclass/common/jwt/JwtTokenProviderTest.kt
@@ -33,12 +33,14 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    fun `refresh token 생성 후 파싱하면 userId가 복원된다`() {
-        val token = provider.generateRefreshToken("user-456")
+    fun `refresh token 생성 후 파싱하면 userId와 tokenId와 role이 복원된다`() {
+        val token = provider.generateRefreshToken("user-456", "STUDENT")
 
-        val userId = provider.parseRefreshToken(token)
+        val info = provider.parseRefreshToken(token.token)
 
-        assertEquals("user-456", userId)
+        assertEquals("user-456", info.userId)
+        assertEquals(token.tokenId, info.tokenId)
+        assertEquals("STUDENT", info.role)
     }
 
     @Test
@@ -85,10 +87,10 @@ class JwtTokenProviderTest {
 
     @Test
     fun `refresh token으로 access token 파싱을 시도하면 InvalidTokenException이 발생한다`() {
-        val refreshToken = provider.generateRefreshToken("user-id")
+        val refreshToken = provider.generateRefreshToken("user-id", "STUDENT")
 
         assertThrows<InvalidTokenException> {
-            provider.parseAccessToken(refreshToken)
+            provider.parseAccessToken(refreshToken.token)
         }
     }
 

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/adaptor/RefreshTokenAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/adaptor/RefreshTokenAdaptor.kt
@@ -3,18 +3,20 @@ package com.sclass.domain.domains.token.adaptor
 import com.sclass.common.annotation.Adaptor
 import com.sclass.domain.domains.token.domain.RefreshToken
 import com.sclass.domain.domains.token.repository.RefreshTokenRepository
+import java.time.Clock
 import java.time.LocalDateTime
 
 @Adaptor
 class RefreshTokenAdaptor(
     private val refreshTokenRepository: RefreshTokenRepository,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     fun findAllByUserId(userId: String): List<RefreshToken> = refreshTokenRepository.findAllByUserId(userId)
 
     fun existsValidByTokenIdAndUserId(
         tokenId: String,
         userId: String,
-    ): Boolean = refreshTokenRepository.existsByTokenIdAndUserIdAndExpiresAtAfter(tokenId, userId, LocalDateTime.now())
+    ): Boolean = refreshTokenRepository.existsByTokenIdAndUserIdAndExpiresAtAfter(tokenId, userId, LocalDateTime.now(clock))
 
     fun save(refreshToken: RefreshToken): RefreshToken = refreshTokenRepository.save(refreshToken)
 
@@ -23,7 +25,7 @@ class RefreshTokenAdaptor(
     fun deleteValidByTokenIdAndUserId(
         tokenId: String,
         userId: String,
-    ): Long = refreshTokenRepository.deleteValidByTokenIdAndUserId(tokenId, userId, LocalDateTime.now())
+    ): Long = refreshTokenRepository.deleteValidByTokenIdAndUserId(tokenId, userId, LocalDateTime.now(clock))
 
     fun deleteById(id: String) = refreshTokenRepository.deleteById(id)
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/adaptor/RefreshTokenAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/adaptor/RefreshTokenAdaptor.kt
@@ -11,11 +11,19 @@ class RefreshTokenAdaptor(
 ) {
     fun findAllByUserId(userId: String): List<RefreshToken> = refreshTokenRepository.findAllByUserId(userId)
 
-    fun existsValidByUserId(userId: String): Boolean = refreshTokenRepository.existsByUserIdAndExpiresAtAfter(userId, LocalDateTime.now())
+    fun existsValidByTokenIdAndUserId(
+        tokenId: String,
+        userId: String,
+    ): Boolean = refreshTokenRepository.existsByTokenIdAndUserIdAndExpiresAtAfter(tokenId, userId, LocalDateTime.now())
 
     fun save(refreshToken: RefreshToken): RefreshToken = refreshTokenRepository.save(refreshToken)
 
     fun deleteAllByUserId(userId: String) = refreshTokenRepository.deleteAllByUserId(userId)
+
+    fun deleteValidByTokenIdAndUserId(
+        tokenId: String,
+        userId: String,
+    ): Long = refreshTokenRepository.deleteValidByTokenIdAndUserId(tokenId, userId, LocalDateTime.now())
 
     fun deleteById(id: String) = refreshTokenRepository.deleteById(id)
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/domain/RefreshToken.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/domain/RefreshToken.kt
@@ -15,6 +15,7 @@ import java.time.LocalDateTime
     name = "refresh_tokens",
     indexes = [
         Index(name = "idx_refresh_token_user_id", columnList = "userId"),
+        Index(name = "idx_refresh_token_token_id", columnList = "tokenId", unique = true),
     ],
 )
 class RefreshToken(
@@ -24,6 +25,9 @@ class RefreshToken(
 
     @Column(nullable = false, length = 26)
     val userId: String,
+
+    @Column(nullable = false, unique = true, length = 36)
+    val tokenId: String,
 
     @Column(nullable = false)
     val expiresAt: LocalDateTime,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/dto/ResolvedRefreshToken.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/dto/ResolvedRefreshToken.kt
@@ -1,0 +1,9 @@
+package com.sclass.domain.domains.token.dto
+
+import com.sclass.domain.domains.user.domain.Role
+
+data class ResolvedRefreshToken(
+    val userId: String,
+    val tokenId: String,
+    val role: Role,
+)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/repository/RefreshTokenCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/repository/RefreshTokenCustomRepository.kt
@@ -1,0 +1,11 @@
+package com.sclass.domain.domains.token.repository
+
+import java.time.LocalDateTime
+
+interface RefreshTokenCustomRepository {
+    fun deleteValidByTokenIdAndUserId(
+        tokenId: String,
+        userId: String,
+        now: LocalDateTime,
+    ): Long
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/repository/RefreshTokenCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/repository/RefreshTokenCustomRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.sclass.domain.domains.token.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sclass.domain.domains.token.domain.QRefreshToken.refreshToken
+import java.time.LocalDateTime
+
+class RefreshTokenCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : RefreshTokenCustomRepository {
+    override fun deleteValidByTokenIdAndUserId(
+        tokenId: String,
+        userId: String,
+        now: LocalDateTime,
+    ): Long =
+        queryFactory
+            .delete(refreshToken)
+            .where(
+                refreshToken.tokenId.eq(tokenId),
+                refreshToken.userId.eq(userId),
+                refreshToken.expiresAt.gt(now),
+            ).execute()
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/repository/RefreshTokenRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/repository/RefreshTokenRepository.kt
@@ -4,10 +4,13 @@ import com.sclass.domain.domains.token.domain.RefreshToken
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDateTime
 
-interface RefreshTokenRepository : JpaRepository<RefreshToken, String> {
+interface RefreshTokenRepository :
+    JpaRepository<RefreshToken, String>,
+    RefreshTokenCustomRepository {
     fun findAllByUserId(userId: String): List<RefreshToken>
 
-    fun existsByUserIdAndExpiresAtAfter(
+    fun existsByTokenIdAndUserIdAndExpiresAtAfter(
+        tokenId: String,
         userId: String,
         now: LocalDateTime,
     ): Boolean

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/service/TokenDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/service/TokenDomainService.kt
@@ -5,9 +5,11 @@ import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.common.jwt.JwtTokenProvider
 import com.sclass.common.jwt.SignupTokenInfo
 import com.sclass.common.jwt.VerificationTokenInfo
+import com.sclass.common.jwt.exception.InvalidTokenException
 import com.sclass.common.jwt.exception.RefreshTokenRevokedException
 import com.sclass.domain.domains.token.adaptor.RefreshTokenAdaptor
 import com.sclass.domain.domains.token.domain.RefreshToken
+import com.sclass.domain.domains.token.dto.ResolvedRefreshToken
 import com.sclass.domain.domains.token.dto.TokenResult
 import com.sclass.domain.domains.user.domain.AuthProvider
 import com.sclass.domain.domains.user.domain.Platform
@@ -28,18 +30,19 @@ class TokenDomainService(
         role: Role,
     ): TokenResult {
         val accessToken = jwtTokenProvider.generateAccessToken(userId, role.name)
-        val refreshJwt = jwtTokenProvider.generateRefreshToken(userId)
+        val refreshJwt = jwtTokenProvider.generateRefreshToken(userId, role.name)
 
         refreshTokenAdaptor.save(
             RefreshToken(
                 userId = userId,
+                tokenId = refreshJwt.tokenId,
                 expiresAt = LocalDateTime.now().plusSeconds(jwtTokenProvider.getRefreshTokenTtlSecond()),
             ),
         )
 
         return TokenResult(
             accessToken = aesTokenEncryptor.encrypt(accessToken),
-            refreshToken = aesTokenEncryptor.encrypt(refreshJwt),
+            refreshToken = aesTokenEncryptor.encrypt(refreshJwt.token),
         )
     }
 
@@ -48,15 +51,28 @@ class TokenDomainService(
         refreshTokenAdaptor.deleteAllByUserId(userId)
     }
 
-    fun resolveUserId(encryptedRefreshToken: String): String {
-        val refreshJwt = aesTokenEncryptor.decrypt(encryptedRefreshToken)
-        val userId = jwtTokenProvider.parseRefreshToken(refreshJwt)
+    @Transactional
+    fun consumeRefreshToken(encryptedRefreshToken: String): ResolvedRefreshToken {
+        val refreshToken = parseEncryptedRefreshToken(encryptedRefreshToken)
+        val deletedCount =
+            refreshTokenAdaptor.deleteValidByTokenIdAndUserId(
+                tokenId = refreshToken.tokenId,
+                userId = refreshToken.userId,
+            )
+        if (deletedCount == 0L) {
+            throw RefreshTokenRevokedException()
+        }
+        return refreshToken
+    }
 
-        if (!refreshTokenAdaptor.existsValidByUserId(userId)) {
+    fun resolveRefreshToken(encryptedRefreshToken: String): ResolvedRefreshToken {
+        val refreshToken = parseEncryptedRefreshToken(encryptedRefreshToken)
+
+        if (!refreshTokenAdaptor.existsValidByTokenIdAndUserId(refreshToken.tokenId, refreshToken.userId)) {
             throw RefreshTokenRevokedException()
         }
 
-        return userId
+        return refreshToken
     }
 
     fun issueSignupToken(
@@ -88,4 +104,28 @@ class TokenDomainService(
         val jwt = aesTokenEncryptor.decrypt(encryptedToken)
         return jwtTokenProvider.parseVerificationToken(jwt)
     }
+
+    private fun decryptRefreshToken(encryptedRefreshToken: String): String =
+        try {
+            aesTokenEncryptor.decrypt(encryptedRefreshToken)
+        } catch (e: Exception) {
+            throw InvalidTokenException()
+        }
+
+    private fun parseEncryptedRefreshToken(encryptedRefreshToken: String): ResolvedRefreshToken {
+        val refreshJwt = decryptRefreshToken(encryptedRefreshToken)
+        val tokenInfo = jwtTokenProvider.parseRefreshToken(refreshJwt)
+        return ResolvedRefreshToken(
+            userId = tokenInfo.userId,
+            tokenId = tokenInfo.tokenId,
+            role = parseRole(tokenInfo.role),
+        )
+    }
+
+    private fun parseRole(role: String): Role =
+        try {
+            Role.valueOf(role)
+        } catch (e: IllegalArgumentException) {
+            throw InvalidTokenException()
+        }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/service/TokenDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/token/service/TokenDomainService.kt
@@ -16,6 +16,7 @@ import com.sclass.domain.domains.user.domain.Platform
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.domain.domains.verification.domain.VerificationChannel
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 import java.time.LocalDateTime
 
 @DomainService
@@ -23,6 +24,7 @@ class TokenDomainService(
     private val jwtTokenProvider: JwtTokenProvider,
     private val aesTokenEncryptor: AesTokenEncryptor,
     private val refreshTokenAdaptor: RefreshTokenAdaptor,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     @Transactional
     fun issueTokens(
@@ -36,7 +38,7 @@ class TokenDomainService(
             RefreshToken(
                 userId = userId,
                 tokenId = refreshJwt.tokenId,
-                expiresAt = LocalDateTime.now().plusSeconds(jwtTokenProvider.getRefreshTokenTtlSecond()),
+                expiresAt = LocalDateTime.now(clock).plusSeconds(jwtTokenProvider.getRefreshTokenTtlSecond()),
             ),
         )
 
@@ -52,7 +54,14 @@ class TokenDomainService(
     }
 
     @Transactional
-    fun consumeRefreshToken(encryptedRefreshToken: String): ResolvedRefreshToken {
+    fun consumeRefreshToken(encryptedRefreshToken: String): ResolvedRefreshToken = deleteValidRefreshToken(encryptedRefreshToken)
+
+    @Transactional
+    fun revokeRefreshToken(encryptedRefreshToken: String) {
+        deleteValidRefreshToken(encryptedRefreshToken)
+    }
+
+    private fun deleteValidRefreshToken(encryptedRefreshToken: String): ResolvedRefreshToken {
         val refreshToken = parseEncryptedRefreshToken(encryptedRefreshToken)
         val deletedCount =
             refreshTokenAdaptor.deleteValidByTokenIdAndUserId(

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/service/UserDomainService.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/service/UserDomainService.kt
@@ -146,6 +146,17 @@ class UserDomainService(
         }
     }
 
+    @Transactional(readOnly = true)
+    fun validateUserHasRole(
+        userId: String,
+        role: Role,
+    ) {
+        userAdaptor.findById(userId)
+        if (userRoleAdaptor.findAllByUserIdAndRole(userId, role).isEmpty()) {
+            throw RoleNotFoundException()
+        }
+    }
+
     fun addUserRole(
         userId: String,
         platform: Platform,

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceIntegrationTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceIntegrationTest.kt
@@ -41,6 +41,12 @@ class TokenDomainServiceIntegrationTest {
         val refreshTokens = refreshTokenRepository.findAllByUserId(userId)
         assertThat(refreshTokens).hasSize(1)
         assertThat(refreshTokens[0].userId).isEqualTo(userId)
+        assertThat(refreshTokens[0].tokenId).isNotBlank()
+
+        val resolvedRefreshToken = tokenDomainService.resolveRefreshToken(result.refreshToken)
+        assertThat(resolvedRefreshToken.userId).isEqualTo(userId)
+        assertThat(resolvedRefreshToken.tokenId).isEqualTo(refreshTokens[0].tokenId)
+        assertThat(resolvedRefreshToken.role).isEqualTo(Role.STUDENT)
     }
 
     @Test

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceIntegrationTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceIntegrationTest.kt
@@ -88,4 +88,19 @@ class TokenDomainServiceIntegrationTest {
         // then
         assertThat(refreshTokenRepository.findAllByUserId(userId)).isEmpty()
     }
+
+    @Test
+    fun `revokeRefreshToken은 요청한 RefreshToken만 삭제한다`() {
+        // given
+        val userId = "test-user-id-0000000000003"
+        val firstTokens = tokenDomainService.issueTokens(userId, Role.STUDENT)
+        tokenDomainService.issueTokens(userId, Role.STUDENT)
+        assertThat(refreshTokenRepository.findAllByUserId(userId)).hasSize(2)
+
+        // when
+        tokenDomainService.revokeRefreshToken(firstTokens.refreshToken)
+
+        // then
+        assertThat(refreshTokenRepository.findAllByUserId(userId)).hasSize(1)
+    }
 }

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceTest.kt
@@ -23,19 +23,24 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 class TokenDomainServiceTest {
     private lateinit var jwtTokenProvider: JwtTokenProvider
     private lateinit var aesTokenEncryptor: AesTokenEncryptor
     private lateinit var refreshTokenAdaptor: RefreshTokenAdaptor
     private lateinit var tokenDomainService: TokenDomainService
+    private val fixedClock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneId.of("UTC"))
 
     @BeforeEach
     fun setUp() {
         jwtTokenProvider = mockk()
         aesTokenEncryptor = mockk()
         refreshTokenAdaptor = mockk()
-        tokenDomainService = TokenDomainService(jwtTokenProvider, aesTokenEncryptor, refreshTokenAdaptor)
+        tokenDomainService = TokenDomainService(jwtTokenProvider, aesTokenEncryptor, refreshTokenAdaptor, fixedClock)
     }
 
     @Nested
@@ -70,6 +75,7 @@ class TokenDomainServiceTest {
 
             assertEquals("user-id", refreshTokenSlot.captured.userId)
             assertEquals("refresh-token-id", refreshTokenSlot.captured.tokenId)
+            assertEquals(LocalDateTime.of(2026, 1, 8, 0, 0), refreshTokenSlot.captured.expiresAt)
         }
     }
 
@@ -141,6 +147,21 @@ class TokenDomainServiceTest {
             assertThrows<RefreshTokenRevokedException> {
                 tokenDomainService.consumeRefreshToken("encrypted-refresh")
             }
+        }
+    }
+
+    @Nested
+    inner class RevokeRefreshToken {
+        @Test
+        fun `유효한 refresh token이면 해당 jti를 삭제한다`() {
+            every { aesTokenEncryptor.decrypt("encrypted-refresh") } returns "raw-refresh"
+            every { jwtTokenProvider.parseRefreshToken("raw-refresh") } returns
+                RefreshTokenInfo(userId = "user-id", tokenId = "refresh-token-id", role = "STUDENT")
+            every { refreshTokenAdaptor.deleteValidByTokenIdAndUserId("refresh-token-id", "user-id") } returns 1L
+
+            tokenDomainService.revokeRefreshToken("encrypted-refresh")
+
+            verify { refreshTokenAdaptor.deleteValidByTokenIdAndUserId("refresh-token-id", "user-id") }
         }
     }
 

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/token/service/TokenDomainServiceTest.kt
@@ -1,7 +1,9 @@
 package com.sclass.domain.domains.token.service
 
 import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.common.jwt.GeneratedRefreshToken
 import com.sclass.common.jwt.JwtTokenProvider
+import com.sclass.common.jwt.RefreshTokenInfo
 import com.sclass.common.jwt.VerificationTokenInfo
 import com.sclass.common.jwt.exception.RefreshTokenRevokedException
 import com.sclass.domain.domains.token.adaptor.RefreshTokenAdaptor
@@ -41,7 +43,8 @@ class TokenDomainServiceTest {
         @Test
         fun `암호화된 access token과 refresh token을 반환한다`() {
             every { jwtTokenProvider.generateAccessToken("user-id", "STUDENT") } returns "raw-access"
-            every { jwtTokenProvider.generateRefreshToken("user-id") } returns "raw-refresh"
+            every { jwtTokenProvider.generateRefreshToken("user-id", "STUDENT") } returns
+                GeneratedRefreshToken(token = "raw-refresh", tokenId = "refresh-token-id")
             every { jwtTokenProvider.getRefreshTokenTtlSecond() } returns 604800L
             every { aesTokenEncryptor.encrypt("raw-access") } returns "encrypted-access"
             every { aesTokenEncryptor.encrypt("raw-refresh") } returns "encrypted-refresh"
@@ -57,7 +60,8 @@ class TokenDomainServiceTest {
         fun `RefreshToken이 저장된다`() {
             val refreshTokenSlot = slot<RefreshToken>()
             every { jwtTokenProvider.generateAccessToken("user-id", "STUDENT") } returns "raw-access"
-            every { jwtTokenProvider.generateRefreshToken("user-id") } returns "raw-refresh"
+            every { jwtTokenProvider.generateRefreshToken("user-id", "STUDENT") } returns
+                GeneratedRefreshToken(token = "raw-refresh", tokenId = "refresh-token-id")
             every { jwtTokenProvider.getRefreshTokenTtlSecond() } returns 604800L
             every { aesTokenEncryptor.encrypt(any()) } returns "encrypted"
             every { refreshTokenAdaptor.save(capture(refreshTokenSlot)) } returns mockk()
@@ -65,30 +69,35 @@ class TokenDomainServiceTest {
             tokenDomainService.issueTokens("user-id", Role.STUDENT)
 
             assertEquals("user-id", refreshTokenSlot.captured.userId)
+            assertEquals("refresh-token-id", refreshTokenSlot.captured.tokenId)
         }
     }
 
     @Nested
-    inner class ResolveUserId {
+    inner class ResolveRefreshToken {
         @Test
-        fun `유효한 refresh token이 DB에 존재하면 userId를 반환한다`() {
+        fun `유효한 refresh token이 DB에 존재하면 토큰 정보를 반환한다`() {
             every { aesTokenEncryptor.decrypt("encrypted-refresh") } returns "raw-refresh"
-            every { jwtTokenProvider.parseRefreshToken("raw-refresh") } returns "user-id"
-            every { refreshTokenAdaptor.existsValidByUserId("user-id") } returns true
+            every { jwtTokenProvider.parseRefreshToken("raw-refresh") } returns
+                RefreshTokenInfo(userId = "user-id", tokenId = "refresh-token-id", role = "STUDENT")
+            every { refreshTokenAdaptor.existsValidByTokenIdAndUserId("refresh-token-id", "user-id") } returns true
 
-            val result = tokenDomainService.resolveUserId("encrypted-refresh")
+            val result = tokenDomainService.resolveRefreshToken("encrypted-refresh")
 
-            assertEquals("user-id", result)
+            assertEquals("user-id", result.userId)
+            assertEquals("refresh-token-id", result.tokenId)
+            assertEquals(Role.STUDENT, result.role)
         }
 
         @Test
         fun `DB에 유효한 refresh token이 없으면 RefreshTokenRevokedException을 던진다`() {
             every { aesTokenEncryptor.decrypt("encrypted-refresh") } returns "raw-refresh"
-            every { jwtTokenProvider.parseRefreshToken("raw-refresh") } returns "user-id"
-            every { refreshTokenAdaptor.existsValidByUserId("user-id") } returns false
+            every { jwtTokenProvider.parseRefreshToken("raw-refresh") } returns
+                RefreshTokenInfo(userId = "user-id", tokenId = "refresh-token-id", role = "STUDENT")
+            every { refreshTokenAdaptor.existsValidByTokenIdAndUserId("refresh-token-id", "user-id") } returns false
 
             assertThrows<RefreshTokenRevokedException> {
-                tokenDomainService.resolveUserId("encrypted-refresh")
+                tokenDomainService.resolveRefreshToken("encrypted-refresh")
             }
         }
     }
@@ -102,6 +111,36 @@ class TokenDomainServiceTest {
             tokenDomainService.revokeAllByUserId("user-id")
 
             verify { refreshTokenAdaptor.deleteAllByUserId("user-id") }
+        }
+    }
+
+    @Nested
+    inner class ConsumeRefreshToken {
+        @Test
+        fun `유효한 refresh token이면 해당 jti를 삭제하고 토큰 정보를 반환한다`() {
+            every { aesTokenEncryptor.decrypt("encrypted-refresh") } returns "raw-refresh"
+            every { jwtTokenProvider.parseRefreshToken("raw-refresh") } returns
+                RefreshTokenInfo(userId = "user-id", tokenId = "refresh-token-id", role = "STUDENT")
+            every { refreshTokenAdaptor.deleteValidByTokenIdAndUserId("refresh-token-id", "user-id") } returns 1L
+
+            val result = tokenDomainService.consumeRefreshToken("encrypted-refresh")
+
+            assertEquals("user-id", result.userId)
+            assertEquals("refresh-token-id", result.tokenId)
+            assertEquals(Role.STUDENT, result.role)
+            verify { refreshTokenAdaptor.deleteValidByTokenIdAndUserId("refresh-token-id", "user-id") }
+        }
+
+        @Test
+        fun `삭제된 refresh token이면 RefreshTokenRevokedException을 던진다`() {
+            every { aesTokenEncryptor.decrypt("encrypted-refresh") } returns "raw-refresh"
+            every { jwtTokenProvider.parseRefreshToken("raw-refresh") } returns
+                RefreshTokenInfo(userId = "user-id", tokenId = "refresh-token-id", role = "STUDENT")
+            every { refreshTokenAdaptor.deleteValidByTokenIdAndUserId("refresh-token-id", "user-id") } returns 0L
+
+            assertThrows<RefreshTokenRevokedException> {
+                tokenDomainService.consumeRefreshToken("encrypted-refresh")
+            }
         }
     }
 

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/user/service/UserDomainServiceTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/user/service/UserDomainServiceTest.kt
@@ -354,4 +354,30 @@ class UserDomainServiceTest {
             verify(exactly = 1) { userRoleAdaptor.save(any()) }
         }
     }
+
+    @Nested
+    inner class ValidateUserHasRole {
+        @Test
+        fun `유저에게 해당 role이 있으면 정상 종료한다`() {
+            val user = mockk<User> { every { id } returns "user-id" }
+            every { userAdaptor.findById("user-id") } returns user
+            every { userRoleAdaptor.findAllByUserIdAndRole("user-id", Role.STUDENT) } returns listOf(mockk())
+
+            userDomainService.validateUserHasRole("user-id", Role.STUDENT)
+
+            verify { userAdaptor.findById("user-id") }
+            verify { userRoleAdaptor.findAllByUserIdAndRole("user-id", Role.STUDENT) }
+        }
+
+        @Test
+        fun `유저에게 해당 role이 없으면 RoleNotFoundException이 발생한다`() {
+            val user = mockk<User> { every { id } returns "user-id" }
+            every { userAdaptor.findById("user-id") } returns user
+            every { userRoleAdaptor.findAllByUserIdAndRole("user-id", Role.ADMIN) } returns emptyList()
+
+            assertThrows<RoleNotFoundException> {
+                userDomainService.validateUserHasRole("user-id", Role.ADMIN)
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 요약
- refresh token에 jti(tokenId)와 role을 포함하고 DB에도 tokenId를 저장하도록 변경했습니다.
- refresh 재발급 시 기존 refresh token을 QueryDSL bulk delete로 consume하고 새 access/refresh token을 발급하도록 rotation을 적용했습니다.
- backoffice와 supporters 모두 /api/v1/auth/refresh, /logout 흐름과 테스트를 추가했습니다.

## 배포 참고
- 기존 refresh token에는 jti가 없으므로 배포 시 refresh_tokens 테이블 비우기가 필요합니다.
- FE는 refresh 성공 시 accessToken과 refreshToken을 모두 교체해야 합니다.

## 검증
- ./gradlew ktlintCheck :SClass-Domain:test :SClass-Api-Supporters:test :SClass-Api-Backoffice:test
- pre-commit build hook
