### PR TITLE
feat(lesson): start/complete/record lifecycle APIs

### DIFF
--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/controller/LessonController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/controller/LessonController.kt
@@ -4,17 +4,23 @@ import com.sclass.common.annotation.CurrentUserId
 import com.sclass.common.dto.ApiResponse
 import com.sclass.domain.domains.lesson.domain.LessonStatus
 import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
+import com.sclass.supporters.lesson.dto.CompleteLessonRequest
 import com.sclass.supporters.lesson.dto.CreateLessonInquiryPlanRequest
 import com.sclass.supporters.lesson.dto.LessonDetailResponse
 import com.sclass.supporters.lesson.dto.LessonReportResponse
 import com.sclass.supporters.lesson.dto.LessonResponse
+import com.sclass.supporters.lesson.dto.RecordLessonRequest
+import com.sclass.supporters.lesson.dto.StartLessonRequest
 import com.sclass.supporters.lesson.dto.SubmitLessonReportRequest
 import com.sclass.supporters.lesson.dto.UpdateLessonReportRequest
 import com.sclass.supporters.lesson.dto.UpdateLessonRequest
+import com.sclass.supporters.lesson.usecase.CompleteLessonUseCase
 import com.sclass.supporters.lesson.usecase.CreateLessonInquiryPlanUseCase
 import com.sclass.supporters.lesson.usecase.GetLessonDetailUseCase
 import com.sclass.supporters.lesson.usecase.GetLessonReportUseCase
 import com.sclass.supporters.lesson.usecase.GetMySubstituteLessonsUseCase
+import com.sclass.supporters.lesson.usecase.RecordLessonUseCase
+import com.sclass.supporters.lesson.usecase.StartLessonUseCase
 import com.sclass.supporters.lesson.usecase.SubmitLessonReportUseCase
 import com.sclass.supporters.lesson.usecase.UpdateLessonReportUseCase
 import com.sclass.supporters.lesson.usecase.UpdateLessonUseCase
@@ -39,6 +45,9 @@ class LessonController(
     private val getLessonReportUseCase: GetLessonReportUseCase,
     private val updateLessonReportUseCase: UpdateLessonReportUseCase,
     private val getMySubstituteLessonsUseCase: GetMySubstituteLessonsUseCase,
+    private val startLessonUseCase: StartLessonUseCase,
+    private val completeLessonUseCase: CompleteLessonUseCase,
+    private val recordLessonUseCase: RecordLessonUseCase,
 ) {
     @GetMapping("/my/substitutes")
     fun mySubstituteLessons(
@@ -85,4 +94,25 @@ class LessonController(
         @PathVariable lessonId: Long,
         @Valid @RequestBody request: UpdateLessonReportRequest,
     ): ApiResponse<LessonReportResponse> = ApiResponse.success(updateLessonReportUseCase.execute(userId, lessonId, request))
+
+    @PostMapping("/{lessonId}/start")
+    fun start(
+        @CurrentUserId userId: String,
+        @PathVariable lessonId: Long,
+        @Valid @RequestBody request: StartLessonRequest,
+    ): ApiResponse<LessonResponse> = ApiResponse.success(startLessonUseCase.execute(userId, lessonId, request))
+
+    @PostMapping("/{lessonId}/complete")
+    fun complete(
+        @CurrentUserId userId: String,
+        @PathVariable lessonId: Long,
+        @Valid @RequestBody request: CompleteLessonRequest,
+    ): ApiResponse<LessonResponse> = ApiResponse.success(completeLessonUseCase.execute(userId, lessonId, request))
+
+    @PutMapping("/{lessonId}/record")
+    fun record(
+        @CurrentUserId userId: String,
+        @PathVariable lessonId: Long,
+        @Valid @RequestBody request: RecordLessonRequest,
+    ): ApiResponse<LessonResponse> = ApiResponse.success(recordLessonUseCase.execute(userId, lessonId, request))
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/controller/LessonController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/controller/LessonController.kt
@@ -99,15 +99,16 @@ class LessonController(
     fun start(
         @CurrentUserId userId: String,
         @PathVariable lessonId: Long,
-        @Valid @RequestBody request: StartLessonRequest,
-    ): ApiResponse<LessonResponse> = ApiResponse.success(startLessonUseCase.execute(userId, lessonId, request))
+        @Valid @RequestBody(required = false) request: StartLessonRequest?,
+    ): ApiResponse<LessonResponse> = ApiResponse.success(startLessonUseCase.execute(userId, lessonId, request ?: StartLessonRequest()))
 
     @PostMapping("/{lessonId}/complete")
     fun complete(
         @CurrentUserId userId: String,
         @PathVariable lessonId: Long,
-        @Valid @RequestBody request: CompleteLessonRequest,
-    ): ApiResponse<LessonResponse> = ApiResponse.success(completeLessonUseCase.execute(userId, lessonId, request))
+        @Valid @RequestBody(required = false) request: CompleteLessonRequest?,
+    ): ApiResponse<LessonResponse> =
+        ApiResponse.success(completeLessonUseCase.execute(userId, lessonId, request ?: CompleteLessonRequest()))
 
     @PutMapping("/{lessonId}/record")
     fun record(

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/CompleteLessonRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/CompleteLessonRequest.kt
@@ -1,0 +1,7 @@
+package com.sclass.supporters.lesson.dto
+
+import java.time.LocalDateTime
+
+data class CompleteLessonRequest(
+    val completedAt: LocalDateTime? = null,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/RecordLessonRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/RecordLessonRequest.kt
@@ -1,0 +1,9 @@
+package com.sclass.supporters.lesson.dto
+
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDateTime
+
+data class RecordLessonRequest(
+    @field:NotNull val startedAt: LocalDateTime,
+    @field:NotNull val completedAt: LocalDateTime,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/StartLessonRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/StartLessonRequest.kt
@@ -1,0 +1,7 @@
+package com.sclass.supporters.lesson.dto
+
+import java.time.LocalDateTime
+
+data class StartLessonRequest(
+    val startedAt: LocalDateTime? = null,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CompleteLessonUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CompleteLessonUseCase.kt
@@ -1,0 +1,26 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.supporters.lesson.dto.CompleteLessonRequest
+import com.sclass.supporters.lesson.dto.LessonResponse
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@UseCase
+class CompleteLessonUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+) {
+    @Transactional
+    fun execute(
+        userId: String,
+        lessonId: Long,
+        request: CompleteLessonRequest,
+    ): LessonResponse {
+        val lesson = lessonAdaptor.findById(lessonId)
+        if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
+        lesson.complete(actualTeacherUserId = userId, at = request.completedAt ?: LocalDateTime.now())
+        return LessonResponse.from(lesson)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CompleteLessonUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CompleteLessonUseCase.kt
@@ -6,11 +6,12 @@ import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessExcept
 import com.sclass.supporters.lesson.dto.CompleteLessonRequest
 import com.sclass.supporters.lesson.dto.LessonResponse
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
+import java.time.Clock
 
 @UseCase
 class CompleteLessonUseCase(
     private val lessonAdaptor: LessonAdaptor,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     @Transactional
     fun execute(
@@ -20,7 +21,12 @@ class CompleteLessonUseCase(
     ): LessonResponse {
         val lesson = lessonAdaptor.findById(lessonId)
         if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
-        lesson.complete(actualTeacherUserId = userId, at = request.completedAt ?: LocalDateTime.now())
+        lesson.complete(
+            actualTeacherUserId = userId,
+            at = request.completedAt,
+            clock = clock,
+        )
+        lessonAdaptor.save(lesson)
         return LessonResponse.from(lesson)
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/RecordLessonUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/RecordLessonUseCase.kt
@@ -1,0 +1,29 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.supporters.lesson.dto.LessonResponse
+import com.sclass.supporters.lesson.dto.RecordLessonRequest
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class RecordLessonUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+) {
+    @Transactional
+    fun execute(
+        userId: String,
+        lessonId: Long,
+        request: RecordLessonRequest,
+    ): LessonResponse {
+        val lesson = lessonAdaptor.findById(lessonId)
+        if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
+        lesson.record(
+            actualTeacherUserId = userId,
+            startedAt = request.startedAt,
+            completedAt = request.completedAt,
+        )
+        return LessonResponse.from(lesson)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/RecordLessonUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/RecordLessonUseCase.kt
@@ -6,10 +6,12 @@ import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessExcept
 import com.sclass.supporters.lesson.dto.LessonResponse
 import com.sclass.supporters.lesson.dto.RecordLessonRequest
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 
 @UseCase
 class RecordLessonUseCase(
     private val lessonAdaptor: LessonAdaptor,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     @Transactional
     fun execute(
@@ -23,7 +25,9 @@ class RecordLessonUseCase(
             actualTeacherUserId = userId,
             startedAt = request.startedAt,
             completedAt = request.completedAt,
+            clock = clock,
         )
+        lessonAdaptor.save(lesson)
         return LessonResponse.from(lesson)
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/StartLessonUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/StartLessonUseCase.kt
@@ -1,0 +1,28 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.supporters.lesson.dto.LessonResponse
+import com.sclass.supporters.lesson.dto.LessonResponse.Companion.from
+import com.sclass.supporters.lesson.dto.StartLessonRequest
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@UseCase
+class StartLessonUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+) {
+    @Transactional
+    fun execute(
+        userId: String,
+        lessonId: Long,
+        request: StartLessonRequest,
+    ): LessonResponse {
+        val lesson = lessonAdaptor.findById(lessonId)
+
+        if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
+        lesson.start(actualTeacherUserId = userId, at = request.startedAt ?: LocalDateTime.now())
+        return from(lesson)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/StartLessonUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/StartLessonUseCase.kt
@@ -4,14 +4,14 @@ import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
 import com.sclass.supporters.lesson.dto.LessonResponse
-import com.sclass.supporters.lesson.dto.LessonResponse.Companion.from
 import com.sclass.supporters.lesson.dto.StartLessonRequest
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
+import java.time.Clock
 
 @UseCase
 class StartLessonUseCase(
     private val lessonAdaptor: LessonAdaptor,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     @Transactional
     fun execute(
@@ -20,9 +20,13 @@ class StartLessonUseCase(
         request: StartLessonRequest,
     ): LessonResponse {
         val lesson = lessonAdaptor.findById(lessonId)
-
         if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
-        lesson.start(actualTeacherUserId = userId, at = request.startedAt ?: LocalDateTime.now())
-        return from(lesson)
+        lesson.start(
+            actualTeacherUserId = userId,
+            at = request.startedAt,
+            clock = clock,
+        )
+        lessonAdaptor.save(lesson)
+        return LessonResponse.from(lesson)
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CompleteLessonUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CompleteLessonUseCaseTest.kt
@@ -12,11 +12,12 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.Clock
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 class CompleteLessonUseCaseTest {
     private lateinit var lessonAdaptor: LessonAdaptor
@@ -25,10 +26,18 @@ class CompleteLessonUseCaseTest {
     private val student = "student-user-id-0000000001"
     private val assignedTeacher = "assigned-teacher-id-0000001"
 
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
+    private val clock =
+        Clock.fixed(
+            fixedNow.atZone(ZoneId.systemDefault()).toInstant(),
+            ZoneId.systemDefault(),
+        )
+
     @BeforeEach
     fun setUp() {
         lessonAdaptor = mockk()
-        useCase = CompleteLessonUseCase(lessonAdaptor)
+        every { lessonAdaptor.save(any()) } answers { firstArg() }
+        useCase = CompleteLessonUseCase(lessonAdaptor, clock)
     }
 
     private fun newLesson(
@@ -48,7 +57,7 @@ class CompleteLessonUseCaseTest {
 
     @Test
     fun `요청 시각이 없으면 서버 now로 complete되고 COMPLETED 전이`() {
-        val lesson = newLesson(startedAt = LocalDateTime.now().minusMinutes(30))
+        val lesson = newLesson(startedAt = fixedNow.minusMinutes(30))
         every { lessonAdaptor.findById(1L) } returns lesson
 
         val response = useCase.execute(assignedTeacher, 1L, CompleteLessonRequest())
@@ -56,16 +65,16 @@ class CompleteLessonUseCaseTest {
         assertAll(
             { assertEquals(LessonStatus.COMPLETED, lesson.status) },
             { assertEquals(assignedTeacher, lesson.actualTeacherUserId) },
-            { assertNotNull(lesson.completedAt) },
+            { assertEquals(fixedNow, lesson.completedAt) },
             { assertEquals(LessonStatus.COMPLETED, response.status) },
         )
     }
 
     @Test
     fun `요청 시각이 있으면 그 값으로 completedAt이 채워진다`() {
-        val started = LocalDateTime.now().minusMinutes(60)
+        val started = fixedNow.minusMinutes(60)
         val lesson = newLesson(startedAt = started)
-        val customComplete = LocalDateTime.now().minusMinutes(5)
+        val customComplete = fixedNow.minusMinutes(5)
         every { lessonAdaptor.findById(1L) } returns lesson
 
         useCase.execute(assignedTeacher, 1L, CompleteLessonRequest(completedAt = customComplete))
@@ -75,8 +84,8 @@ class CompleteLessonUseCaseTest {
 
     @Test
     fun `complete는 scheduledAt과 startedAt을 변경하지 않는다`() {
-        val scheduled = LocalDateTime.now().minusHours(2)
-        val started = LocalDateTime.now().minusMinutes(45)
+        val scheduled = fixedNow.minusHours(2)
+        val started = fixedNow.minusMinutes(45)
         val lesson = newLesson(scheduledAt = scheduled, startedAt = started)
         every { lessonAdaptor.findById(1L) } returns lesson
 
@@ -107,28 +116,28 @@ class CompleteLessonUseCaseTest {
     }
 
     @Test
-    fun `미래 시각으로 complete 요청 시 예외`() {
+    fun `미래 시각으로 complete 요청 시 예외 - now+1초도 거절 (boundary)`() {
         every { lessonAdaptor.findById(1L) } returns newLesson()
 
         assertThrows<LessonInvalidTimeException> {
             useCase.execute(
                 assignedTeacher,
                 1L,
-                CompleteLessonRequest(completedAt = LocalDateTime.now().plusMinutes(10)),
+                CompleteLessonRequest(completedAt = fixedNow.plusSeconds(1)),
             )
         }
     }
 
     @Test
     fun `completedAt이 startedAt 이전이면 예외`() {
-        val started = LocalDateTime.now().minusMinutes(10)
+        val started = fixedNow.minusMinutes(10)
         every { lessonAdaptor.findById(1L) } returns newLesson(startedAt = started)
 
         assertThrows<LessonInvalidTimeException> {
             useCase.execute(
                 assignedTeacher,
                 1L,
-                CompleteLessonRequest(completedAt = started.minusMinutes(1)),
+                CompleteLessonRequest(completedAt = started.minusSeconds(1)),
             )
         }
     }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CompleteLessonUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CompleteLessonUseCaseTest.kt
@@ -1,0 +1,135 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonInvalidStatusTransitionException
+import com.sclass.domain.domains.lesson.exception.LessonInvalidTimeException
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.supporters.lesson.dto.CompleteLessonRequest
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class CompleteLessonUseCaseTest {
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var useCase: CompleteLessonUseCase
+
+    private val student = "student-user-id-0000000001"
+    private val assignedTeacher = "assigned-teacher-id-0000001"
+
+    @BeforeEach
+    fun setUp() {
+        lessonAdaptor = mockk()
+        useCase = CompleteLessonUseCase(lessonAdaptor)
+    }
+
+    private fun newLesson(
+        status: LessonStatus = LessonStatus.IN_PROGRESS,
+        scheduledAt: LocalDateTime? = null,
+        startedAt: LocalDateTime? = null,
+    ) = Lesson(
+        id = 1L,
+        lessonType = LessonType.COURSE,
+        studentUserId = student,
+        assignedTeacherUserId = assignedTeacher,
+        name = "lesson",
+        status = status,
+        scheduledAt = scheduledAt,
+        startedAt = startedAt,
+    )
+
+    @Test
+    fun `요청 시각이 없으면 서버 now로 complete되고 COMPLETED 전이`() {
+        val lesson = newLesson(startedAt = LocalDateTime.now().minusMinutes(30))
+        every { lessonAdaptor.findById(1L) } returns lesson
+
+        val response = useCase.execute(assignedTeacher, 1L, CompleteLessonRequest())
+
+        assertAll(
+            { assertEquals(LessonStatus.COMPLETED, lesson.status) },
+            { assertEquals(assignedTeacher, lesson.actualTeacherUserId) },
+            { assertNotNull(lesson.completedAt) },
+            { assertEquals(LessonStatus.COMPLETED, response.status) },
+        )
+    }
+
+    @Test
+    fun `요청 시각이 있으면 그 값으로 completedAt이 채워진다`() {
+        val started = LocalDateTime.now().minusMinutes(60)
+        val lesson = newLesson(startedAt = started)
+        val customComplete = LocalDateTime.now().minusMinutes(5)
+        every { lessonAdaptor.findById(1L) } returns lesson
+
+        useCase.execute(assignedTeacher, 1L, CompleteLessonRequest(completedAt = customComplete))
+
+        assertEquals(customComplete, lesson.completedAt)
+    }
+
+    @Test
+    fun `complete는 scheduledAt과 startedAt을 변경하지 않는다`() {
+        val scheduled = LocalDateTime.now().minusHours(2)
+        val started = LocalDateTime.now().minusMinutes(45)
+        val lesson = newLesson(scheduledAt = scheduled, startedAt = started)
+        every { lessonAdaptor.findById(1L) } returns lesson
+
+        useCase.execute(assignedTeacher, 1L, CompleteLessonRequest())
+
+        assertAll(
+            { assertEquals(scheduled, lesson.scheduledAt) },
+            { assertEquals(started, lesson.startedAt) },
+        )
+    }
+
+    @Test
+    fun `담당이 아닌 유저는 complete 불가`() {
+        every { lessonAdaptor.findById(1L) } returns newLesson()
+
+        assertThrows<LessonUnauthorizedAccessException> {
+            useCase.execute("other-user-id", 1L, CompleteLessonRequest())
+        }
+    }
+
+    @Test
+    fun `이미 COMPLETED인 lesson은 다시 complete 불가`() {
+        every { lessonAdaptor.findById(1L) } returns newLesson(status = LessonStatus.COMPLETED)
+
+        assertThrows<LessonInvalidStatusTransitionException> {
+            useCase.execute(assignedTeacher, 1L, CompleteLessonRequest())
+        }
+    }
+
+    @Test
+    fun `미래 시각으로 complete 요청 시 예외`() {
+        every { lessonAdaptor.findById(1L) } returns newLesson()
+
+        assertThrows<LessonInvalidTimeException> {
+            useCase.execute(
+                assignedTeacher,
+                1L,
+                CompleteLessonRequest(completedAt = LocalDateTime.now().plusMinutes(10)),
+            )
+        }
+    }
+
+    @Test
+    fun `completedAt이 startedAt 이전이면 예외`() {
+        val started = LocalDateTime.now().minusMinutes(10)
+        every { lessonAdaptor.findById(1L) } returns newLesson(startedAt = started)
+
+        assertThrows<LessonInvalidTimeException> {
+            useCase.execute(
+                assignedTeacher,
+                1L,
+                CompleteLessonRequest(completedAt = started.minusMinutes(1)),
+            )
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/RecordLessonUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/RecordLessonUseCaseTest.kt
@@ -15,7 +15,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.Clock
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 class RecordLessonUseCaseTest {
     private lateinit var lessonAdaptor: LessonAdaptor
@@ -24,10 +26,18 @@ class RecordLessonUseCaseTest {
     private val student = "student-user-id-0000000001"
     private val assignedTeacher = "assigned-teacher-id-0000001"
 
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
+    private val clock =
+        Clock.fixed(
+            fixedNow.atZone(ZoneId.systemDefault()).toInstant(),
+            ZoneId.systemDefault(),
+        )
+
     @BeforeEach
     fun setUp() {
         lessonAdaptor = mockk()
-        useCase = RecordLessonUseCase(lessonAdaptor)
+        every { lessonAdaptor.save(any()) } answers { firstArg() }
+        useCase = RecordLessonUseCase(lessonAdaptor, clock)
     }
 
     private fun newLesson(
@@ -48,8 +58,8 @@ class RecordLessonUseCaseTest {
     @Test
     fun `record 호출 시 두 시각이 모두 기록되고 COMPLETED로 전이`() {
         val lesson = newLesson()
-        val started = LocalDateTime.now().minusMinutes(60)
-        val completed = LocalDateTime.now().minusMinutes(10)
+        val started = fixedNow.minusMinutes(60)
+        val completed = fixedNow.minusMinutes(10)
         every { lessonAdaptor.findById(1L) } returns lesson
 
         val response =
@@ -70,7 +80,7 @@ class RecordLessonUseCaseTest {
 
     @Test
     fun `record는 scheduledAt을 변경하지 않는다`() {
-        val scheduled = LocalDateTime.now().minusHours(3)
+        val scheduled = fixedNow.minusHours(3)
         val lesson = newLesson(scheduledAt = scheduled)
         every { lessonAdaptor.findById(1L) } returns lesson
 
@@ -78,8 +88,8 @@ class RecordLessonUseCaseTest {
             assignedTeacher,
             1L,
             RecordLessonRequest(
-                startedAt = LocalDateTime.now().minusMinutes(60),
-                completedAt = LocalDateTime.now().minusMinutes(10),
+                startedAt = fixedNow.minusMinutes(60),
+                completedAt = fixedNow.minusMinutes(10),
             ),
         )
 
@@ -95,8 +105,8 @@ class RecordLessonUseCaseTest {
                 "other-user-id",
                 1L,
                 RecordLessonRequest(
-                    startedAt = LocalDateTime.now().minusMinutes(60),
-                    completedAt = LocalDateTime.now().minusMinutes(10),
+                    startedAt = fixedNow.minusMinutes(60),
+                    completedAt = fixedNow.minusMinutes(10),
                 ),
             )
         }
@@ -107,7 +117,7 @@ class RecordLessonUseCaseTest {
         every { lessonAdaptor.findById(1L) } returns
             newLesson(
                 status = LessonStatus.IN_PROGRESS,
-                startedAt = LocalDateTime.now().minusMinutes(30),
+                startedAt = fixedNow.minusMinutes(30),
             )
 
         assertThrows<LessonAlreadyStartedException> {
@@ -115,8 +125,8 @@ class RecordLessonUseCaseTest {
                 assignedTeacher,
                 1L,
                 RecordLessonRequest(
-                    startedAt = LocalDateTime.now().minusMinutes(60),
-                    completedAt = LocalDateTime.now().minusMinutes(10),
+                    startedAt = fixedNow.minusMinutes(60),
+                    completedAt = fixedNow.minusMinutes(10),
                 ),
             )
         }
@@ -124,14 +134,30 @@ class RecordLessonUseCaseTest {
 
     @Test
     fun `종료 시각이 시작 시각보다 이전이면 예외`() {
-        val started = LocalDateTime.now().minusMinutes(10)
+        val started = fixedNow.minusMinutes(10)
         every { lessonAdaptor.findById(1L) } returns newLesson()
 
         assertThrows<LessonInvalidTimeException> {
             useCase.execute(
                 assignedTeacher,
                 1L,
-                RecordLessonRequest(startedAt = started, completedAt = started.minusMinutes(1)),
+                RecordLessonRequest(startedAt = started, completedAt = started.minusSeconds(1)),
+            )
+        }
+    }
+
+    @Test
+    fun `시작 시각이 미래면 예외 - now+1초도 거절 (boundary)`() {
+        every { lessonAdaptor.findById(1L) } returns newLesson()
+
+        assertThrows<LessonInvalidTimeException> {
+            useCase.execute(
+                assignedTeacher,
+                1L,
+                RecordLessonRequest(
+                    startedAt = fixedNow.plusSeconds(1),
+                    completedAt = fixedNow.plusMinutes(60),
+                ),
             )
         }
     }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/RecordLessonUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/RecordLessonUseCaseTest.kt
@@ -1,0 +1,138 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonAlreadyStartedException
+import com.sclass.domain.domains.lesson.exception.LessonInvalidTimeException
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.supporters.lesson.dto.RecordLessonRequest
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class RecordLessonUseCaseTest {
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var useCase: RecordLessonUseCase
+
+    private val student = "student-user-id-0000000001"
+    private val assignedTeacher = "assigned-teacher-id-0000001"
+
+    @BeforeEach
+    fun setUp() {
+        lessonAdaptor = mockk()
+        useCase = RecordLessonUseCase(lessonAdaptor)
+    }
+
+    private fun newLesson(
+        status: LessonStatus = LessonStatus.SCHEDULED,
+        scheduledAt: LocalDateTime? = null,
+        startedAt: LocalDateTime? = null,
+    ) = Lesson(
+        id = 1L,
+        lessonType = LessonType.COURSE,
+        studentUserId = student,
+        assignedTeacherUserId = assignedTeacher,
+        name = "lesson",
+        status = status,
+        scheduledAt = scheduledAt,
+        startedAt = startedAt,
+    )
+
+    @Test
+    fun `record 호출 시 두 시각이 모두 기록되고 COMPLETED로 전이`() {
+        val lesson = newLesson()
+        val started = LocalDateTime.now().minusMinutes(60)
+        val completed = LocalDateTime.now().minusMinutes(10)
+        every { lessonAdaptor.findById(1L) } returns lesson
+
+        val response =
+            useCase.execute(
+                assignedTeacher,
+                1L,
+                RecordLessonRequest(startedAt = started, completedAt = completed),
+            )
+
+        assertAll(
+            { assertEquals(LessonStatus.COMPLETED, lesson.status) },
+            { assertEquals(assignedTeacher, lesson.actualTeacherUserId) },
+            { assertEquals(started, lesson.startedAt) },
+            { assertEquals(completed, lesson.completedAt) },
+            { assertEquals(LessonStatus.COMPLETED, response.status) },
+        )
+    }
+
+    @Test
+    fun `record는 scheduledAt을 변경하지 않는다`() {
+        val scheduled = LocalDateTime.now().minusHours(3)
+        val lesson = newLesson(scheduledAt = scheduled)
+        every { lessonAdaptor.findById(1L) } returns lesson
+
+        useCase.execute(
+            assignedTeacher,
+            1L,
+            RecordLessonRequest(
+                startedAt = LocalDateTime.now().minusMinutes(60),
+                completedAt = LocalDateTime.now().minusMinutes(10),
+            ),
+        )
+
+        assertEquals(scheduled, lesson.scheduledAt)
+    }
+
+    @Test
+    fun `담당이 아닌 유저는 record 불가`() {
+        every { lessonAdaptor.findById(1L) } returns newLesson()
+
+        assertThrows<LessonUnauthorizedAccessException> {
+            useCase.execute(
+                "other-user-id",
+                1L,
+                RecordLessonRequest(
+                    startedAt = LocalDateTime.now().minusMinutes(60),
+                    completedAt = LocalDateTime.now().minusMinutes(10),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `이미 startedAt이 기록된 lesson은 record 불가`() {
+        every { lessonAdaptor.findById(1L) } returns
+            newLesson(
+                status = LessonStatus.IN_PROGRESS,
+                startedAt = LocalDateTime.now().minusMinutes(30),
+            )
+
+        assertThrows<LessonAlreadyStartedException> {
+            useCase.execute(
+                assignedTeacher,
+                1L,
+                RecordLessonRequest(
+                    startedAt = LocalDateTime.now().minusMinutes(60),
+                    completedAt = LocalDateTime.now().minusMinutes(10),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `종료 시각이 시작 시각보다 이전이면 예외`() {
+        val started = LocalDateTime.now().minusMinutes(10)
+        every { lessonAdaptor.findById(1L) } returns newLesson()
+
+        assertThrows<LessonInvalidTimeException> {
+            useCase.execute(
+                assignedTeacher,
+                1L,
+                RecordLessonRequest(startedAt = started, completedAt = started.minusMinutes(1)),
+            )
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/StartLessonUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/StartLessonUseCaseTest.kt
@@ -1,0 +1,127 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonAlreadyStartedException
+import com.sclass.domain.domains.lesson.exception.LessonInvalidStatusTransitionException
+import com.sclass.domain.domains.lesson.exception.LessonInvalidTimeException
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.supporters.lesson.dto.StartLessonRequest
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class StartLessonUseCaseTest {
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var useCase: StartLessonUseCase
+
+    private val student = "student-user-id-0000000001"
+    private val assignedTeacher = "assigned-teacher-id-0000001"
+
+    @BeforeEach
+    fun setUp() {
+        lessonAdaptor = mockk()
+        useCase = StartLessonUseCase(lessonAdaptor)
+    }
+
+    private fun newLesson(
+        status: LessonStatus = LessonStatus.SCHEDULED,
+        scheduledAt: LocalDateTime? = null,
+        startedAt: LocalDateTime? = null,
+    ) = Lesson(
+        id = 1L,
+        lessonType = LessonType.COURSE,
+        studentUserId = student,
+        assignedTeacherUserId = assignedTeacher,
+        name = "lesson",
+        status = status,
+        scheduledAt = scheduledAt,
+        startedAt = startedAt,
+    )
+
+    @Test
+    fun `요청 시각이 없으면 서버 now로 start되고 IN_PROGRESS 전이`() {
+        val lesson = newLesson()
+        every { lessonAdaptor.findById(1L) } returns lesson
+
+        val response = useCase.execute(assignedTeacher, 1L, StartLessonRequest())
+
+        assertAll(
+            { assertEquals(LessonStatus.IN_PROGRESS, lesson.status) },
+            { assertEquals(assignedTeacher, lesson.actualTeacherUserId) },
+            { assertNotNull(lesson.startedAt) },
+            { assertEquals(LessonStatus.IN_PROGRESS, response.status) },
+        )
+    }
+
+    @Test
+    fun `요청 시각이 있으면 그 값으로 startedAt이 채워진다`() {
+        val lesson = newLesson()
+        val customStart = LocalDateTime.now().minusMinutes(15)
+        every { lessonAdaptor.findById(1L) } returns lesson
+
+        useCase.execute(assignedTeacher, 1L, StartLessonRequest(startedAt = customStart))
+
+        assertEquals(customStart, lesson.startedAt)
+    }
+
+    @Test
+    fun `start는 scheduledAt을 변경하지 않는다`() {
+        val scheduled = LocalDateTime.now().minusHours(1)
+        val lesson = newLesson(scheduledAt = scheduled)
+        every { lessonAdaptor.findById(1L) } returns lesson
+
+        useCase.execute(assignedTeacher, 1L, StartLessonRequest())
+
+        assertEquals(scheduled, lesson.scheduledAt)
+    }
+
+    @Test
+    fun `담당이 아닌 유저는 start 불가`() {
+        every { lessonAdaptor.findById(1L) } returns newLesson()
+
+        assertThrows<LessonUnauthorizedAccessException> {
+            useCase.execute("other-user-id", 1L, StartLessonRequest())
+        }
+    }
+
+    @Test
+    fun `이미 COMPLETED인 lesson은 start 불가`() {
+        every { lessonAdaptor.findById(1L) } returns newLesson(status = LessonStatus.COMPLETED)
+
+        assertThrows<LessonInvalidStatusTransitionException> {
+            useCase.execute(assignedTeacher, 1L, StartLessonRequest())
+        }
+    }
+
+    @Test
+    fun `미래 시각으로 start 요청 시 예외`() {
+        every { lessonAdaptor.findById(1L) } returns newLesson()
+
+        assertThrows<LessonInvalidTimeException> {
+            useCase.execute(
+                assignedTeacher,
+                1L,
+                StartLessonRequest(startedAt = LocalDateTime.now().plusMinutes(10)),
+            )
+        }
+    }
+
+    @Test
+    fun `startedAt이 이미 기록된 lesson은 start 불가`() {
+        every { lessonAdaptor.findById(1L) } returns
+            newLesson(startedAt = LocalDateTime.now().minusMinutes(10))
+
+        assertThrows<LessonAlreadyStartedException> {
+            useCase.execute(assignedTeacher, 1L, StartLessonRequest())
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/StartLessonUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/StartLessonUseCaseTest.kt
@@ -13,11 +13,12 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.Clock
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 class StartLessonUseCaseTest {
     private lateinit var lessonAdaptor: LessonAdaptor
@@ -26,10 +27,18 @@ class StartLessonUseCaseTest {
     private val student = "student-user-id-0000000001"
     private val assignedTeacher = "assigned-teacher-id-0000001"
 
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
+    private val clock =
+        Clock.fixed(
+            fixedNow.atZone(ZoneId.systemDefault()).toInstant(),
+            ZoneId.systemDefault(),
+        )
+
     @BeforeEach
     fun setUp() {
         lessonAdaptor = mockk()
-        useCase = StartLessonUseCase(lessonAdaptor)
+        every { lessonAdaptor.save(any()) } answers { firstArg() }
+        useCase = StartLessonUseCase(lessonAdaptor, clock)
     }
 
     private fun newLesson(
@@ -57,7 +66,7 @@ class StartLessonUseCaseTest {
         assertAll(
             { assertEquals(LessonStatus.IN_PROGRESS, lesson.status) },
             { assertEquals(assignedTeacher, lesson.actualTeacherUserId) },
-            { assertNotNull(lesson.startedAt) },
+            { assertEquals(fixedNow, lesson.startedAt) },
             { assertEquals(LessonStatus.IN_PROGRESS, response.status) },
         )
     }
@@ -65,7 +74,7 @@ class StartLessonUseCaseTest {
     @Test
     fun `요청 시각이 있으면 그 값으로 startedAt이 채워진다`() {
         val lesson = newLesson()
-        val customStart = LocalDateTime.now().minusMinutes(15)
+        val customStart = fixedNow.minusMinutes(15)
         every { lessonAdaptor.findById(1L) } returns lesson
 
         useCase.execute(assignedTeacher, 1L, StartLessonRequest(startedAt = customStart))
@@ -75,7 +84,7 @@ class StartLessonUseCaseTest {
 
     @Test
     fun `start는 scheduledAt을 변경하지 않는다`() {
-        val scheduled = LocalDateTime.now().minusHours(1)
+        val scheduled = fixedNow.minusHours(1)
         val lesson = newLesson(scheduledAt = scheduled)
         every { lessonAdaptor.findById(1L) } returns lesson
 
@@ -103,22 +112,21 @@ class StartLessonUseCaseTest {
     }
 
     @Test
-    fun `미래 시각으로 start 요청 시 예외`() {
+    fun `미래 시각으로 start 요청 시 예외 - now+1초도 거절 (boundary)`() {
         every { lessonAdaptor.findById(1L) } returns newLesson()
 
         assertThrows<LessonInvalidTimeException> {
             useCase.execute(
                 assignedTeacher,
                 1L,
-                StartLessonRequest(startedAt = LocalDateTime.now().plusMinutes(10)),
+                StartLessonRequest(startedAt = fixedNow.plusSeconds(1)),
             )
         }
     }
 
     @Test
     fun `startedAt이 이미 기록된 lesson은 start 불가`() {
-        every { lessonAdaptor.findById(1L) } returns
-            newLesson(startedAt = LocalDateTime.now().minusMinutes(10))
+        every { lessonAdaptor.findById(1L) } returns newLesson(startedAt = fixedNow.minusMinutes(10))
 
         assertThrows<LessonAlreadyStartedException> {
             useCase.execute(assignedTeacher, 1L, StartLessonRequest())

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
@@ -16,6 +16,7 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Index
 import jakarta.persistence.Table
+import java.time.Clock
 import java.time.LocalDateTime
 
 @Entity
@@ -72,26 +73,32 @@ class Lesson(
 
     fun start(
         actualTeacherUserId: String,
-        at: LocalDateTime = LocalDateTime.now(),
+        at: LocalDateTime? = null,
+        clock: Clock = Clock.systemDefaultZone(),
     ) {
         validateTransition(LessonStatus.IN_PROGRESS)
         if (startedAt != null) throw LessonAlreadyStartedException()
-        if (at.isAfter(LocalDateTime.now())) throw LessonInvalidTimeException()
+        val now = LocalDateTime.now(clock)
+        val effectiveAt = at ?: now
+        if (effectiveAt.isAfter(now)) throw LessonInvalidTimeException()
         this.actualTeacherUserId = actualTeacherUserId
-        this.startedAt = at
+        this.startedAt = effectiveAt
         this.status = LessonStatus.IN_PROGRESS
     }
 
     fun complete(
         actualTeacherUserId: String,
-        at: LocalDateTime = LocalDateTime.now(),
+        at: LocalDateTime? = null,
+        clock: Clock = Clock.systemDefaultZone(),
     ) {
         validateTransition(LessonStatus.COMPLETED)
         if (completedAt != null) throw LessonAlreadyCompletedException()
-        if (at.isAfter(LocalDateTime.now())) throw LessonInvalidTimeException()
-        startedAt?.let { if (at.isBefore(it)) throw LessonInvalidTimeException() }
+        val now = LocalDateTime.now(clock)
+        val effectiveAt = at ?: now
+        if (effectiveAt.isAfter(now)) throw LessonInvalidTimeException()
+        startedAt?.let { if (effectiveAt.isBefore(it)) throw LessonInvalidTimeException() }
         this.actualTeacherUserId = actualTeacherUserId
-        this.completedAt = at
+        this.completedAt = effectiveAt
         this.status = LessonStatus.COMPLETED
     }
 
@@ -99,11 +106,12 @@ class Lesson(
         actualTeacherUserId: String,
         startedAt: LocalDateTime,
         completedAt: LocalDateTime,
+        clock: Clock = Clock.systemDefaultZone(),
     ) {
         validateTransition(LessonStatus.COMPLETED)
         if (this.startedAt != null) throw LessonAlreadyStartedException()
         if (this.completedAt != null) throw LessonAlreadyCompletedException()
-        val now = LocalDateTime.now()
+        val now = LocalDateTime.now(clock)
         if (startedAt.isAfter(now) || completedAt.isAfter(now)) throw LessonInvalidTimeException()
         if (completedAt.isBefore(startedAt)) throw LessonInvalidTimeException()
         this.actualTeacherUserId = actualTeacherUserId

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
@@ -1,7 +1,10 @@
 package com.sclass.domain.domains.lesson.domain
 
 import com.sclass.domain.common.model.BaseTimeEntity
+import com.sclass.domain.domains.lesson.exception.LessonAlreadyCompletedException
+import com.sclass.domain.domains.lesson.exception.LessonAlreadyStartedException
 import com.sclass.domain.domains.lesson.exception.LessonInvalidStatusTransitionException
+import com.sclass.domain.domains.lesson.exception.LessonInvalidTimeException
 import com.sclass.domain.domains.lesson.exception.LessonSubstituteAssignNotAllowedException
 import com.sclass.domain.domains.lesson.exception.LessonSubstituteSameAsAssignedException
 import jakarta.persistence.Column
@@ -72,6 +75,8 @@ class Lesson(
         at: LocalDateTime = LocalDateTime.now(),
     ) {
         validateTransition(LessonStatus.IN_PROGRESS)
+        if (startedAt != null) throw LessonAlreadyStartedException()
+        if (at.isAfter(LocalDateTime.now())) throw LessonInvalidTimeException()
         this.actualTeacherUserId = actualTeacherUserId
         this.startedAt = at
         this.status = LessonStatus.IN_PROGRESS
@@ -82,8 +87,28 @@ class Lesson(
         at: LocalDateTime = LocalDateTime.now(),
     ) {
         validateTransition(LessonStatus.COMPLETED)
+        if (completedAt != null) throw LessonAlreadyCompletedException()
+        if (at.isAfter(LocalDateTime.now())) throw LessonInvalidTimeException()
+        startedAt?.let { if (at.isBefore(it)) throw LessonInvalidTimeException() }
         this.actualTeacherUserId = actualTeacherUserId
         this.completedAt = at
+        this.status = LessonStatus.COMPLETED
+    }
+
+    fun record(
+        actualTeacherUserId: String,
+        startedAt: LocalDateTime,
+        completedAt: LocalDateTime,
+    ) {
+        validateTransition(LessonStatus.COMPLETED)
+        if (this.startedAt != null) throw LessonAlreadyStartedException()
+        if (this.completedAt != null) throw LessonAlreadyCompletedException()
+        val now = LocalDateTime.now()
+        if (startedAt.isAfter(now) || completedAt.isAfter(now)) throw LessonInvalidTimeException()
+        if (completedAt.isBefore(startedAt)) throw LessonInvalidTimeException()
+        this.actualTeacherUserId = actualTeacherUserId
+        this.startedAt = startedAt
+        this.completedAt = completedAt
         this.status = LessonStatus.COMPLETED
     }
 

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonErrorCode.kt
@@ -14,4 +14,6 @@ enum class LessonErrorCode(
     LESSON_SUBSTITUTE_ASSIGN_NOT_ALLOWED("LESSON_005", "예정 상태의 수업만 대타 배정이 가능합니다", 400),
     LESSON_SUBSTITUTE_SAME_AS_ASSIGNED("LESSON_006", "기존 담당 선생님은 대타로 배정할 수 없습니다", 400),
     LESSON_ALREADY_COMPLETED("LESSON_007", "이미 완료 처리된 수업입니다", 400),
+    LESSON_INVALID_TIME("LESSON_008", "유효하지 않은 시간입니다", 400),
+    LESSON_ALREADY_STARTED("LESSON_009", "이미 시작된 수업입니다", 400),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonExceptions.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonExceptions.kt
@@ -9,3 +9,7 @@ class LessonInvalidStatusTransitionException : BusinessException(LessonErrorCode
 class LessonNotCompletedException : BusinessException(LessonErrorCode.LESSON_NOT_COMPLETED)
 
 class LessonAlreadyCompletedException : BusinessException(LessonErrorCode.LESSON_ALREADY_COMPLETED)
+
+class LessonInvalidTimeException : BusinessException(LessonErrorCode.LESSON_INVALID_TIME)
+
+class LessonAlreadyStartedException : BusinessException(LessonErrorCode.LESSON_ALREADY_STARTED)

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/domain/LessonTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/domain/LessonTest.kt
@@ -12,12 +12,21 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.Clock
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 class LessonTest {
     private val student = "student-user-id-0000000001"
     private val assignedTeacher = "assigned-teacher-id-0000001"
     private val substitute = "substitute-teacher-id-00001"
+
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
+    private val clock =
+        Clock.fixed(
+            fixedNow.atZone(ZoneId.systemDefault()).toInstant(),
+            ZoneId.systemDefault(),
+        )
 
     private fun newLesson(
         status: LessonStatus = LessonStatus.SCHEDULED,
@@ -82,12 +91,13 @@ class LessonTest {
     @Test
     fun `SCHEDULED에서 바로 COMPLETED 전이 가능`() {
         val lesson = newLesson()
-        val now = LocalDateTime.now()
-        lesson.complete(assignedTeacher, now)
+
+        lesson.complete(assignedTeacher, fixedNow, clock)
+
         assertAll(
             { assertEquals(LessonStatus.COMPLETED, lesson.status) },
             { assertEquals(assignedTeacher, lesson.actualTeacherUserId) },
-            { assertEquals(now, lesson.completedAt) },
+            { assertEquals(fixedNow, lesson.completedAt) },
         )
     }
 
@@ -95,7 +105,7 @@ class LessonTest {
     fun `COMPLETED에서 다시 complete 호출 시 예외`() {
         val lesson = newLesson(status = LessonStatus.COMPLETED)
         assertThrows<LessonInvalidStatusTransitionException> {
-            lesson.complete(assignedTeacher)
+            lesson.complete(assignedTeacher, fixedNow, clock)
         }
     }
 
@@ -116,11 +126,11 @@ class LessonTest {
     }
 
     @Test
-    fun `SCHEDULED에서 start 호출 시 IN_PROGRESS로 전이되고 startedAt이 기록된다`() {
+    fun `start 호출 시 IN_PROGRESS로 전이되고 startedAt이 정확히 기록된다`() {
         val lesson = newLesson()
-        val startTime = LocalDateTime.now().minusMinutes(5)
+        val startTime = fixedNow.minusMinutes(5)
 
-        lesson.start(assignedTeacher, startTime)
+        lesson.start(assignedTeacher, startTime, clock)
 
         assertAll(
             { assertEquals(LessonStatus.IN_PROGRESS, lesson.status) },
@@ -130,72 +140,80 @@ class LessonTest {
     }
 
     @Test
+    fun `at이 null이면 clock 기반 now로 startedAt이 채워진다`() {
+        val lesson = newLesson()
+
+        lesson.start(assignedTeacher, at = null, clock = clock)
+
+        assertEquals(fixedNow, lesson.startedAt)
+    }
+
+    @Test
     fun `start는 scheduledAt에 영향을 주지 않는다`() {
-        val scheduled = LocalDateTime.now().minusHours(1)
+        val scheduled = fixedNow.minusHours(1)
         val lesson = newLesson(scheduledAt = scheduled)
 
-        lesson.start(assignedTeacher)
+        lesson.start(assignedTeacher, fixedNow, clock)
 
         assertEquals(scheduled, lesson.scheduledAt)
     }
 
     @Test
-    fun `미래 시각으로 start 호출 시 예외`() {
+    fun `미래 시각으로 start 호출 시 예외 - now+1초도 거절 (boundary)`() {
         val lesson = newLesson()
         assertThrows<LessonInvalidTimeException> {
-            lesson.start(assignedTeacher, LocalDateTime.now().plusMinutes(10))
+            lesson.start(assignedTeacher, fixedNow.plusSeconds(1), clock)
         }
     }
 
     @Test
     fun `complete는 scheduledAt에 영향을 주지 않는다`() {
-        val scheduled = LocalDateTime.now().minusHours(2)
+        val scheduled = fixedNow.minusHours(2)
         val lesson = newLesson(scheduledAt = scheduled)
 
-        lesson.complete(assignedTeacher)
+        lesson.complete(assignedTeacher, fixedNow, clock)
 
         assertEquals(scheduled, lesson.scheduledAt)
     }
 
     @Test
-    fun `미래 시각으로 complete 호출 시 예외`() {
+    fun `미래 시각으로 complete 호출 시 예외 - now+1초도 거절 (boundary)`() {
         val lesson = newLesson()
         assertThrows<LessonInvalidTimeException> {
-            lesson.complete(assignedTeacher, LocalDateTime.now().plusMinutes(10))
+            lesson.complete(assignedTeacher, fixedNow.plusSeconds(1), clock)
         }
     }
 
     @Test
     fun `completedAt이 startedAt보다 이전이면 예외`() {
-        val started = LocalDateTime.now().minusMinutes(10)
+        val started = fixedNow.minusMinutes(10)
         val lesson = newLesson(status = LessonStatus.IN_PROGRESS, startedAt = started)
 
         assertThrows<LessonInvalidTimeException> {
-            lesson.complete(assignedTeacher, started.minusMinutes(1))
+            lesson.complete(assignedTeacher, started.minusSeconds(1), clock)
         }
     }
 
     @Test
-    fun `IN_PROGRESS에서 complete 호출 시 COMPLETED로 전이되고 completedAt이 기록된다`() {
-        val started = LocalDateTime.now().minusMinutes(30)
+    fun `IN_PROGRESS에서 complete 호출 시 COMPLETED로 전이되고 completedAt이 정확히 기록된다`() {
+        val started = fixedNow.minusMinutes(30)
         val lesson = newLesson(status = LessonStatus.IN_PROGRESS, startedAt = started)
-        val completedAt = LocalDateTime.now()
 
-        lesson.complete(assignedTeacher, completedAt)
+        lesson.complete(assignedTeacher, fixedNow, clock)
 
         assertAll(
             { assertEquals(LessonStatus.COMPLETED, lesson.status) },
             { assertEquals(assignedTeacher, lesson.actualTeacherUserId) },
-            { assertEquals(completedAt, lesson.completedAt) },
+            { assertEquals(fixedNow, lesson.completedAt) },
             { assertEquals(started, lesson.startedAt) },
         )
     }
 
     @Test
     fun `startedAt이 이미 있으면 start 호출 시 예외`() {
-        val lesson = newLesson(startedAt = LocalDateTime.now().minusMinutes(10))
+        val lesson = newLesson(startedAt = fixedNow.minusMinutes(10))
         assertThrows<LessonAlreadyStartedException> {
-            lesson.start(assignedTeacher)
+            lesson.start(assignedTeacher, fixedNow, clock)
         }
     }
 
@@ -204,21 +222,21 @@ class LessonTest {
         val lesson =
             newLesson(
                 status = LessonStatus.IN_PROGRESS,
-                startedAt = LocalDateTime.now().minusMinutes(30),
-                completedAt = LocalDateTime.now().minusMinutes(5),
+                startedAt = fixedNow.minusMinutes(30),
+                completedAt = fixedNow.minusMinutes(5),
             )
         assertThrows<LessonAlreadyCompletedException> {
-            lesson.complete(assignedTeacher)
+            lesson.complete(assignedTeacher, fixedNow, clock)
         }
     }
 
     @Test
-    fun `record 호출 시 startedAt과 completedAt이 모두 채워지고 COMPLETED로 전이`() {
+    fun `record 호출 시 startedAt과 completedAt이 모두 정확히 기록되고 COMPLETED로 전이`() {
         val lesson = newLesson()
-        val started = LocalDateTime.now().minusMinutes(60)
-        val completed = LocalDateTime.now().minusMinutes(10)
+        val started = fixedNow.minusMinutes(60)
+        val completed = fixedNow.minusMinutes(10)
 
-        lesson.record(assignedTeacher, started, completed)
+        lesson.record(assignedTeacher, started, completed, clock)
 
         assertAll(
             { assertEquals(LessonStatus.COMPLETED, lesson.status) },
@@ -230,13 +248,14 @@ class LessonTest {
 
     @Test
     fun `record는 scheduledAt에 영향을 주지 않는다`() {
-        val scheduled = LocalDateTime.now().minusHours(3)
+        val scheduled = fixedNow.minusHours(3)
         val lesson = newLesson(scheduledAt = scheduled)
 
         lesson.record(
             assignedTeacher,
-            LocalDateTime.now().minusMinutes(60),
-            LocalDateTime.now().minusMinutes(10),
+            fixedNow.minusMinutes(60),
+            fixedNow.minusMinutes(10),
+            clock,
         )
 
         assertEquals(scheduled, lesson.scheduledAt)
@@ -247,25 +266,27 @@ class LessonTest {
         val lesson =
             newLesson(
                 status = LessonStatus.IN_PROGRESS,
-                startedAt = LocalDateTime.now().minusMinutes(30),
+                startedAt = fixedNow.minusMinutes(30),
             )
         assertThrows<LessonAlreadyStartedException> {
             lesson.record(
                 assignedTeacher,
-                LocalDateTime.now().minusMinutes(60),
-                LocalDateTime.now().minusMinutes(10),
+                fixedNow.minusMinutes(60),
+                fixedNow.minusMinutes(10),
+                clock,
             )
         }
     }
 
     @Test
-    fun `record의 시작 시각이 미래면 예외`() {
+    fun `record의 시작 시각이 미래면 예외 - now+1초도 거절 (boundary)`() {
         val lesson = newLesson()
         assertThrows<LessonInvalidTimeException> {
             lesson.record(
                 assignedTeacher,
-                LocalDateTime.now().plusMinutes(10),
-                LocalDateTime.now().plusMinutes(70),
+                fixedNow.plusSeconds(1),
+                fixedNow.plusMinutes(60),
+                clock,
             )
         }
     }
@@ -273,9 +294,9 @@ class LessonTest {
     @Test
     fun `record의 종료 시각이 시작 시각보다 이전이면 예외`() {
         val lesson = newLesson()
-        val started = LocalDateTime.now().minusMinutes(10)
+        val started = fixedNow.minusMinutes(10)
         assertThrows<LessonInvalidTimeException> {
-            lesson.record(assignedTeacher, started, started.minusMinutes(1))
+            lesson.record(assignedTeacher, started, started.minusSeconds(1), clock)
         }
     }
 }

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/domain/LessonTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/domain/LessonTest.kt
@@ -1,6 +1,9 @@
 package com.sclass.domain.domains.lesson.domain
 
+import com.sclass.domain.domains.lesson.exception.LessonAlreadyCompletedException
+import com.sclass.domain.domains.lesson.exception.LessonAlreadyStartedException
 import com.sclass.domain.domains.lesson.exception.LessonInvalidStatusTransitionException
+import com.sclass.domain.domains.lesson.exception.LessonInvalidTimeException
 import com.sclass.domain.domains.lesson.exception.LessonSubstituteAssignNotAllowedException
 import com.sclass.domain.domains.lesson.exception.LessonSubstituteSameAsAssignedException
 import org.junit.jupiter.api.Assertions.assertAll
@@ -19,6 +22,9 @@ class LessonTest {
     private fun newLesson(
         status: LessonStatus = LessonStatus.SCHEDULED,
         substituteTeacherUserId: String? = null,
+        scheduledAt: LocalDateTime? = null,
+        startedAt: LocalDateTime? = null,
+        completedAt: LocalDateTime? = null,
     ) = Lesson(
         lessonType = LessonType.COURSE,
         studentUserId = student,
@@ -26,6 +32,9 @@ class LessonTest {
         substituteTeacherUserId = substituteTeacherUserId,
         name = "lesson",
         status = status,
+        scheduledAt = scheduledAt,
+        startedAt = startedAt,
+        completedAt = completedAt,
     )
 
     @Test
@@ -103,6 +112,170 @@ class LessonTest {
         val lesson = newLesson(status = LessonStatus.CANCELLED)
         assertThrows<LessonSubstituteAssignNotAllowedException> {
             lesson.assignSubstitute(substitute)
+        }
+    }
+
+    @Test
+    fun `SCHEDULED에서 start 호출 시 IN_PROGRESS로 전이되고 startedAt이 기록된다`() {
+        val lesson = newLesson()
+        val startTime = LocalDateTime.now().minusMinutes(5)
+
+        lesson.start(assignedTeacher, startTime)
+
+        assertAll(
+            { assertEquals(LessonStatus.IN_PROGRESS, lesson.status) },
+            { assertEquals(assignedTeacher, lesson.actualTeacherUserId) },
+            { assertEquals(startTime, lesson.startedAt) },
+        )
+    }
+
+    @Test
+    fun `start는 scheduledAt에 영향을 주지 않는다`() {
+        val scheduled = LocalDateTime.now().minusHours(1)
+        val lesson = newLesson(scheduledAt = scheduled)
+
+        lesson.start(assignedTeacher)
+
+        assertEquals(scheduled, lesson.scheduledAt)
+    }
+
+    @Test
+    fun `미래 시각으로 start 호출 시 예외`() {
+        val lesson = newLesson()
+        assertThrows<LessonInvalidTimeException> {
+            lesson.start(assignedTeacher, LocalDateTime.now().plusMinutes(10))
+        }
+    }
+
+    @Test
+    fun `complete는 scheduledAt에 영향을 주지 않는다`() {
+        val scheduled = LocalDateTime.now().minusHours(2)
+        val lesson = newLesson(scheduledAt = scheduled)
+
+        lesson.complete(assignedTeacher)
+
+        assertEquals(scheduled, lesson.scheduledAt)
+    }
+
+    @Test
+    fun `미래 시각으로 complete 호출 시 예외`() {
+        val lesson = newLesson()
+        assertThrows<LessonInvalidTimeException> {
+            lesson.complete(assignedTeacher, LocalDateTime.now().plusMinutes(10))
+        }
+    }
+
+    @Test
+    fun `completedAt이 startedAt보다 이전이면 예외`() {
+        val started = LocalDateTime.now().minusMinutes(10)
+        val lesson = newLesson(status = LessonStatus.IN_PROGRESS, startedAt = started)
+
+        assertThrows<LessonInvalidTimeException> {
+            lesson.complete(assignedTeacher, started.minusMinutes(1))
+        }
+    }
+
+    @Test
+    fun `IN_PROGRESS에서 complete 호출 시 COMPLETED로 전이되고 completedAt이 기록된다`() {
+        val started = LocalDateTime.now().minusMinutes(30)
+        val lesson = newLesson(status = LessonStatus.IN_PROGRESS, startedAt = started)
+        val completedAt = LocalDateTime.now()
+
+        lesson.complete(assignedTeacher, completedAt)
+
+        assertAll(
+            { assertEquals(LessonStatus.COMPLETED, lesson.status) },
+            { assertEquals(assignedTeacher, lesson.actualTeacherUserId) },
+            { assertEquals(completedAt, lesson.completedAt) },
+            { assertEquals(started, lesson.startedAt) },
+        )
+    }
+
+    @Test
+    fun `startedAt이 이미 있으면 start 호출 시 예외`() {
+        val lesson = newLesson(startedAt = LocalDateTime.now().minusMinutes(10))
+        assertThrows<LessonAlreadyStartedException> {
+            lesson.start(assignedTeacher)
+        }
+    }
+
+    @Test
+    fun `completedAt이 이미 있으면 complete 호출 시 예외`() {
+        val lesson =
+            newLesson(
+                status = LessonStatus.IN_PROGRESS,
+                startedAt = LocalDateTime.now().minusMinutes(30),
+                completedAt = LocalDateTime.now().minusMinutes(5),
+            )
+        assertThrows<LessonAlreadyCompletedException> {
+            lesson.complete(assignedTeacher)
+        }
+    }
+
+    @Test
+    fun `record 호출 시 startedAt과 completedAt이 모두 채워지고 COMPLETED로 전이`() {
+        val lesson = newLesson()
+        val started = LocalDateTime.now().minusMinutes(60)
+        val completed = LocalDateTime.now().minusMinutes(10)
+
+        lesson.record(assignedTeacher, started, completed)
+
+        assertAll(
+            { assertEquals(LessonStatus.COMPLETED, lesson.status) },
+            { assertEquals(assignedTeacher, lesson.actualTeacherUserId) },
+            { assertEquals(started, lesson.startedAt) },
+            { assertEquals(completed, lesson.completedAt) },
+        )
+    }
+
+    @Test
+    fun `record는 scheduledAt에 영향을 주지 않는다`() {
+        val scheduled = LocalDateTime.now().minusHours(3)
+        val lesson = newLesson(scheduledAt = scheduled)
+
+        lesson.record(
+            assignedTeacher,
+            LocalDateTime.now().minusMinutes(60),
+            LocalDateTime.now().minusMinutes(10),
+        )
+
+        assertEquals(scheduled, lesson.scheduledAt)
+    }
+
+    @Test
+    fun `이미 startedAt이 있으면 record 호출 시 예외`() {
+        val lesson =
+            newLesson(
+                status = LessonStatus.IN_PROGRESS,
+                startedAt = LocalDateTime.now().minusMinutes(30),
+            )
+        assertThrows<LessonAlreadyStartedException> {
+            lesson.record(
+                assignedTeacher,
+                LocalDateTime.now().minusMinutes(60),
+                LocalDateTime.now().minusMinutes(10),
+            )
+        }
+    }
+
+    @Test
+    fun `record의 시작 시각이 미래면 예외`() {
+        val lesson = newLesson()
+        assertThrows<LessonInvalidTimeException> {
+            lesson.record(
+                assignedTeacher,
+                LocalDateTime.now().plusMinutes(10),
+                LocalDateTime.now().plusMinutes(70),
+            )
+        }
+    }
+
+    @Test
+    fun `record의 종료 시각이 시작 시각보다 이전이면 예외`() {
+        val lesson = newLesson()
+        val started = LocalDateTime.now().minusMinutes(10)
+        assertThrows<LessonInvalidTimeException> {
+            lesson.record(assignedTeacher, started, started.minusMinutes(1))
         }
     }
 }


### PR DESCRIPTION
Closes #286
Closes #190

## Summary
수업 진행 lifecycle을 report 제출 흐름과 분리해 독립적으로 다룰 수 있는 API를 추가합니다.

| Method | Path | 용도 |
|---|---|---|
| `POST` | `/api/v1/lessons/{id}/start` | SCHEDULED → IN_PROGRESS 전이 |
| `POST` | `/api/v1/lessons/{id}/complete` | → COMPLETED 전이 |
| `PUT` | `/api/v1/lessons/{id}/record` | 시작/종료 시각을 한 번에 기록 (오프라인 사후 기록) |

세 엔드포인트 모두 `actualTeacherUserId = currentUser`로 자동 채워지며, 시간은 요청에서 받거나 서버 now로 채웁니다. 권한은 lesson의 effectiveTeacher(대타 우선) 기준으로 검증합니다.

## 도메인 검증 강화
- 미래 시각 거절 (수업이 미래에 시작/종료될 수 없음)
- `completedAt < startedAt`인 경우 거절
- `startedAt`/`completedAt`이 이미 채워져 있으면 재호출 거절 — status 외에 timestamp 필드를 직접 검증해 다중 source-of-truth 위험 차단
- `start`/`complete`/`record` 모두 `scheduledAt`은 건드리지 않음 (예정 시각 보존)

## HTTP 메서드 선택 근거

### 왜 POST `/start`, `/complete` 인가
1. **URL이 동사 → 액션 엔드포인트.** PATCH는 리소스의 부분 수정 의미라 `/start`라는 동사 path와 어울리지 않음.
2. **비멱등 상태 전이.** 두 번째 호출이 거절돼야 함 (이미 IN_PROGRESS인 lesson을 다시 start 못 함). PUT/PATCH의 멱등성 의미와 충돌.
3. **현재 + 미래의 부수효과.** 단순 데이터 수정이 아니라 status 전이 + timestamp 자동 기록 + (향후) Meet 링크 생성 등 액션 시맨틱.

### 왜 PUT `/record` 인가
1. **데이터 업데이트 시맨틱.** "이 수업의 record를 설정한다" — `record`는 동사가 아니라 sub-resource(명사)로 해석. start/complete 같은 "행위"가 아닌 "기록 채우기".
2. **멱등성 만족.** 같은 body 두 번 호출 시 최종 상태 동일(이미 기록된 경우 거절되지만 서버 상태 변화 없음 → RFC 9110 § 9.2.2 정의 충족).
3. **오프라인 사후 기록 use case.** 실시간 버튼 클릭이 아니라 "수업이 끝난 후 시작/종료 시각을 한 번에 적는다"는 흐름이 dominant.

### 참고 자료
- [RFC 9110 § 9.2.2 — Idempotent Methods](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.2.2)
- [RFC 9110 § 9.3 — Method Definitions](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3)
- [Google AIP-136 — Custom Methods](https://google.aip.dev/136)
- Stripe API: [POST /v1/charges/{id}/capture](https://stripe.com/docs/api/charges/capture), [POST /v1/subscriptions/{id}/cancel](https://stripe.com/docs/api/subscriptions/cancel) — 액션은 POST
- GitHub API: [PUT /repos/{owner}/{repo}/issues/{issue_number}/lock](https://docs.github.com/en/rest/issues/issues#lock-an-issue) — PUT을 멱등 액션에 사용한 사례

## 향후 작업 (이 PR 범위 밖)
- Zoom/Meet 연동 시: `record()` 도메인 메서드에 `if (source == ZOOM) throw LessonNotEditableException()` 같은 정책 hook 추가 가능
- 시작/종료된 lesson의 시각만 사후 보정하는 별도 PATCH는 권한 정책이 다를 수 있어 별도 이슈로 분리

## Test plan
- [x] `LessonTest`: start/complete/record 도메인 단위 테스트 (정상 전이, 권한, 시간 검증, scheduledAt 보존, 재호출 거절)
- [x] `StartLessonUseCaseTest` / `CompleteLessonUseCaseTest` / `RecordLessonUseCaseTest`: usecase 레벨 검증
- [x] `./gradlew ktlintCheck` 통과
- [x] `./gradlew :SClass-Domain:test :SClass-Api-Supporters:test` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)