### PR TITLE
feat(oauth): teacher Google account OAuth integration

### DIFF
--- a/SClass-Api-Backoffice/src/main/resources/application.yml.example
+++ b/SClass-Api-Backoffice/src/main/resources/application.yml.example
@@ -58,6 +58,7 @@ oauth2:
   providers:
     google:
       client-id: ${GOOGLE_CLIENT_ID:}
+      client-secret: ${GOOGLE_CLIENT_SECRET:}
     kakao:
       client-id: ${KAKAO_CLIENT_ID:}
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/controller/GoogleConnectionController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/controller/GoogleConnectionController.kt
@@ -1,7 +1,9 @@
 package com.sclass.supporters.oauth.controller
 
 import com.sclass.common.annotation.CurrentUserId
+import com.sclass.common.annotation.CurrentUserRole
 import com.sclass.common.dto.ApiResponse
+import com.sclass.domain.domains.user.domain.Role
 import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
 import com.sclass.supporters.oauth.dto.GoogleConnectionStatusResponse
 import com.sclass.supporters.oauth.usecase.ConnectGoogleUseCase
@@ -25,8 +27,12 @@ class GoogleConnectionController(
     @PostMapping("/connect")
     fun connect(
         @CurrentUserId userId: String,
+        @CurrentUserRole role: String,
         @Valid @RequestBody request: ConnectGoogleRequest,
-    ): ApiResponse<GoogleConnectionStatusResponse> = ApiResponse.success(connectGoogleUseCase.execute(userId, request))
+    ): ApiResponse<GoogleConnectionStatusResponse> =
+        ApiResponse.success(
+            connectGoogleUseCase.execute(userId, Role.valueOf(role), request),
+        )
 
     @DeleteMapping
     fun disconnect(

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/controller/GoogleConnectionController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/controller/GoogleConnectionController.kt
@@ -1,0 +1,43 @@
+package com.sclass.supporters.oauth.controller
+
+import com.sclass.common.annotation.CurrentUserId
+import com.sclass.common.dto.ApiResponse
+import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
+import com.sclass.supporters.oauth.dto.GoogleConnectionStatusResponse
+import com.sclass.supporters.oauth.usecase.ConnectGoogleUseCase
+import com.sclass.supporters.oauth.usecase.DisconnectGoogleUseCase
+import com.sclass.supporters.oauth.usecase.GetGoogleConnectionStatusUseCase
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/teachers/me/google")
+class GoogleConnectionController(
+    private val connectGoogleUseCase: ConnectGoogleUseCase,
+    private val disconnectGoogleUseCase: DisconnectGoogleUseCase,
+    private val getStatusUseCase: GetGoogleConnectionStatusUseCase,
+) {
+    @PostMapping("/connect")
+    fun connect(
+        @CurrentUserId userId: String,
+        @Valid @RequestBody request: ConnectGoogleRequest,
+    ): ApiResponse<GoogleConnectionStatusResponse> = ApiResponse.success(connectGoogleUseCase.execute(userId, request))
+
+    @DeleteMapping
+    fun disconnect(
+        @CurrentUserId userId: String,
+    ): ApiResponse<Unit> {
+        disconnectGoogleUseCase.execute(userId)
+        return ApiResponse.success(Unit)
+    }
+
+    @GetMapping
+    fun status(
+        @CurrentUserId userId: String,
+    ): ApiResponse<GoogleConnectionStatusResponse> = ApiResponse.success(getStatusUseCase.execute(userId))
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/controller/GoogleConnectionController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/controller/GoogleConnectionController.kt
@@ -3,6 +3,7 @@ package com.sclass.supporters.oauth.controller
 import com.sclass.common.annotation.CurrentUserId
 import com.sclass.common.annotation.CurrentUserRole
 import com.sclass.common.dto.ApiResponse
+import com.sclass.common.exception.ForbiddenException
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
 import com.sclass.supporters.oauth.dto.GoogleConnectionStatusResponse
@@ -31,13 +32,15 @@ class GoogleConnectionController(
         @Valid @RequestBody request: ConnectGoogleRequest,
     ): ApiResponse<GoogleConnectionStatusResponse> =
         ApiResponse.success(
-            connectGoogleUseCase.execute(userId, Role.valueOf(role), request),
+            connectGoogleUseCase.execute(userId, requireTeacherRole(role), request),
         )
 
     @DeleteMapping
     fun disconnect(
         @CurrentUserId userId: String,
+        @CurrentUserRole role: String,
     ): ApiResponse<Unit> {
+        requireTeacherRole(role)
         disconnectGoogleUseCase.execute(userId)
         return ApiResponse.success(Unit)
     }
@@ -45,5 +48,17 @@ class GoogleConnectionController(
     @GetMapping
     fun status(
         @CurrentUserId userId: String,
-    ): ApiResponse<GoogleConnectionStatusResponse> = ApiResponse.success(getStatusUseCase.execute(userId))
+        @CurrentUserRole role: String,
+    ): ApiResponse<GoogleConnectionStatusResponse> {
+        requireTeacherRole(role)
+        return ApiResponse.success(getStatusUseCase.execute(userId))
+    }
+
+    private fun requireTeacherRole(role: String): Role {
+        val currentRole =
+            runCatching { Role.valueOf(role) }
+                .getOrElse { throw ForbiddenException() }
+        if (currentRole != Role.TEACHER) throw ForbiddenException()
+        return currentRole
+    }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/dto/ConnectGoogleRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/dto/ConnectGoogleRequest.kt
@@ -1,0 +1,8 @@
+package com.sclass.supporters.oauth.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class ConnectGoogleRequest(
+    @field:NotBlank val code: String,
+    @field:NotBlank val redirectUri: String,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/dto/GoogleConnectionStatusResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/dto/GoogleConnectionStatusResponse.kt
@@ -1,0 +1,23 @@
+package com.sclass.supporters.oauth.dto
+
+import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
+import java.time.LocalDateTime
+
+data class GoogleConnectionStatusResponse(
+    val connected: Boolean,
+    val googleEmail: String? = null,
+    val connectedAt: LocalDateTime? = null,
+    val scope: String? = null,
+) {
+    companion object {
+        fun connected(account: TeacherGoogleAccount) =
+            GoogleConnectionStatusResponse(
+                connected = true,
+                googleEmail = account.googleEmail,
+                connectedAt = account.connectedAt,
+                scope = account.scope,
+            )
+
+        fun notConnected() = GoogleConnectionStatusResponse(connected = false)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleAccountLockedUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleAccountLockedUseCase.kt
@@ -1,0 +1,42 @@
+package com.sclass.supporters.oauth.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+
+@UseCase
+class ConnectGoogleAccountLockedUseCase(
+    private val accountAdaptor: TeacherGoogleAccountAdaptor,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    @DistributedLock(prefix = "teacher-google-account", waitTime = 30)
+    @Transactional
+    fun execute(
+        @LockKey userId: String,
+        googleEmail: String,
+        encryptedRefreshToken: String,
+        scope: String,
+    ): TeacherGoogleAccount {
+        val existing = accountAdaptor.findByUserIdOrNull(userId)
+
+        return if (existing != null) {
+            existing.reconnect(googleEmail, encryptedRefreshToken, scope)
+            accountAdaptor.save(existing)
+        } else {
+            accountAdaptor.save(
+                TeacherGoogleAccount(
+                    userId = userId,
+                    googleEmail = googleEmail,
+                    encryptedRefreshToken = encryptedRefreshToken,
+                    scope = scope,
+                    connectedAt = LocalDateTime.now(clock),
+                ),
+            )
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
@@ -5,24 +5,17 @@ import com.sclass.common.exception.ForbiddenException
 import com.sclass.common.exception.GoogleIdentityScopeMissingException
 import com.sclass.common.exception.GoogleRefreshTokenMissingException
 import com.sclass.common.jwt.AesTokenEncryptor
-import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
-import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
 import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
 import com.sclass.supporters.oauth.dto.GoogleConnectionStatusResponse
-import org.springframework.transaction.annotation.Transactional
-import java.time.Clock
-import java.time.LocalDateTime
 
 @UseCase
 class ConnectGoogleUseCase(
     private val googleClient: GoogleAuthorizationCodeClient,
-    private val accountAdaptor: TeacherGoogleAccountAdaptor,
+    private val connectGoogleAccountLockedUseCase: ConnectGoogleAccountLockedUseCase,
     private val encryptor: AesTokenEncryptor,
-    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
-    @Transactional
     fun execute(
         userId: String,
         role: Role,
@@ -37,22 +30,13 @@ class ConnectGoogleUseCase(
         val userInfo = googleClient.fetchUserInfo(tokens.accessToken)
         val encryptedRefreshToken = encryptor.encrypt(refreshToken)
 
-        val existing = accountAdaptor.findByUserIdOrNull(userId)
         val account =
-            if (existing != null) {
-                existing.reconnect(userInfo.email, encryptedRefreshToken, tokens.scope)
-                accountAdaptor.save(existing)
-            } else {
-                accountAdaptor.save(
-                    TeacherGoogleAccount(
-                        userId = userId,
-                        googleEmail = userInfo.email,
-                        encryptedRefreshToken = encryptedRefreshToken,
-                        scope = tokens.scope,
-                        connectedAt = LocalDateTime.now(clock),
-                    ),
-                )
-            }
+            connectGoogleAccountLockedUseCase.execute(
+                userId = userId,
+                googleEmail = userInfo.email,
+                encryptedRefreshToken = encryptedRefreshToken,
+                scope = tokens.scope,
+            )
 
         return GoogleConnectionStatusResponse.connected(account)
     }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
@@ -1,10 +1,12 @@
 package com.sclass.supporters.oauth.usecase
 
 import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.ForbiddenException
 import com.sclass.common.exception.GoogleRefreshTokenMissingException
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
 import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
+import com.sclass.domain.domains.user.domain.Role
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
 import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
 import com.sclass.supporters.oauth.dto.GoogleConnectionStatusResponse
@@ -22,8 +24,11 @@ class ConnectGoogleUseCase(
     @Transactional
     fun execute(
         userId: String,
+        role: Role,
         request: ConnectGoogleRequest,
     ): GoogleConnectionStatusResponse {
+        if (role != Role.TEACHER) throw ForbiddenException()
+
         val tokens = googleClient.exchangeCodeForTokens(request.code, request.redirectUri)
         val refreshToken = tokens.refreshToken ?: throw GoogleRefreshTokenMissingException()
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
@@ -2,6 +2,7 @@ package com.sclass.supporters.oauth.usecase
 
 import com.sclass.common.annotation.UseCase
 import com.sclass.common.exception.ForbiddenException
+import com.sclass.common.exception.GoogleCalendarScopeMissingException
 import com.sclass.common.exception.GoogleIdentityScopeMissingException
 import com.sclass.common.exception.GoogleRefreshTokenMissingException
 import com.sclass.common.jwt.AesTokenEncryptor
@@ -25,7 +26,9 @@ class ConnectGoogleUseCase(
 
         val tokens = googleClient.exchangeCodeForTokens(request.code, request.redirectUri)
         val refreshToken = tokens.refreshToken ?: throw GoogleRefreshTokenMissingException()
-        if (!tokens.scope.hasGoogleEmailScope()) throw GoogleIdentityScopeMissingException()
+        val grantedScopes = tokens.scope.toScopeSet()
+        if (!grantedScopes.hasGoogleEmailScope()) throw GoogleIdentityScopeMissingException()
+        if (GOOGLE_CALENDAR_EVENTS_SCOPE !in grantedScopes) throw GoogleCalendarScopeMissingException()
 
         val userInfo = googleClient.fetchUserInfo(tokens.accessToken)
         val encryptedRefreshToken = encryptor.encrypt(refreshToken)
@@ -41,11 +44,15 @@ class ConnectGoogleUseCase(
         return GoogleConnectionStatusResponse.connected(account)
     }
 
-    private fun String.hasGoogleEmailScope(): Boolean =
+    private fun String.toScopeSet(): Set<String> =
         split(" ")
-            .any { it in GOOGLE_EMAIL_SCOPES }
+            .filter { it.isNotBlank() }
+            .toSet()
+
+    private fun Set<String>.hasGoogleEmailScope(): Boolean = any { it in GOOGLE_EMAIL_SCOPES }
 
     companion object {
+        private const val GOOGLE_CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
         private val GOOGLE_EMAIL_SCOPES =
             setOf(
                 "email",

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
@@ -1,0 +1,52 @@
+package com.sclass.supporters.oauth.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.GoogleRefreshTokenMissingException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
+import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
+import com.sclass.supporters.oauth.dto.GoogleConnectionStatusResponse
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+
+@UseCase
+class ConnectGoogleUseCase(
+    private val googleClient: GoogleAuthorizationCodeClient,
+    private val accountAdaptor: TeacherGoogleAccountAdaptor,
+    private val encryptor: AesTokenEncryptor,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    @Transactional
+    fun execute(
+        userId: String,
+        request: ConnectGoogleRequest,
+    ): GoogleConnectionStatusResponse {
+        val tokens = googleClient.exchangeCodeForTokens(request.code, request.redirectUri)
+        val refreshToken = tokens.refreshToken ?: throw GoogleRefreshTokenMissingException()
+
+        val userInfo = googleClient.fetchUserInfo(tokens.accessToken)
+        val encryptedRefreshToken = encryptor.encrypt(refreshToken)
+
+        val existing = accountAdaptor.findByUserIdOrNull(userId)
+        val account =
+            if (existing != null) {
+                existing.reconnect(userInfo.email, encryptedRefreshToken, tokens.scope)
+                accountAdaptor.save(existing)
+            } else {
+                accountAdaptor.save(
+                    TeacherGoogleAccount(
+                        userId = userId,
+                        googleEmail = userInfo.email,
+                        encryptedRefreshToken = encryptedRefreshToken,
+                        scope = tokens.scope,
+                        connectedAt = LocalDateTime.now(clock),
+                    ),
+                )
+            }
+
+        return GoogleConnectionStatusResponse.connected(account)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
@@ -2,6 +2,7 @@ package com.sclass.supporters.oauth.usecase
 
 import com.sclass.common.annotation.UseCase
 import com.sclass.common.exception.ForbiddenException
+import com.sclass.common.exception.GoogleIdentityScopeMissingException
 import com.sclass.common.exception.GoogleRefreshTokenMissingException
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
@@ -31,6 +32,7 @@ class ConnectGoogleUseCase(
 
         val tokens = googleClient.exchangeCodeForTokens(request.code, request.redirectUri)
         val refreshToken = tokens.refreshToken ?: throw GoogleRefreshTokenMissingException()
+        if (!tokens.scope.hasGoogleIdentityScope()) throw GoogleIdentityScopeMissingException()
 
         val userInfo = googleClient.fetchUserInfo(tokens.accessToken)
         val encryptedRefreshToken = encryptor.encrypt(refreshToken)
@@ -53,5 +55,18 @@ class ConnectGoogleUseCase(
             }
 
         return GoogleConnectionStatusResponse.connected(account)
+    }
+
+    private fun String.hasGoogleIdentityScope(): Boolean =
+        split(" ")
+            .any { it in GOOGLE_IDENTITY_SCOPES }
+
+    companion object {
+        private val GOOGLE_IDENTITY_SCOPES =
+            setOf(
+                "openid",
+                "email",
+                "https://www.googleapis.com/auth/userinfo.email",
+            )
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
@@ -8,6 +8,8 @@ import com.sclass.common.exception.GoogleRefreshTokenMissingException
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
 import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
 import com.sclass.supporters.oauth.dto.GoogleConnectionStatusResponse
 
@@ -17,8 +19,9 @@ class ConnectGoogleUseCase(
     private val connectGoogleAccountLockedUseCase: ConnectGoogleAccountLockedUseCase,
     private val encryptor: AesTokenEncryptor,
 ) {
+    @DistributedLock(prefix = "teacher-google-account", waitTime = 30)
     fun execute(
-        userId: String,
+        @LockKey userId: String,
         role: Role,
         request: ConnectGoogleRequest,
     ): GoogleConnectionStatusResponse {

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
@@ -32,7 +32,7 @@ class ConnectGoogleUseCase(
 
         val tokens = googleClient.exchangeCodeForTokens(request.code, request.redirectUri)
         val refreshToken = tokens.refreshToken ?: throw GoogleRefreshTokenMissingException()
-        if (!tokens.scope.hasGoogleIdentityScope()) throw GoogleIdentityScopeMissingException()
+        if (!tokens.scope.hasGoogleEmailScope()) throw GoogleIdentityScopeMissingException()
 
         val userInfo = googleClient.fetchUserInfo(tokens.accessToken)
         val encryptedRefreshToken = encryptor.encrypt(refreshToken)
@@ -57,14 +57,13 @@ class ConnectGoogleUseCase(
         return GoogleConnectionStatusResponse.connected(account)
     }
 
-    private fun String.hasGoogleIdentityScope(): Boolean =
+    private fun String.hasGoogleEmailScope(): Boolean =
         split(" ")
-            .any { it in GOOGLE_IDENTITY_SCOPES }
+            .any { it in GOOGLE_EMAIL_SCOPES }
 
     companion object {
-        private val GOOGLE_IDENTITY_SCOPES =
+        private val GOOGLE_EMAIL_SCOPES =
             setOf(
-                "openid",
                 "email",
                 "https://www.googleapis.com/auth/userinfo.email",
             )

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/DisconnectGoogleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/DisconnectGoogleUseCase.kt
@@ -1,0 +1,31 @@
+package com.sclass.supporters.oauth.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
+import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import org.slf4j.LoggerFactory
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class DisconnectGoogleUseCase(
+    private val googleClient: GoogleAuthorizationCodeClient,
+    private val accountAdaptor: TeacherGoogleAccountAdaptor,
+    private val encryptor: AesTokenEncryptor,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun execute(userId: String) {
+        val account = accountAdaptor.findByUserIdOrNull(userId) ?: return
+
+        runCatching {
+            val refreshToken = encryptor.decrypt(account.encryptedRefreshToken)
+            googleClient.revokeRefreshToken(refreshToken)
+        }.onFailure {
+            log.warn("Google token revoke 실패(DB 삭제는 진행)", it)
+        }
+
+        accountAdaptor.deleteByUserId(userId)
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/DisconnectGoogleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/DisconnectGoogleUseCase.kt
@@ -4,6 +4,8 @@ import com.sclass.common.annotation.UseCase
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
 import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,8 +17,11 @@ class DisconnectGoogleUseCase(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
+    @DistributedLock(prefix = "teacher-google-account", waitTime = 30)
     @Transactional
-    fun execute(userId: String) {
+    fun execute(
+        @LockKey userId: String,
+    ) {
         val account = accountAdaptor.findByUserIdOrNull(userId) ?: return
 
         runCatching {

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/GetGoogleConnectionStatusUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/GetGoogleConnectionStatusUseCase.kt
@@ -1,0 +1,22 @@
+package com.sclass.supporters.oauth.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
+import com.sclass.supporters.oauth.dto.GoogleConnectionStatusResponse
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetGoogleConnectionStatusUseCase(
+    private val accountAdaptor: TeacherGoogleAccountAdaptor,
+) {
+    @Transactional
+    fun execute(userId: String): GoogleConnectionStatusResponse {
+        val account = accountAdaptor.findByUserIdOrNull(userId)
+
+        return if (account != null) {
+            GoogleConnectionStatusResponse.connected(account)
+        } else {
+            GoogleConnectionStatusResponse.notConnected()
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/main/resources/application.yml.example
+++ b/SClass-Api-Supporters/src/main/resources/application.yml.example
@@ -66,6 +66,7 @@ oauth2:
   providers:
     google:
       client-id: ${GOOGLE_CLIENT_ID:}
+      client-secret: ${GOOGLE_CLIENT_SECRET:}
     kakao:
       client-id: ${KAKAO_CLIENT_ID:}
 

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleAccountLockedUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleAccountLockedUseCaseTest.kt
@@ -1,0 +1,121 @@
+package com.sclass.supporters.oauth.usecase
+
+import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class ConnectGoogleAccountLockedUseCaseTest {
+    private lateinit var accountAdaptor: TeacherGoogleAccountAdaptor
+    private lateinit var useCase: ConnectGoogleAccountLockedUseCase
+
+    private val userId = "user-id-00000000000000001"
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
+    private val clock =
+        Clock.fixed(
+            fixedNow.atZone(ZoneId.systemDefault()).toInstant(),
+            ZoneId.systemDefault(),
+        )
+
+    @BeforeEach
+    fun setUp() {
+        accountAdaptor = mockk()
+        useCase = ConnectGoogleAccountLockedUseCase(accountAdaptor, clock)
+
+        every { accountAdaptor.save(any()) } answers { firstArg() }
+    }
+
+    @Test
+    fun `신규 연결 시 lock 안에서 새 TeacherGoogleAccount를 저장한다`() {
+        every { accountAdaptor.findByUserIdOrNull(userId) } returns null
+
+        val account =
+            useCase.execute(
+                userId = userId,
+                googleEmail = "teacher@gmail.com",
+                encryptedRefreshToken = "encrypted-refresh-token",
+                scope = "email https://www.googleapis.com/auth/calendar.events",
+            )
+
+        assertAll(
+            { assertEquals(userId, account.userId) },
+            { assertEquals("teacher@gmail.com", account.googleEmail) },
+            { assertEquals("encrypted-refresh-token", account.encryptedRefreshToken) },
+            { assertEquals("email https://www.googleapis.com/auth/calendar.events", account.scope) },
+            { assertEquals(fixedNow, account.connectedAt) },
+        )
+        verify {
+            accountAdaptor.save(
+                match<TeacherGoogleAccount> {
+                    it.userId == userId &&
+                        it.googleEmail == "teacher@gmail.com" &&
+                        it.encryptedRefreshToken == "encrypted-refresh-token" &&
+                        it.connectedAt == fixedNow
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `기존 연결이 있으면 lock 안에서 reconnect로 토큰과 이메일이 갱신된다`() {
+        val existing =
+            TeacherGoogleAccount(
+                userId = userId,
+                googleEmail = "old@gmail.com",
+                encryptedRefreshToken = "encrypted-old-token",
+                scope = "old-scope",
+                connectedAt = fixedNow.minusDays(30),
+            )
+        every { accountAdaptor.findByUserIdOrNull(userId) } returns existing
+
+        val account =
+            useCase.execute(
+                userId = userId,
+                googleEmail = "teacher@gmail.com",
+                encryptedRefreshToken = "encrypted-new-token",
+                scope = "email https://www.googleapis.com/auth/calendar.events",
+            )
+
+        assertAll(
+            { assertEquals(existing, account) },
+            { assertEquals("teacher@gmail.com", existing.googleEmail) },
+            { assertEquals("encrypted-new-token", existing.encryptedRefreshToken) },
+            { assertEquals("email https://www.googleapis.com/auth/calendar.events", existing.scope) },
+            { assertEquals(fixedNow.minusDays(30), existing.connectedAt) },
+        )
+        verify { accountAdaptor.save(existing) }
+    }
+
+    @Test
+    fun `동시 최초 연결 저장을 막기 위해 userId 기반 분산 락이 적용된다`() {
+        val method =
+            ConnectGoogleAccountLockedUseCase::class.java.getDeclaredMethod(
+                "execute",
+                String::class.java,
+                String::class.java,
+                String::class.java,
+                String::class.java,
+            )
+
+        val lock = method.getAnnotation(DistributedLock::class.java)
+
+        assertAll(
+            { assertNotNull(lock) },
+            { assertEquals("teacher-google-account", lock.prefix) },
+            { assertEquals(30L, lock.waitTime) },
+            { assertTrue(method.parameters[0].isAnnotationPresent(LockKey::class.java)) },
+        )
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.sclass.supporters.oauth.usecase
 
 import com.sclass.common.exception.ForbiddenException
+import com.sclass.common.exception.GoogleIdentityScopeMissingException
 import com.sclass.common.exception.GoogleRefreshTokenMissingException
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
@@ -31,6 +32,12 @@ class ConnectGoogleUseCaseTest {
 
     private val userId = "user-id-00000000000000001"
     private val redirectUri = "http://localhost:3000/oauth/google/callback"
+    private val grantedScope =
+        listOf(
+            "openid",
+            "https://www.googleapis.com/auth/userinfo.email",
+            "https://www.googleapis.com/auth/calendar.events",
+        ).joinToString(" ")
 
     private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
     private val clock =
@@ -50,14 +57,16 @@ class ConnectGoogleUseCaseTest {
         every { accountAdaptor.save(any()) } answers { firstArg() }
     }
 
-    private fun tokenResponse(refreshToken: String? = "refresh-token-xyz") =
-        GoogleTokenExchangeResponse(
-            accessToken = "access-token-abc",
-            expiresIn = 3600,
-            refreshToken = refreshToken,
-            scope = "https://www.googleapis.com/auth/calendar.events",
-            tokenType = "Bearer",
-        )
+    private fun tokenResponse(
+        refreshToken: String? = "refresh-token-xyz",
+        scope: String = grantedScope,
+    ) = GoogleTokenExchangeResponse(
+        accessToken = "access-token-abc",
+        expiresIn = 3600,
+        refreshToken = refreshToken,
+        scope = scope,
+        tokenType = "Bearer",
+    )
 
     private fun userInfo() =
         GoogleUserInfoResponse(
@@ -84,7 +93,7 @@ class ConnectGoogleUseCaseTest {
             { assertTrue(response.connected) },
             { assertEquals("teacher@gmail.com", response.googleEmail) },
             { assertEquals(fixedNow, response.connectedAt) },
-            { assertEquals("https://www.googleapis.com/auth/calendar.events", response.scope) },
+            { assertEquals(grantedScope, response.scope) },
         )
         verify { encryptor.encrypt("refresh-token-xyz") }
         verify {
@@ -124,7 +133,7 @@ class ConnectGoogleUseCaseTest {
         assertAll(
             { assertEquals("teacher@gmail.com", existing.googleEmail) },
             { assertEquals("encrypted-new-refresh-token", existing.encryptedRefreshToken) },
-            { assertEquals("https://www.googleapis.com/auth/calendar.events", existing.scope) },
+            { assertEquals(grantedScope, existing.scope) },
             { assertEquals(fixedNow.minusDays(30), existing.connectedAt) },
         )
         verify { accountAdaptor.save(existing) }
@@ -157,6 +166,24 @@ class ConnectGoogleUseCaseTest {
         }
 
         verify(exactly = 0) { googleClient.exchangeCodeForTokens(any(), any()) }
+        verify(exactly = 0) { accountAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `Google identity scope가 없으면 userinfo 호출 전에 실패한다`() {
+        every {
+            googleClient.exchangeCodeForTokens("code-5", redirectUri)
+        } returns tokenResponse(scope = "https://www.googleapis.com/auth/calendar.events")
+
+        assertThrows<GoogleIdentityScopeMissingException> {
+            useCase.execute(
+                userId,
+                Role.TEACHER,
+                ConnectGoogleRequest(code = "code-5", redirectUri = redirectUri),
+            )
+        }
+
+        verify(exactly = 0) { googleClient.fetchUserInfo(any()) }
         verify(exactly = 0) { accountAdaptor.save(any()) }
     }
 

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
@@ -1,9 +1,11 @@
 package com.sclass.supporters.oauth.usecase
 
+import com.sclass.common.exception.ForbiddenException
 import com.sclass.common.exception.GoogleRefreshTokenMissingException
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
 import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
+import com.sclass.domain.domains.user.domain.Role
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
 import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
 import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
@@ -71,7 +73,12 @@ class ConnectGoogleUseCaseTest {
         every { googleClient.fetchUserInfo("access-token-abc") } returns userInfo()
         every { accountAdaptor.findByUserIdOrNull(userId) } returns null
 
-        val response = useCase.execute(userId, ConnectGoogleRequest(code = "code-1", redirectUri = redirectUri))
+        val response =
+            useCase.execute(
+                userId,
+                Role.TEACHER,
+                ConnectGoogleRequest(code = "code-1", redirectUri = redirectUri),
+            )
 
         assertAll(
             { assertTrue(response.connected) },
@@ -108,7 +115,11 @@ class ConnectGoogleUseCaseTest {
         every { googleClient.fetchUserInfo("access-token-abc") } returns userInfo()
         every { accountAdaptor.findByUserIdOrNull(userId) } returns existing
 
-        useCase.execute(userId, ConnectGoogleRequest(code = "code-2", redirectUri = redirectUri))
+        useCase.execute(
+            userId,
+            Role.TEACHER,
+            ConnectGoogleRequest(code = "code-2", redirectUri = redirectUri),
+        )
 
         assertAll(
             { assertEquals("teacher@gmail.com", existing.googleEmail) },
@@ -126,8 +137,26 @@ class ConnectGoogleUseCaseTest {
         } returns tokenResponse(refreshToken = null)
 
         assertThrows<GoogleRefreshTokenMissingException> {
-            useCase.execute(userId, ConnectGoogleRequest(code = "code-3", redirectUri = redirectUri))
+            useCase.execute(
+                userId,
+                Role.TEACHER,
+                ConnectGoogleRequest(code = "code-3", redirectUri = redirectUri),
+            )
         }
+        verify(exactly = 0) { accountAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `선생님 권한이 아니면 Google 계정을 연결할 수 없다`() {
+        assertThrows<ForbiddenException> {
+            useCase.execute(
+                userId,
+                Role.STUDENT,
+                ConnectGoogleRequest(code = "code-3", redirectUri = redirectUri),
+            )
+        }
+
+        verify(exactly = 0) { googleClient.exchangeCodeForTokens(any(), any()) }
         verify(exactly = 0) { accountAdaptor.save(any()) }
     }
 
@@ -137,7 +166,11 @@ class ConnectGoogleUseCaseTest {
         every { googleClient.fetchUserInfo(any()) } returns userInfo()
         every { accountAdaptor.findByUserIdOrNull(userId) } returns null
 
-        useCase.execute(userId, ConnectGoogleRequest(code = "code-4", redirectUri = redirectUri))
+        useCase.execute(
+            userId,
+            Role.TEACHER,
+            ConnectGoogleRequest(code = "code-4", redirectUri = redirectUri),
+        )
 
         verify { encryptor.encrypt("raw-token") }
         verify {

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
@@ -170,7 +170,7 @@ class ConnectGoogleUseCaseTest {
     }
 
     @Test
-    fun `Google identity scope가 없으면 userinfo 호출 전에 실패한다`() {
+    fun `Google email scope가 없으면 userinfo 호출 전에 실패한다`() {
         every {
             googleClient.exchangeCodeForTokens("code-5", redirectUri)
         } returns tokenResponse(scope = "https://www.googleapis.com/auth/calendar.events")
@@ -180,6 +180,24 @@ class ConnectGoogleUseCaseTest {
                 userId,
                 Role.TEACHER,
                 ConnectGoogleRequest(code = "code-5", redirectUri = redirectUri),
+            )
+        }
+
+        verify(exactly = 0) { googleClient.fetchUserInfo(any()) }
+        verify(exactly = 0) { accountAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `openid만 있고 email scope가 없으면 userinfo 호출 전에 실패한다`() {
+        every {
+            googleClient.exchangeCodeForTokens("code-6", redirectUri)
+        } returns tokenResponse(scope = "openid profile https://www.googleapis.com/auth/calendar.events")
+
+        assertThrows<GoogleIdentityScopeMissingException> {
+            useCase.execute(
+                userId,
+                Role.TEACHER,
+                ConnectGoogleRequest(code = "code-6", redirectUri = redirectUri),
             )
         }
 

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
@@ -1,0 +1,152 @@
+package com.sclass.supporters.oauth.usecase
+
+import com.sclass.common.exception.GoogleRefreshTokenMissingException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
+import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
+import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
+import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class ConnectGoogleUseCaseTest {
+    private lateinit var googleClient: GoogleAuthorizationCodeClient
+    private lateinit var accountAdaptor: TeacherGoogleAccountAdaptor
+    private lateinit var encryptor: AesTokenEncryptor
+    private lateinit var useCase: ConnectGoogleUseCase
+
+    private val userId = "user-id-00000000000000001"
+    private val redirectUri = "http://localhost:3000/oauth/google/callback"
+
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
+    private val clock =
+        Clock.fixed(
+            fixedNow.atZone(ZoneId.systemDefault()).toInstant(),
+            ZoneId.systemDefault(),
+        )
+
+    @BeforeEach
+    fun setUp() {
+        googleClient = mockk()
+        accountAdaptor = mockk()
+        encryptor = mockk()
+        useCase = ConnectGoogleUseCase(googleClient, accountAdaptor, encryptor, clock)
+
+        every { encryptor.encrypt(any()) } answers { "encrypted-${firstArg<String>()}" }
+        every { accountAdaptor.save(any()) } answers { firstArg() }
+    }
+
+    private fun tokenResponse(refreshToken: String? = "refresh-token-xyz") =
+        GoogleTokenExchangeResponse(
+            accessToken = "access-token-abc",
+            expiresIn = 3600,
+            refreshToken = refreshToken,
+            scope = "https://www.googleapis.com/auth/calendar.events",
+            tokenType = "Bearer",
+        )
+
+    private fun userInfo() =
+        GoogleUserInfoResponse(
+            id = "google-user-id",
+            email = "teacher@gmail.com",
+            verifiedEmail = true,
+            name = "Teacher",
+        )
+
+    @Test
+    fun `신규 연결 시 새 TeacherGoogleAccount가 저장된다`() {
+        every { googleClient.exchangeCodeForTokens("code-1", redirectUri) } returns tokenResponse()
+        every { googleClient.fetchUserInfo("access-token-abc") } returns userInfo()
+        every { accountAdaptor.findByUserIdOrNull(userId) } returns null
+
+        val response = useCase.execute(userId, ConnectGoogleRequest(code = "code-1", redirectUri = redirectUri))
+
+        assertAll(
+            { assertTrue(response.connected) },
+            { assertEquals("teacher@gmail.com", response.googleEmail) },
+            { assertEquals(fixedNow, response.connectedAt) },
+            { assertEquals("https://www.googleapis.com/auth/calendar.events", response.scope) },
+        )
+        verify { encryptor.encrypt("refresh-token-xyz") }
+        verify {
+            accountAdaptor.save(
+                match<TeacherGoogleAccount> {
+                    it.userId == userId &&
+                        it.googleEmail == "teacher@gmail.com" &&
+                        it.encryptedRefreshToken == "encrypted-refresh-token-xyz" &&
+                        it.connectedAt == fixedNow
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `기존 연결이 있으면 reconnect로 토큰과 이메일이 갱신된다`() {
+        val existing =
+            TeacherGoogleAccount(
+                userId = userId,
+                googleEmail = "old@gmail.com",
+                encryptedRefreshToken = "encrypted-old-token",
+                scope = "old-scope",
+                connectedAt = fixedNow.minusDays(30),
+            )
+        every {
+            googleClient.exchangeCodeForTokens("code-2", redirectUri)
+        } returns tokenResponse(refreshToken = "new-refresh-token")
+        every { googleClient.fetchUserInfo("access-token-abc") } returns userInfo()
+        every { accountAdaptor.findByUserIdOrNull(userId) } returns existing
+
+        useCase.execute(userId, ConnectGoogleRequest(code = "code-2", redirectUri = redirectUri))
+
+        assertAll(
+            { assertEquals("teacher@gmail.com", existing.googleEmail) },
+            { assertEquals("encrypted-new-refresh-token", existing.encryptedRefreshToken) },
+            { assertEquals("https://www.googleapis.com/auth/calendar.events", existing.scope) },
+            { assertEquals(fixedNow.minusDays(30), existing.connectedAt) },
+        )
+        verify { accountAdaptor.save(existing) }
+    }
+
+    @Test
+    fun `Google이 refresh_token을 안 주면 GoogleRefreshTokenMissingException`() {
+        every {
+            googleClient.exchangeCodeForTokens("code-3", redirectUri)
+        } returns tokenResponse(refreshToken = null)
+
+        assertThrows<GoogleRefreshTokenMissingException> {
+            useCase.execute(userId, ConnectGoogleRequest(code = "code-3", redirectUri = redirectUri))
+        }
+        verify(exactly = 0) { accountAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `refresh token은 항상 암호화되어 저장된다`() {
+        every { googleClient.exchangeCodeForTokens(any(), any()) } returns tokenResponse(refreshToken = "raw-token")
+        every { googleClient.fetchUserInfo(any()) } returns userInfo()
+        every { accountAdaptor.findByUserIdOrNull(userId) } returns null
+
+        useCase.execute(userId, ConnectGoogleRequest(code = "code-4", redirectUri = redirectUri))
+
+        verify { encryptor.encrypt("raw-token") }
+        verify {
+            accountAdaptor.save(
+                match<TeacherGoogleAccount> {
+                    it.encryptedRefreshToken == "encrypted-raw-token" &&
+                        it.encryptedRefreshToken != "raw-token"
+                },
+            )
+        }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
@@ -4,7 +4,6 @@ import com.sclass.common.exception.ForbiddenException
 import com.sclass.common.exception.GoogleIdentityScopeMissingException
 import com.sclass.common.exception.GoogleRefreshTokenMissingException
 import com.sclass.common.jwt.AesTokenEncryptor
-import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
 import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
@@ -20,13 +19,11 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.time.Clock
 import java.time.LocalDateTime
-import java.time.ZoneId
 
 class ConnectGoogleUseCaseTest {
     private lateinit var googleClient: GoogleAuthorizationCodeClient
-    private lateinit var accountAdaptor: TeacherGoogleAccountAdaptor
+    private lateinit var connectGoogleAccountLockedUseCase: ConnectGoogleAccountLockedUseCase
     private lateinit var encryptor: AesTokenEncryptor
     private lateinit var useCase: ConnectGoogleUseCase
 
@@ -40,21 +37,15 @@ class ConnectGoogleUseCaseTest {
         ).joinToString(" ")
 
     private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
-    private val clock =
-        Clock.fixed(
-            fixedNow.atZone(ZoneId.systemDefault()).toInstant(),
-            ZoneId.systemDefault(),
-        )
 
     @BeforeEach
     fun setUp() {
         googleClient = mockk()
-        accountAdaptor = mockk()
+        connectGoogleAccountLockedUseCase = mockk()
         encryptor = mockk()
-        useCase = ConnectGoogleUseCase(googleClient, accountAdaptor, encryptor, clock)
+        useCase = ConnectGoogleUseCase(googleClient, connectGoogleAccountLockedUseCase, encryptor)
 
         every { encryptor.encrypt(any()) } answers { "encrypted-${firstArg<String>()}" }
-        every { accountAdaptor.save(any()) } answers { firstArg() }
     }
 
     private fun tokenResponse(
@@ -76,11 +67,31 @@ class ConnectGoogleUseCaseTest {
             name = "Teacher",
         )
 
+    private fun connectedAccount(
+        googleEmail: String = "teacher@gmail.com",
+        encryptedRefreshToken: String = "encrypted-refresh-token-xyz",
+        scope: String = grantedScope,
+        connectedAt: LocalDateTime = fixedNow,
+    ) = TeacherGoogleAccount(
+        userId = userId,
+        googleEmail = googleEmail,
+        encryptedRefreshToken = encryptedRefreshToken,
+        scope = scope,
+        connectedAt = connectedAt,
+    )
+
     @Test
     fun `신규 연결 시 새 TeacherGoogleAccount가 저장된다`() {
         every { googleClient.exchangeCodeForTokens("code-1", redirectUri) } returns tokenResponse()
         every { googleClient.fetchUserInfo("access-token-abc") } returns userInfo()
-        every { accountAdaptor.findByUserIdOrNull(userId) } returns null
+        every {
+            connectGoogleAccountLockedUseCase.execute(
+                userId = userId,
+                googleEmail = "teacher@gmail.com",
+                encryptedRefreshToken = "encrypted-refresh-token-xyz",
+                scope = grantedScope,
+            )
+        } returns connectedAccount()
 
         val response =
             useCase.execute(
@@ -97,46 +108,48 @@ class ConnectGoogleUseCaseTest {
         )
         verify { encryptor.encrypt("refresh-token-xyz") }
         verify {
-            accountAdaptor.save(
-                match<TeacherGoogleAccount> {
-                    it.userId == userId &&
-                        it.googleEmail == "teacher@gmail.com" &&
-                        it.encryptedRefreshToken == "encrypted-refresh-token-xyz" &&
-                        it.connectedAt == fixedNow
-                },
+            connectGoogleAccountLockedUseCase.execute(
+                userId = userId,
+                googleEmail = "teacher@gmail.com",
+                encryptedRefreshToken = "encrypted-refresh-token-xyz",
+                scope = grantedScope,
             )
         }
     }
 
     @Test
-    fun `기존 연결이 있으면 reconnect로 토큰과 이메일이 갱신된다`() {
-        val existing =
-            TeacherGoogleAccount(
-                userId = userId,
-                googleEmail = "old@gmail.com",
-                encryptedRefreshToken = "encrypted-old-token",
-                scope = "old-scope",
-                connectedAt = fixedNow.minusDays(30),
-            )
+    fun `locked use case가 반환한 계정으로 연결 응답을 만든다`() {
         every {
             googleClient.exchangeCodeForTokens("code-2", redirectUri)
         } returns tokenResponse(refreshToken = "new-refresh-token")
         every { googleClient.fetchUserInfo("access-token-abc") } returns userInfo()
-        every { accountAdaptor.findByUserIdOrNull(userId) } returns existing
+        every {
+            connectGoogleAccountLockedUseCase.execute(
+                userId = userId,
+                googleEmail = "teacher@gmail.com",
+                encryptedRefreshToken = "encrypted-new-refresh-token",
+                scope = grantedScope,
+            )
+        } returns
+            connectedAccount(
+                googleEmail = "teacher@gmail.com",
+                encryptedRefreshToken = "encrypted-new-refresh-token",
+                connectedAt = fixedNow.minusDays(30),
+            )
 
-        useCase.execute(
-            userId,
-            Role.TEACHER,
-            ConnectGoogleRequest(code = "code-2", redirectUri = redirectUri),
-        )
+        val response =
+            useCase.execute(
+                userId,
+                Role.TEACHER,
+                ConnectGoogleRequest(code = "code-2", redirectUri = redirectUri),
+            )
 
         assertAll(
-            { assertEquals("teacher@gmail.com", existing.googleEmail) },
-            { assertEquals("encrypted-new-refresh-token", existing.encryptedRefreshToken) },
-            { assertEquals(grantedScope, existing.scope) },
-            { assertEquals(fixedNow.minusDays(30), existing.connectedAt) },
+            { assertTrue(response.connected) },
+            { assertEquals("teacher@gmail.com", response.googleEmail) },
+            { assertEquals(grantedScope, response.scope) },
+            { assertEquals(fixedNow.minusDays(30), response.connectedAt) },
         )
-        verify { accountAdaptor.save(existing) }
     }
 
     @Test
@@ -152,7 +165,7 @@ class ConnectGoogleUseCaseTest {
                 ConnectGoogleRequest(code = "code-3", redirectUri = redirectUri),
             )
         }
-        verify(exactly = 0) { accountAdaptor.save(any()) }
+        verify(exactly = 0) { connectGoogleAccountLockedUseCase.execute(any(), any(), any(), any()) }
     }
 
     @Test
@@ -166,7 +179,7 @@ class ConnectGoogleUseCaseTest {
         }
 
         verify(exactly = 0) { googleClient.exchangeCodeForTokens(any(), any()) }
-        verify(exactly = 0) { accountAdaptor.save(any()) }
+        verify(exactly = 0) { connectGoogleAccountLockedUseCase.execute(any(), any(), any(), any()) }
     }
 
     @Test
@@ -184,7 +197,7 @@ class ConnectGoogleUseCaseTest {
         }
 
         verify(exactly = 0) { googleClient.fetchUserInfo(any()) }
-        verify(exactly = 0) { accountAdaptor.save(any()) }
+        verify(exactly = 0) { connectGoogleAccountLockedUseCase.execute(any(), any(), any(), any()) }
     }
 
     @Test
@@ -202,14 +215,21 @@ class ConnectGoogleUseCaseTest {
         }
 
         verify(exactly = 0) { googleClient.fetchUserInfo(any()) }
-        verify(exactly = 0) { accountAdaptor.save(any()) }
+        verify(exactly = 0) { connectGoogleAccountLockedUseCase.execute(any(), any(), any(), any()) }
     }
 
     @Test
     fun `refresh token은 항상 암호화되어 저장된다`() {
         every { googleClient.exchangeCodeForTokens(any(), any()) } returns tokenResponse(refreshToken = "raw-token")
         every { googleClient.fetchUserInfo(any()) } returns userInfo()
-        every { accountAdaptor.findByUserIdOrNull(userId) } returns null
+        every {
+            connectGoogleAccountLockedUseCase.execute(
+                userId = userId,
+                googleEmail = "teacher@gmail.com",
+                encryptedRefreshToken = "encrypted-raw-token",
+                scope = grantedScope,
+            )
+        } returns connectedAccount(encryptedRefreshToken = "encrypted-raw-token")
 
         useCase.execute(
             userId,
@@ -219,11 +239,11 @@ class ConnectGoogleUseCaseTest {
 
         verify { encryptor.encrypt("raw-token") }
         verify {
-            accountAdaptor.save(
-                match<TeacherGoogleAccount> {
-                    it.encryptedRefreshToken == "encrypted-raw-token" &&
-                        it.encryptedRefreshToken != "raw-token"
-                },
+            connectGoogleAccountLockedUseCase.execute(
+                userId = userId,
+                googleEmail = "teacher@gmail.com",
+                encryptedRefreshToken = "encrypted-raw-token",
+                scope = grantedScope,
             )
         }
     }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
@@ -10,12 +10,15 @@ import com.sclass.domain.domains.user.domain.Role
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
 import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
 import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
 import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -265,5 +268,25 @@ class ConnectGoogleUseCaseTest {
                 scope = grantedScope,
             )
         }
+    }
+
+    @Test
+    fun `connect 전체 흐름은 userId 기반 분산 락으로 보호된다`() {
+        val method =
+            ConnectGoogleUseCase::class.java.getDeclaredMethod(
+                "execute",
+                String::class.java,
+                Role::class.java,
+                ConnectGoogleRequest::class.java,
+            )
+
+        val lock = method.getAnnotation(DistributedLock::class.java)
+
+        assertAll(
+            { assertNotNull(lock) },
+            { assertEquals("teacher-google-account", lock.prefix) },
+            { assertEquals(30L, lock.waitTime) },
+            { assertTrue(method.parameters[0].isAnnotationPresent(LockKey::class.java)) },
+        )
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.sclass.supporters.oauth.usecase
 
 import com.sclass.common.exception.ForbiddenException
+import com.sclass.common.exception.GoogleCalendarScopeMissingException
 import com.sclass.common.exception.GoogleIdentityScopeMissingException
 import com.sclass.common.exception.GoogleRefreshTokenMissingException
 import com.sclass.common.jwt.AesTokenEncryptor
@@ -211,6 +212,24 @@ class ConnectGoogleUseCaseTest {
                 userId,
                 Role.TEACHER,
                 ConnectGoogleRequest(code = "code-6", redirectUri = redirectUri),
+            )
+        }
+
+        verify(exactly = 0) { googleClient.fetchUserInfo(any()) }
+        verify(exactly = 0) { connectGoogleAccountLockedUseCase.execute(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `calendar scope가 없으면 userinfo 호출 전에 실패한다`() {
+        every {
+            googleClient.exchangeCodeForTokens("code-7", redirectUri)
+        } returns tokenResponse(scope = "openid email https://www.googleapis.com/auth/userinfo.email")
+
+        assertThrows<GoogleCalendarScopeMissingException> {
+            useCase.execute(
+                userId,
+                Role.TEACHER,
+                ConnectGoogleRequest(code = "code-7", redirectUri = redirectUri),
             )
         }
 

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/DisconnectGoogleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/DisconnectGoogleUseCaseTest.kt
@@ -1,0 +1,87 @@
+package com.sclass.supporters.oauth.usecase
+
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
+import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class DisconnectGoogleUseCaseTest {
+    private lateinit var googleClient: GoogleAuthorizationCodeClient
+    private lateinit var accountAdaptor: TeacherGoogleAccountAdaptor
+    private lateinit var encryptor: AesTokenEncryptor
+    private lateinit var useCase: DisconnectGoogleUseCase
+
+    private val userId = "user-id-00000000000000001"
+
+    @BeforeEach
+    fun setUp() {
+        googleClient = mockk()
+        accountAdaptor = mockk()
+        encryptor = mockk()
+        useCase = DisconnectGoogleUseCase(googleClient, accountAdaptor, encryptor)
+    }
+
+    private fun account() =
+        TeacherGoogleAccount(
+            userId = userId,
+            googleEmail = "teacher@gmail.com",
+            encryptedRefreshToken = "encrypted-refresh-token",
+            scope = "https://www.googleapis.com/auth/calendar.events",
+            connectedAt = LocalDateTime.of(2026, 4, 26, 14, 0),
+        )
+
+    @Test
+    fun `연결된 계정이 있으면 Google revoke 후 DB 삭제`() {
+        every { accountAdaptor.findByUserIdOrNull(userId) } returns account()
+        every { encryptor.decrypt("encrypted-refresh-token") } returns "raw-refresh-token"
+        every { googleClient.revokeRefreshToken("raw-refresh-token") } just Runs
+        every { accountAdaptor.deleteByUserId(userId) } just Runs
+
+        useCase.execute(userId)
+
+        verify { googleClient.revokeRefreshToken("raw-refresh-token") }
+        verify { accountAdaptor.deleteByUserId(userId) }
+    }
+
+    @Test
+    fun `연결된 계정이 없으면 아무 동작 없이 종료`() {
+        every { accountAdaptor.findByUserIdOrNull(userId) } returns null
+
+        useCase.execute(userId)
+
+        verify(exactly = 0) { googleClient.revokeRefreshToken(any()) }
+        verify(exactly = 0) { accountAdaptor.deleteByUserId(any()) }
+    }
+
+    @Test
+    fun `복호화 실패해도 DB 삭제는 진행된다`() {
+        every { accountAdaptor.findByUserIdOrNull(userId) } returns account()
+        every { encryptor.decrypt(any()) } throws RuntimeException("decrypt failed")
+        every { accountAdaptor.deleteByUserId(userId) } just Runs
+
+        useCase.execute(userId)
+
+        verify(exactly = 0) { googleClient.revokeRefreshToken(any()) }
+        verify { accountAdaptor.deleteByUserId(userId) }
+    }
+
+    @Test
+    fun `Google revoke 호출이 예외를 던져도 DB 삭제는 진행된다`() {
+        every { accountAdaptor.findByUserIdOrNull(userId) } returns account()
+        every { encryptor.decrypt(any()) } returns "raw-refresh-token"
+        every { googleClient.revokeRefreshToken(any()) } throws RuntimeException("revoke failed")
+        every { accountAdaptor.deleteByUserId(userId) } just Runs
+
+        useCase.execute(userId)
+
+        verify { accountAdaptor.deleteByUserId(userId) }
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/DisconnectGoogleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/DisconnectGoogleUseCaseTest.kt
@@ -4,11 +4,17 @@ import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
 import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
@@ -83,5 +89,18 @@ class DisconnectGoogleUseCaseTest {
         useCase.execute(userId)
 
         verify { accountAdaptor.deleteByUserId(userId) }
+    }
+
+    @Test
+    fun `connect와 disconnect 경합을 막기 위해 userId 기반 분산 락이 적용된다`() {
+        val method = DisconnectGoogleUseCase::class.java.getDeclaredMethod("execute", String::class.java)
+        val lock = method.getAnnotation(DistributedLock::class.java)
+
+        assertAll(
+            { assertNotNull(lock) },
+            { assertEquals("teacher-google-account", lock.prefix) },
+            { assertEquals(30L, lock.waitTime) },
+            { assertTrue(method.parameters[0].isAnnotationPresent(LockKey::class.java)) },
+        )
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/GetGoogleConnectionStatusUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/GetGoogleConnectionStatusUseCaseTest.kt
@@ -1,0 +1,63 @@
+package com.sclass.supporters.oauth.usecase
+
+import com.sclass.domain.domains.oauth.adaptor.TeacherGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class GetGoogleConnectionStatusUseCaseTest {
+    private lateinit var accountAdaptor: TeacherGoogleAccountAdaptor
+    private lateinit var useCase: GetGoogleConnectionStatusUseCase
+
+    private val userId = "user-id-00000000000000001"
+
+    @BeforeEach
+    fun setUp() {
+        accountAdaptor = mockk()
+        useCase = GetGoogleConnectionStatusUseCase(accountAdaptor)
+    }
+
+    @Test
+    fun `연결된 계정이 있으면 connected=true와 상세 정보 반환`() {
+        val connectedAt = LocalDateTime.of(2026, 4, 26, 14, 0)
+        every { accountAdaptor.findByUserIdOrNull(userId) } returns
+            TeacherGoogleAccount(
+                userId = userId,
+                googleEmail = "teacher@gmail.com",
+                encryptedRefreshToken = "encrypted-token",
+                scope = "https://www.googleapis.com/auth/calendar.events",
+                connectedAt = connectedAt,
+            )
+
+        val response = useCase.execute(userId)
+
+        assertAll(
+            { assertTrue(response.connected) },
+            { assertEquals("teacher@gmail.com", response.googleEmail) },
+            { assertEquals(connectedAt, response.connectedAt) },
+            { assertEquals("https://www.googleapis.com/auth/calendar.events", response.scope) },
+        )
+    }
+
+    @Test
+    fun `연결된 계정이 없으면 connected=false`() {
+        every { accountAdaptor.findByUserIdOrNull(userId) } returns null
+
+        val response = useCase.execute(userId)
+
+        assertAll(
+            { assertFalse(response.connected) },
+            { assertNull(response.googleEmail) },
+            { assertNull(response.connectedAt) },
+            { assertNull(response.scope) },
+        )
+    }
+}

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/GlobalErrorCode.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/GlobalErrorCode.kt
@@ -10,5 +10,6 @@ enum class GlobalErrorCode(
     FORBIDDEN("GLOBAL_003", "권한이 없습니다", 403),
     NOT_FOUND("GLOBAL_004", "리소스를 찾을 수 없습니다", 404),
     CONFLICT("GLOBAL_005", "충돌이 발생했습니다", 409),
+    LOCK_CONFLICT("GLOBAL_006", "요청이 이미 처리 중입니다. 잠시 후 다시 시도해주세요", 409),
     INTERNAL_ERROR("GLOBAL_500", "서버 내부 오류가 발생했습니다", 500),
 }

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleCalendarScopeMissingException.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleCalendarScopeMissingException.kt
@@ -1,0 +1,3 @@
+package com.sclass.common.exception
+
+class GoogleCalendarScopeMissingException : BusinessException(OAuthTokenErrorCode.GOOGLE_CALENDAR_SCOPE_MISSING)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleIdentityScopeMissingException.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleIdentityScopeMissingException.kt
@@ -1,0 +1,3 @@
+package com.sclass.common.exception
+
+class GoogleIdentityScopeMissingException : BusinessException(OAuthTokenErrorCode.GOOGLE_IDENTITY_SCOPE_MISSING)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleOAuthProviderUnavailableException.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleOAuthProviderUnavailableException.kt
@@ -1,0 +1,3 @@
+package com.sclass.common.exception
+
+class GoogleOAuthProviderUnavailableException : BusinessException(OAuthTokenErrorCode.GOOGLE_OAUTH_PROVIDER_UNAVAILABLE)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleRefreshTokenMissingException.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleRefreshTokenMissingException.kt
@@ -1,0 +1,3 @@
+package com.sclass.common.exception
+
+class GoogleRefreshTokenMissingException : BusinessException(OAuthTokenErrorCode.GOOGLE_REFRESH_TOKEN_MISSING)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleTokenExchangeFailedException.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleTokenExchangeFailedException.kt
@@ -1,0 +1,3 @@
+package com.sclass.common.exception
+
+class GoogleTokenExchangeFailedException : BusinessException(OAuthTokenErrorCode.GOOGLE_TOKEN_EXCHANGE_FAILED)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleTokenRefreshFailedException.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleTokenRefreshFailedException.kt
@@ -1,0 +1,3 @@
+package com.sclass.common.exception
+
+class GoogleTokenRefreshFailedException : BusinessException(OAuthTokenErrorCode.GOOGLE_TOKEN_REFRESH_FAILED)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
@@ -7,4 +7,7 @@ enum class OAuthTokenErrorCode(
 ) : ErrorCode {
     OAUTH_TOKEN_AUDIENCE_MISMATCH("OAUTH_010", "OAuth 토큰의 대상 애플리케이션이 일치하지 않습니다", 401),
     OAUTH_TOKEN_VALIDATION_FAILED("OAUTH_011", "OAuth 토큰 검증에 실패했습니다", 502),
+    GOOGLE_TOKEN_EXCHANGE_FAILED("OAUTH_012", "Google 토큰 교환에 실패했습니다", 400),
+    GOOGLE_TOKEN_REFRESH_FAILED("OAUTH_013", "Google 토큰 갱신에 실패했습니다", 401),
+    GOOGLE_REFRESH_TOKEN_MISSING("OAUTH_014", "Google에서 refresh token이 발급되지 않았습니다", 400),
 }

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
@@ -10,5 +10,5 @@ enum class OAuthTokenErrorCode(
     GOOGLE_TOKEN_EXCHANGE_FAILED("OAUTH_012", "Google 토큰 교환에 실패했습니다", 400),
     GOOGLE_TOKEN_REFRESH_FAILED("OAUTH_013", "Google 토큰 갱신에 실패했습니다", 401),
     GOOGLE_REFRESH_TOKEN_MISSING("OAUTH_014", "Google에서 refresh token이 발급되지 않았습니다", 400),
-    GOOGLE_IDENTITY_SCOPE_MISSING("OAUTH_016", "Google 계정 이메일 조회를 위한 identity scope가 필요합니다", 400),
+    GOOGLE_IDENTITY_SCOPE_MISSING("OAUTH_016", "Google 계정 이메일 조회를 위한 email scope가 필요합니다", 400),
 }

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
@@ -11,4 +11,5 @@ enum class OAuthTokenErrorCode(
     GOOGLE_TOKEN_REFRESH_FAILED("OAUTH_013", "Google 토큰 갱신에 실패했습니다", 401),
     GOOGLE_REFRESH_TOKEN_MISSING("OAUTH_014", "Google에서 refresh token이 발급되지 않았습니다", 400),
     GOOGLE_IDENTITY_SCOPE_MISSING("OAUTH_016", "Google 계정 이메일 조회를 위한 email scope가 필요합니다", 400),
+    GOOGLE_CALENDAR_SCOPE_MISSING("OAUTH_017", "Google Calendar 연동을 위한 calendar.events scope가 필요합니다", 400),
 }

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
@@ -12,4 +12,5 @@ enum class OAuthTokenErrorCode(
     GOOGLE_REFRESH_TOKEN_MISSING("OAUTH_014", "Google에서 refresh token이 발급되지 않았습니다", 400),
     GOOGLE_IDENTITY_SCOPE_MISSING("OAUTH_016", "Google 계정 이메일 조회를 위한 email scope가 필요합니다", 400),
     GOOGLE_CALENDAR_SCOPE_MISSING("OAUTH_017", "Google Calendar 연동을 위한 calendar.events scope가 필요합니다", 400),
+    GOOGLE_OAUTH_PROVIDER_UNAVAILABLE("OAUTH_018", "Google OAuth 서버가 일시적으로 응답하지 않습니다", 503),
 }

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
@@ -10,4 +10,5 @@ enum class OAuthTokenErrorCode(
     GOOGLE_TOKEN_EXCHANGE_FAILED("OAUTH_012", "Google 토큰 교환에 실패했습니다", 400),
     GOOGLE_TOKEN_REFRESH_FAILED("OAUTH_013", "Google 토큰 갱신에 실패했습니다", 401),
     GOOGLE_REFRESH_TOKEN_MISSING("OAUTH_014", "Google에서 refresh token이 발급되지 않았습니다", 400),
+    GOOGLE_IDENTITY_SCOPE_MISSING("OAUTH_016", "Google 계정 이메일 조회를 위한 identity scope가 필요합니다", 400),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/adaptor/TeacherGoogleAccountAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/adaptor/TeacherGoogleAccountAdaptor.kt
@@ -1,0 +1,22 @@
+package com.sclass.domain.domains.oauth.adaptor
+
+import com.sclass.common.annotation.Adaptor
+import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
+import com.sclass.domain.domains.oauth.exception.TeacherGoogleAccountNotFoundException
+import com.sclass.domain.domains.oauth.repository.TeacherGoogleAccountRepository
+
+@Adaptor
+class TeacherGoogleAccountAdaptor(
+    private val repository: TeacherGoogleAccountRepository,
+) {
+    fun save(account: TeacherGoogleAccount): TeacherGoogleAccount = repository.save(account)
+
+    fun findByUserId(userId: String): TeacherGoogleAccount =
+        repository.findByUserId(userId) ?: throw TeacherGoogleAccountNotFoundException()
+
+    fun findByUserIdOrNull(userId: String): TeacherGoogleAccount? = repository.findByUserId(userId)
+
+    fun existsByUserId(userId: String): Boolean = repository.existsByUserId(userId)
+
+    fun deleteByUserId(userId: String) = repository.deleteByUserId(userId)
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/domain/TeacherGoogleAccount.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/domain/TeacherGoogleAccount.kt
@@ -1,0 +1,50 @@
+package com.sclass.domain.domains.oauth.domain
+
+import com.sclass.domain.common.model.BaseTimeEntity
+import com.sclass.domain.common.vo.Ulid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "teacher_google_accounts",
+    indexes = [
+        Index(name = "uq_teacher_google_user_id", columnList = "user_id", unique = true),
+        Index(name = "idx_teacher_google_email", columnList = "google_email"),
+    ],
+)
+class TeacherGoogleAccount(
+    @Id
+    @Column(length = 26)
+    val id: String = Ulid.generate(),
+    @Column(name = "user_id", nullable = false, unique = true, length = 26)
+    val userId: String,
+    @Column(name = "google_email", nullable = false, length = 320)
+    var googleEmail: String,
+    @Column(name = "encrypted_refresh_token", nullable = false, columnDefinition = "TEXT")
+    var encryptedRefreshToken: String,
+    @Column(nullable = false, length = 500)
+    var scope: String,
+    @Column(name = "connected_at", nullable = false)
+    val connectedAt: LocalDateTime,
+    @Column(name = "last_used_at")
+    var lastUsedAt: LocalDateTime? = null,
+) : BaseTimeEntity() {
+    fun reconnect(
+        newGoogleEmail: String,
+        newEncryptedRefreshToken: String,
+        newScope: String,
+    ) {
+        this.googleEmail = newGoogleEmail
+        this.encryptedRefreshToken = newEncryptedRefreshToken
+        this.scope = newScope
+    }
+
+    fun markUsed(at: LocalDateTime) {
+        this.lastUsedAt = at
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/exception/OAuthErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/exception/OAuthErrorCode.kt
@@ -7,5 +7,5 @@ enum class OAuthErrorCode(
     override val message: String,
     override val httpStatus: Int,
 ) : ErrorCode {
-    TEACHER_GOOGLE_ACCOUNT_NOT_FOUND("OAUTH_001", "연결된 Google 계정이 없습니다", 404),
+    TEACHER_GOOGLE_ACCOUNT_NOT_FOUND("OAUTH_015", "연결된 Google 계정이 없습니다", 404),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/exception/OAuthErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/exception/OAuthErrorCode.kt
@@ -1,0 +1,11 @@
+package com.sclass.domain.domains.oauth.exception
+
+import com.sclass.common.exception.ErrorCode
+
+enum class OAuthErrorCode(
+    override val code: String,
+    override val message: String,
+    override val httpStatus: Int,
+) : ErrorCode {
+    TEACHER_GOOGLE_ACCOUNT_NOT_FOUND("OAUTH_001", "연결된 Google 계정이 없습니다", 404),
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/exception/TeacherGoogleAccountNotFoundException.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/exception/TeacherGoogleAccountNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.sclass.domain.domains.oauth.exception
+
+import com.sclass.common.exception.BusinessException
+
+class TeacherGoogleAccountNotFoundException : BusinessException(OAuthErrorCode.TEACHER_GOOGLE_ACCOUNT_NOT_FOUND)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/repository/TeacherGoogleAccountRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/repository/TeacherGoogleAccountRepository.kt
@@ -1,0 +1,12 @@
+package com.sclass.domain.domains.oauth.repository
+
+import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TeacherGoogleAccountRepository : JpaRepository<TeacherGoogleAccount, String> {
+    fun findByUserId(userId: String): TeacherGoogleAccount?
+
+    fun deleteByUserId(userId: String)
+
+    fun existsByUserId(userId: String): Boolean
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClient.kt
@@ -1,5 +1,6 @@
 package com.sclass.infrastructure.oauth.client
 
+import com.sclass.common.exception.GoogleOAuthProviderUnavailableException
 import com.sclass.common.exception.GoogleTokenExchangeFailedException
 import com.sclass.common.exception.GoogleTokenRefreshFailedException
 import com.sclass.infrastructure.oauth.config.OAuthProperties
@@ -44,22 +45,28 @@ class GoogleAuthorizationCodeClient(
                 add("grant_type", "authorization_code")
             }
 
-        return try {
-            webClient
-                .post()
-                .uri("https://oauth2.googleapis.com/token")
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(BodyInserters.fromFormData(params))
-                .retrieve()
-                .bodyToMono(GoogleTokenExchangeResponse::class.java)
-                .block()!!
-        } catch (e: WebClientResponseException) {
-            log.warn("Google token exchange failed: ${e.responseBodyAsString}", e)
-            throw GoogleTokenExchangeFailedException()
-        } catch (e: Exception) {
-            log.warn("Google token exchange failed", e)
-            throw GoogleTokenExchangeFailedException()
-        }
+        val response =
+            try {
+                webClient
+                    .post()
+                    .uri("https://oauth2.googleapis.com/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(params))
+                    .retrieve()
+                    .bodyToMono(GoogleTokenExchangeResponse::class.java)
+                    .block()
+            } catch (e: WebClientResponseException) {
+                log.warn("Google token exchange failed: ${e.responseBodyAsString}", e)
+                if (e.isRetryableUpstreamFailure()) {
+                    throw GoogleOAuthProviderUnavailableException()
+                }
+                throw GoogleTokenExchangeFailedException()
+            } catch (e: Exception) {
+                log.warn("Google token exchange failed", e)
+                throw GoogleOAuthProviderUnavailableException()
+            }
+
+        return response ?: throw GoogleOAuthProviderUnavailableException()
     }
 
     fun refreshAccessToken(refreshToken: String): String {
@@ -71,23 +78,28 @@ class GoogleAuthorizationCodeClient(
                 add("grant_type", "refresh_token")
             }
 
-        return try {
-            webClient
-                .post()
-                .uri("https://oauth2.googleapis.com/token")
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(BodyInserters.fromFormData(params))
-                .retrieve()
-                .bodyToMono(GoogleTokenExchangeResponse::class.java)
-                .block()!!
-                .accessToken
-        } catch (e: WebClientResponseException) {
-            log.warn("Google token refresh failed: ${e.responseBodyAsString}", e)
-            throw GoogleTokenRefreshFailedException()
-        } catch (e: Exception) {
-            log.warn("Google token refresh failed", e)
-            throw GoogleTokenRefreshFailedException()
-        }
+        val response =
+            try {
+                webClient
+                    .post()
+                    .uri("https://oauth2.googleapis.com/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(params))
+                    .retrieve()
+                    .bodyToMono(GoogleTokenExchangeResponse::class.java)
+                    .block()
+            } catch (e: WebClientResponseException) {
+                log.warn("Google token refresh failed: ${e.responseBodyAsString}", e)
+                if (e.isRetryableUpstreamFailure()) {
+                    throw GoogleOAuthProviderUnavailableException()
+                }
+                throw GoogleTokenRefreshFailedException()
+            } catch (e: Exception) {
+                log.warn("Google token refresh failed", e)
+                throw GoogleOAuthProviderUnavailableException()
+            }
+
+        return response?.accessToken ?: throw GoogleOAuthProviderUnavailableException()
     }
 
     fun revokeRefreshToken(refreshToken: String) {
@@ -122,12 +134,22 @@ class GoogleAuthorizationCodeClient(
                     .block()
             } catch (e: WebClientResponseException) {
                 log.warn("Google fetch user info failed: ${e.responseBodyAsString}", e)
+                if (e.isRetryableUpstreamFailure()) {
+                    throw GoogleOAuthProviderUnavailableException()
+                }
                 throw GoogleTokenExchangeFailedException()
             } catch (e: Exception) {
                 log.warn("Google fetch user info failed", e)
-                throw GoogleTokenExchangeFailedException()
+                throw GoogleOAuthProviderUnavailableException()
             }
 
-        return userInfo ?: throw GoogleTokenExchangeFailedException()
+        return userInfo ?: throw GoogleOAuthProviderUnavailableException()
+    }
+
+    private fun WebClientResponseException.isRetryableUpstreamFailure(): Boolean =
+        statusCode.is5xxServerError || statusCode.value() == TOO_MANY_REQUESTS_STATUS
+
+    private companion object {
+        const val TOO_MANY_REQUESTS_STATUS = 429
     }
 }

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClient.kt
@@ -1,0 +1,114 @@
+package com.sclass.infrastructure.oauth.client
+
+import com.sclass.common.exception.GoogleTokenExchangeFailedException
+import com.sclass.common.exception.GoogleTokenRefreshFailedException
+import com.sclass.infrastructure.oauth.config.OAuthProperties
+import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
+import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+@Component
+class GoogleAuthorizationCodeClient(
+    private val oAuthProperties: OAuthProperties,
+    @param:Qualifier("oAuthWebClient") private val webClient: WebClient,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private val clientId: String
+        get() =
+            oAuthProperties.providers["google"]?.clientId
+                ?: throw IllegalStateException("Google OAuth client-id가 설정되지 않았습니다")
+
+    private val clientSecret: String
+        get() =
+            oAuthProperties.providers["google"]?.clientSecret
+                ?: throw IllegalStateException("Google OAuth client-secret이 설정되지 않았습니다")
+
+    fun exchangeCodeForTokens(
+        code: String,
+        redirectUri: String,
+    ): GoogleTokenExchangeResponse {
+        val params =
+            LinkedMultiValueMap<String, String>().apply {
+                add("code", code)
+                add("client_id", clientId)
+                add("client_secret", clientSecret)
+                add("redirect_uri", redirectUri)
+                add("grant_type", "authorization_code")
+            }
+
+        return try {
+            webClient
+                .post()
+                .uri("https://oauth2.googleapis.com/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(params))
+                .retrieve()
+                .bodyToMono(GoogleTokenExchangeResponse::class.java)
+                .block()!!
+        } catch (e: WebClientResponseException) {
+            log.warn("Google token exchange failed: ${e.responseBodyAsString}", e)
+            throw GoogleTokenExchangeFailedException()
+        } catch (e: Exception) {
+            log.warn("Google token exchange failed", e)
+            throw GoogleTokenExchangeFailedException()
+        }
+    }
+
+    fun refreshAccessToken(refreshToken: String): String {
+        val params =
+            LinkedMultiValueMap<String, String>().apply {
+                add("client_id", clientId)
+                add("client_secret", clientSecret)
+                add("refresh_token", refreshToken)
+                add("grant_type", "refresh_token")
+            }
+
+        return try {
+            webClient
+                .post()
+                .uri("https://oauth2.googleapis.com/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(params))
+                .retrieve()
+                .bodyToMono(GoogleTokenExchangeResponse::class.java)
+                .block()!!
+                .accessToken
+        } catch (e: WebClientResponseException) {
+            log.warn("Google token refresh failed: ${e.responseBodyAsString}", e)
+            throw GoogleTokenRefreshFailedException()
+        } catch (e: Exception) {
+            log.warn("Google token refresh failed", e)
+            throw GoogleTokenRefreshFailedException()
+        }
+    }
+
+    fun revokeRefreshToken(refreshToken: String) {
+        try {
+            webClient
+                .post()
+                .uri("https://oauth2.googleapis.com/revoke?token=$refreshToken")
+                .retrieve()
+                .toBodilessEntity()
+                .block()
+        } catch (e: Exception) {
+            log.warn("Google token revoke failed (best effort, ignoring)", e)
+        }
+    }
+
+    fun fetchUserInfo(accessToken: String): GoogleUserInfoResponse =
+        webClient
+            .get()
+            .uri("https://www.googleapis.com/oauth2/v2/userinfo")
+            .header("Authorization", "Bearer $accessToken")
+            .retrieve()
+            .bodyToMono(GoogleUserInfoResponse::class.java)
+            .block()!!
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClient.kt
@@ -91,10 +91,17 @@ class GoogleAuthorizationCodeClient(
     }
 
     fun revokeRefreshToken(refreshToken: String) {
+        val params =
+            LinkedMultiValueMap<String, String>().apply {
+                add("token", refreshToken)
+            }
+
         try {
             webClient
                 .post()
-                .uri("https://oauth2.googleapis.com/revoke?token=$refreshToken")
+                .uri("https://oauth2.googleapis.com/revoke")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(params))
                 .retrieve()
                 .toBodilessEntity()
                 .block()
@@ -103,12 +110,24 @@ class GoogleAuthorizationCodeClient(
         }
     }
 
-    fun fetchUserInfo(accessToken: String): GoogleUserInfoResponse =
-        webClient
-            .get()
-            .uri("https://www.googleapis.com/oauth2/v2/userinfo")
-            .header("Authorization", "Bearer $accessToken")
-            .retrieve()
-            .bodyToMono(GoogleUserInfoResponse::class.java)
-            .block()!!
+    fun fetchUserInfo(accessToken: String): GoogleUserInfoResponse {
+        val userInfo =
+            try {
+                webClient
+                    .get()
+                    .uri("https://www.googleapis.com/oauth2/v2/userinfo")
+                    .header("Authorization", "Bearer $accessToken")
+                    .retrieve()
+                    .bodyToMono(GoogleUserInfoResponse::class.java)
+                    .block()
+            } catch (e: WebClientResponseException) {
+                log.warn("Google fetch user info failed: ${e.responseBodyAsString}", e)
+                throw GoogleTokenExchangeFailedException()
+            } catch (e: Exception) {
+                log.warn("Google fetch user info failed", e)
+                throw GoogleTokenExchangeFailedException()
+            }
+
+        return userInfo ?: throw GoogleTokenExchangeFailedException()
+    }
 }

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/config/ProviderConfig.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/config/ProviderConfig.kt
@@ -2,5 +2,6 @@ package com.sclass.infrastructure.oauth.config
 
 data class ProviderConfig(
     val clientId: String = "",
+    val clientSecret: String = "",
     val appId: Long = 0,
 )

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/dto/GoogleTokenExchangeResponse.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/dto/GoogleTokenExchangeResponse.kt
@@ -1,0 +1,12 @@
+package com.sclass.infrastructure.oauth.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class GoogleTokenExchangeResponse(
+    @param:JsonProperty("access_token") val accessToken: String,
+    @param:JsonProperty("expires_in") val expiresIn: Long = 0,
+    @param:JsonProperty("refresh_token") val refreshToken: String? = null,
+    @param:JsonProperty("scope") val scope: String = "",
+    @param:JsonProperty("token_type") val tokenType: String = "Bearer",
+    @param:JsonProperty("id_token") val idToken: String? = null,
+)

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/dto/GoogleUserInfoResponse.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/dto/GoogleUserInfoResponse.kt
@@ -1,0 +1,11 @@
+package com.sclass.infrastructure.oauth.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class GoogleUserInfoResponse(
+    val id: String,
+    val email: String,
+    @param:JsonProperty("verified_email") val verifiedEmail: Boolean = false,
+    val name: String? = null,
+    val picture: String? = null,
+)

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/redis/exception/DistributedLockAcquisitionException.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/redis/exception/DistributedLockAcquisitionException.kt
@@ -1,5 +1,8 @@
 package com.sclass.infrastructure.redis.exception
 
+import com.sclass.common.exception.BusinessException
+import com.sclass.common.exception.GlobalErrorCode
+
 class DistributedLockAcquisitionException(
-    key: String,
-) : RuntimeException("분산 락 획득에 실패했습니다: key=$key")
+    val key: String,
+) : BusinessException(GlobalErrorCode.LOCK_CONFLICT)

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClientTest.kt
@@ -1,5 +1,6 @@
 package com.sclass.infrastructure.oauth.client
 
+import com.sclass.common.exception.GoogleOAuthProviderUnavailableException
 import com.sclass.common.exception.GoogleTokenExchangeFailedException
 import com.sclass.common.exception.GoogleTokenRefreshFailedException
 import com.sclass.infrastructure.oauth.config.OAuthProperties
@@ -113,13 +114,34 @@ class GoogleAuthorizationCodeClientTest {
         }
 
         @Test
-        fun `네트워크 예외 시 GoogleTokenExchangeFailedException`() {
+        fun `Google 5xx 응답 시 GoogleOAuthProviderUnavailableException`() {
+            mockPostFormData()
+            every {
+                responseSpec.bodyToMono(GoogleTokenExchangeResponse::class.java)
+            } returns
+                Mono.error(
+                    WebClientResponseException.create(
+                        HttpStatus.SERVICE_UNAVAILABLE.value(),
+                        "Service Unavailable",
+                        HttpHeaders.EMPTY,
+                        """{"error":"temporarily_unavailable"}""".toByteArray(),
+                        null,
+                    ),
+                )
+
+            assertThrows<GoogleOAuthProviderUnavailableException> {
+                client.exchangeCodeForTokens("code-1", "http://localhost:3000/callback")
+            }
+        }
+
+        @Test
+        fun `네트워크 예외 시 GoogleOAuthProviderUnavailableException`() {
             mockPostFormData()
             every {
                 responseSpec.bodyToMono(GoogleTokenExchangeResponse::class.java)
             } returns Mono.error(RuntimeException("network down"))
 
-            assertThrows<GoogleTokenExchangeFailedException> {
+            assertThrows<GoogleOAuthProviderUnavailableException> {
                 client.exchangeCodeForTokens("code-1", "http://localhost:3000/callback")
             }
         }
@@ -166,6 +188,39 @@ class GoogleAuthorizationCodeClientTest {
 
             assertThrows<GoogleTokenRefreshFailedException> {
                 client.refreshAccessToken("expired-or-revoked-refresh-token")
+            }
+        }
+
+        @Test
+        fun `Google 5xx 응답 시 GoogleOAuthProviderUnavailableException`() {
+            mockPostFormData()
+            every {
+                responseSpec.bodyToMono(GoogleTokenExchangeResponse::class.java)
+            } returns
+                Mono.error(
+                    WebClientResponseException.create(
+                        HttpStatus.BAD_GATEWAY.value(),
+                        "Bad Gateway",
+                        HttpHeaders.EMPTY,
+                        """{"error":"bad_gateway"}""".toByteArray(),
+                        null,
+                    ),
+                )
+
+            assertThrows<GoogleOAuthProviderUnavailableException> {
+                client.refreshAccessToken("refresh-token-xyz")
+            }
+        }
+
+        @Test
+        fun `네트워크 예외 시 GoogleOAuthProviderUnavailableException`() {
+            mockPostFormData()
+            every {
+                responseSpec.bodyToMono(GoogleTokenExchangeResponse::class.java)
+            } returns Mono.error(RuntimeException("network down"))
+
+            assertThrows<GoogleOAuthProviderUnavailableException> {
+                client.refreshAccessToken("refresh-token-xyz")
             }
         }
     }
@@ -215,13 +270,13 @@ class GoogleAuthorizationCodeClientTest {
         }
 
         @Test
-        fun `응답 바디가 없으면 GoogleTokenExchangeFailedException`() {
+        fun `응답 바디가 없으면 GoogleOAuthProviderUnavailableException`() {
             mockGet()
             every {
                 responseSpec.bodyToMono(GoogleUserInfoResponse::class.java)
             } returns Mono.empty()
 
-            assertThrows<GoogleTokenExchangeFailedException> {
+            assertThrows<GoogleOAuthProviderUnavailableException> {
                 client.fetchUserInfo("access-token-abc")
             }
         }

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClientTest.kt
@@ -1,0 +1,194 @@
+package com.sclass.infrastructure.oauth.client
+
+import com.sclass.common.exception.GoogleTokenExchangeFailedException
+import com.sclass.common.exception.GoogleTokenRefreshFailedException
+import com.sclass.infrastructure.oauth.config.OAuthProperties
+import com.sclass.infrastructure.oauth.config.ProviderConfig
+import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
+import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.client.reactive.ClientHttpRequest
+import org.springframework.web.reactive.function.BodyInserter
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Mono
+
+class GoogleAuthorizationCodeClientTest {
+    private lateinit var webClient: WebClient
+    private lateinit var requestBodyUriSpec: WebClient.RequestBodyUriSpec
+    private lateinit var requestBodySpec: WebClient.RequestBodySpec
+    private lateinit var requestHeadersSpec: WebClient.RequestHeadersSpec<*>
+    private lateinit var requestHeadersUriSpec: WebClient.RequestHeadersUriSpec<*>
+    private lateinit var responseSpec: WebClient.ResponseSpec
+    private lateinit var client: GoogleAuthorizationCodeClient
+
+    private val properties =
+        OAuthProperties().apply {
+            providers["google"] =
+                ProviderConfig(
+                    clientId = "test-client-id",
+                    clientSecret = "test-client-secret",
+                )
+        }
+
+    @BeforeEach
+    fun setUp() {
+        webClient = mockk()
+        requestBodyUriSpec = mockk()
+        requestBodySpec = mockk()
+        requestHeadersSpec = mockk()
+        requestHeadersUriSpec = mockk()
+        responseSpec = mockk()
+        client = GoogleAuthorizationCodeClient(properties, webClient)
+    }
+
+    private fun mockPostFormData() {
+        every { webClient.post() } returns requestBodyUriSpec
+        every { requestBodyUriSpec.uri(any<String>()) } returns requestBodySpec
+        every { requestBodySpec.contentType(any()) } returns requestBodySpec
+        every { requestBodySpec.body(any<BodyInserter<*, ClientHttpRequest>>()) } returns requestHeadersSpec
+        every { requestHeadersSpec.retrieve() } returns responseSpec
+    }
+
+    private fun mockGet() {
+        every { webClient.get() } returns requestHeadersUriSpec
+        every { requestHeadersUriSpec.uri(any<String>()) } returns requestHeadersSpec
+        every { requestHeadersSpec.header(any(), any()) } returns requestHeadersSpec
+        every { requestHeadersSpec.retrieve() } returns responseSpec
+    }
+
+    @Nested
+    inner class ExchangeCodeForTokens {
+        @Test
+        fun `성공 시 GoogleTokenExchangeResponse 반환`() {
+            mockPostFormData()
+            every {
+                responseSpec.bodyToMono(GoogleTokenExchangeResponse::class.java)
+            } returns
+                Mono.just(
+                    GoogleTokenExchangeResponse(
+                        accessToken = "access-token-abc",
+                        expiresIn = 3600,
+                        refreshToken = "refresh-token-xyz",
+                        scope = "calendar.events",
+                        tokenType = "Bearer",
+                    ),
+                )
+
+            val result = client.exchangeCodeForTokens("code-1", "http://localhost:3000/callback")
+
+            assertEquals("access-token-abc", result.accessToken)
+            assertEquals("refresh-token-xyz", result.refreshToken)
+        }
+
+        @Test
+        fun `Google 4xx 응답 시 GoogleTokenExchangeFailedException`() {
+            mockPostFormData()
+            every {
+                responseSpec.bodyToMono(GoogleTokenExchangeResponse::class.java)
+            } returns
+                Mono.error(
+                    WebClientResponseException.create(
+                        HttpStatus.BAD_REQUEST.value(),
+                        "Bad Request",
+                        HttpHeaders.EMPTY,
+                        """{"error":"invalid_grant"}""".toByteArray(),
+                        null,
+                    ),
+                )
+
+            assertThrows<GoogleTokenExchangeFailedException> {
+                client.exchangeCodeForTokens("code-bad", "http://localhost:3000/callback")
+            }
+        }
+
+        @Test
+        fun `네트워크 예외 시 GoogleTokenExchangeFailedException`() {
+            mockPostFormData()
+            every {
+                responseSpec.bodyToMono(GoogleTokenExchangeResponse::class.java)
+            } returns Mono.error(RuntimeException("network down"))
+
+            assertThrows<GoogleTokenExchangeFailedException> {
+                client.exchangeCodeForTokens("code-1", "http://localhost:3000/callback")
+            }
+        }
+    }
+
+    @Nested
+    inner class RefreshAccessToken {
+        @Test
+        fun `성공 시 새 access_token 반환`() {
+            mockPostFormData()
+            every {
+                responseSpec.bodyToMono(GoogleTokenExchangeResponse::class.java)
+            } returns
+                Mono.just(
+                    GoogleTokenExchangeResponse(
+                        accessToken = "new-access-token",
+                        expiresIn = 3600,
+                        refreshToken = null,
+                        scope = "calendar.events",
+                        tokenType = "Bearer",
+                    ),
+                )
+
+            val result = client.refreshAccessToken("refresh-token-xyz")
+
+            assertEquals("new-access-token", result)
+        }
+
+        @Test
+        fun `Google 4xx 응답 시 GoogleTokenRefreshFailedException`() {
+            mockPostFormData()
+            every {
+                responseSpec.bodyToMono(GoogleTokenExchangeResponse::class.java)
+            } returns
+                Mono.error(
+                    WebClientResponseException.create(
+                        HttpStatus.UNAUTHORIZED.value(),
+                        "Unauthorized",
+                        HttpHeaders.EMPTY,
+                        """{"error":"invalid_grant"}""".toByteArray(),
+                        null,
+                    ),
+                )
+
+            assertThrows<GoogleTokenRefreshFailedException> {
+                client.refreshAccessToken("expired-or-revoked-refresh-token")
+            }
+        }
+    }
+
+    @Nested
+    inner class FetchUserInfo {
+        @Test
+        fun `성공 시 GoogleUserInfoResponse 반환`() {
+            mockGet()
+            every {
+                responseSpec.bodyToMono(GoogleUserInfoResponse::class.java)
+            } returns
+                Mono.just(
+                    GoogleUserInfoResponse(
+                        id = "google-user-id",
+                        email = "teacher@gmail.com",
+                        verifiedEmail = true,
+                        name = "Teacher",
+                    ),
+                )
+
+            val result = client.fetchUserInfo("access-token-abc")
+
+            assertEquals("teacher@gmail.com", result.email)
+            assertEquals(true, result.verifiedEmail)
+        }
+    }
+}

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClientTest.kt
@@ -8,6 +8,7 @@ import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
 import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.client.reactive.ClientHttpRequest
 import org.springframework.web.reactive.function.BodyInserter
 import org.springframework.web.reactive.function.client.WebClient
@@ -189,6 +191,62 @@ class GoogleAuthorizationCodeClientTest {
 
             assertEquals("teacher@gmail.com", result.email)
             assertEquals(true, result.verifiedEmail)
+        }
+
+        @Test
+        fun `Google 4xx 응답 시 GoogleTokenExchangeFailedException`() {
+            mockGet()
+            every {
+                responseSpec.bodyToMono(GoogleUserInfoResponse::class.java)
+            } returns
+                Mono.error(
+                    WebClientResponseException.create(
+                        HttpStatus.UNAUTHORIZED.value(),
+                        "Unauthorized",
+                        HttpHeaders.EMPTY,
+                        """{"error":"invalid_token"}""".toByteArray(),
+                        null,
+                    ),
+                )
+
+            assertThrows<GoogleTokenExchangeFailedException> {
+                client.fetchUserInfo("invalid-access-token")
+            }
+        }
+
+        @Test
+        fun `응답 바디가 없으면 GoogleTokenExchangeFailedException`() {
+            mockGet()
+            every {
+                responseSpec.bodyToMono(GoogleUserInfoResponse::class.java)
+            } returns Mono.empty()
+
+            assertThrows<GoogleTokenExchangeFailedException> {
+                client.fetchUserInfo("access-token-abc")
+            }
+        }
+    }
+
+    @Nested
+    inner class RevokeRefreshToken {
+        @Test
+        fun `refresh token은 form body로 revoke 요청한다`() {
+            mockPostFormData()
+            every { responseSpec.toBodilessEntity() } returns Mono.empty()
+
+            client.revokeRefreshToken("refresh-token-with-special?chars&")
+
+            verify { requestBodyUriSpec.uri("https://oauth2.googleapis.com/revoke") }
+            verify { requestBodySpec.contentType(MediaType.APPLICATION_FORM_URLENCODED) }
+            verify { requestBodySpec.body(any<BodyInserter<*, ClientHttpRequest>>()) }
+        }
+
+        @Test
+        fun `revoke 실패는 전파하지 않는다`() {
+            mockPostFormData()
+            every { responseSpec.toBodilessEntity() } throws RuntimeException("network down")
+
+            client.revokeRefreshToken("refresh-token-xyz")
         }
     }
 }

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/redis/exception/DistributedLockAcquisitionExceptionTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/redis/exception/DistributedLockAcquisitionExceptionTest.kt
@@ -1,0 +1,19 @@
+package com.sclass.infrastructure.redis.exception
+
+import com.sclass.common.exception.BusinessException
+import com.sclass.common.exception.GlobalErrorCode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+
+class DistributedLockAcquisitionExceptionTest {
+    @Test
+    fun `분산 락 획득 실패는 409 business error로 처리된다`() {
+        val exception = DistributedLockAcquisitionException("lock:teacher-google-account:user-id")
+
+        assertInstanceOf(BusinessException::class.java, exception)
+        assertEquals(GlobalErrorCode.LOCK_CONFLICT, exception.errorCode)
+        assertEquals(409, exception.errorCode.httpStatus)
+        assertEquals("lock:teacher-google-account:user-id", exception.key)
+    }
+}

--- a/infra/env/ecs.tf
+++ b/infra/env/ecs.tf
@@ -325,6 +325,7 @@ locals {
       { name = "JWT_SECRET_KEY", valueFrom = aws_ssm_parameter.jwt_secret_key.arn },
       { name = "TOKEN_ENCRYPTION_KEY", valueFrom = aws_ssm_parameter.token_encryption_key.arn },
       { name = "GOOGLE_CLIENT_ID", valueFrom = aws_ssm_parameter.google_client_id.arn },
+      { name = "GOOGLE_CLIENT_SECRET", valueFrom = aws_ssm_parameter.google_client_secret.arn },
       { name = "KAKAO_CLIENT_ID", valueFrom = aws_ssm_parameter.kakao_client_id.arn },
       { name = "KAKAO_APP_ID", valueFrom = aws_ssm_parameter.kakao_app_id.arn },
       { name = "SMTP_USERNAME", valueFrom = aws_ssm_parameter.smtp_username.arn },
@@ -337,7 +338,7 @@ locals {
       { name = "NICE_PAY_CLIENT_KEY", valueFrom = aws_ssm_parameter.nicepay_client_key.arn },
       { name = "NICE_PAY_SECRET_KEY", valueFrom = aws_ssm_parameter.nicepay_secret_key.arn },
       { name = "REPORT_SERVICE_CALLBACK_SECRET", valueFrom = aws_ssm_parameter.report_service_callback_secret.arn },
-    ], local.is_prod ? [] : [
+      ], local.is_prod ? [] : [
       { name = "REDIS_PASSWORD", valueFrom = aws_ssm_parameter.redis_password.arn },
     ])
   }

--- a/infra/env/ssm.tf
+++ b/infra/env/ssm.tf
@@ -41,6 +41,14 @@ resource "aws_ssm_parameter" "google_client_id" {
   tags      = { Name = "${local.name_prefix}-ssm-google-client" }
 }
 
+resource "aws_ssm_parameter" "google_client_secret" {
+  name      = "/sclass/${var.environment}/GOOGLE_CLIENT_SECRET"
+  type      = "SecureString"
+  value     = var.google_client_secret
+  overwrite = true
+  tags      = { Name = "${local.name_prefix}-ssm-google-client-secret" }
+}
+
 resource "aws_ssm_parameter" "kakao_client_id" {
   name      = "/sclass/${var.environment}/KAKAO_CLIENT_ID"
   type      = "SecureString"

--- a/infra/env/variables.tf
+++ b/infra/env/variables.tf
@@ -124,6 +124,12 @@ variable "google_client_id" {
   default = ""
 }
 
+variable "google_client_secret" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
 variable "kakao_client_id" {
   type    = string
   default = ""

--- a/scripts/teacher-google-accounts-migration.sql
+++ b/scripts/teacher-google-accounts-migration.sql
@@ -1,0 +1,18 @@
+-- Teacher Google account connection schema.
+-- Run before deploying the OAuth Google connection feature because
+-- production services validate JPA mappings at startup.
+
+CREATE TABLE IF NOT EXISTS teacher_google_accounts (
+    id VARCHAR(26) NOT NULL,
+    user_id VARCHAR(26) NOT NULL,
+    google_email VARCHAR(320) NOT NULL,
+    encrypted_refresh_token TEXT NOT NULL,
+    scope VARCHAR(500) NOT NULL,
+    connected_at DATETIME(6) NOT NULL,
+    last_used_at DATETIME(6) NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_teacher_google_user_id (user_id),
+    KEY idx_teacher_google_email (google_email)
+);


### PR DESCRIPTION
Closes #291
Sub-issue of #287

## Summary
선생님이 자기 Google 계정을 s-class에 연결하는 흐름. 향후 Calendar API로 Meet 링크를 발급하기 위한 refresh token을 백엔드에 암호화 저장합니다.

| Method | Path | 용도 |
|---|---|---|
| `POST` | `/api/v1/teachers/me/google/connect` | code + redirectUri로 연동 + refresh token 저장 |
| `GET`  | `/api/v1/teachers/me/google` | 연동 상태 조회 |
| `DELETE` | `/api/v1/teachers/me/google` | Google revoke + DB 삭제 |

기존 \`GoogleOAuthClient\`(로그인용 ID Token Flow)는 그대로 유지. Calendar 연동용 Authorization Code Flow는 새 \`GoogleAuthorizationCodeClient\` 별도 클래스로 분리했습니다.

## 보안
- refresh token은 \`AesTokenEncryptor\` (AES-256-GCM)로 암호화하여 DB 저장
- DB 직접 접근으로는 토큰 평문 조회 불가
- disconnect 시 Google revoke endpoint 호출 + DB 삭제 (revoke 실패해도 DB는 삭제)

## 의존성 룰

Infrastructure → Domain 의존성 위반 없도록 OAuth 예외를 분리:

| 예외 | 던지는 위치 | 정의 위치 |
|---|---|---|
| \`GoogleTokenExchangeFailedException\` | Infrastructure | **Common** |
| \`GoogleTokenRefreshFailedException\` | Infrastructure | **Common** |
| \`GoogleRefreshTokenMissingException\` | UseCase | **Common** |
| \`TeacherGoogleAccountNotFoundException\` | Domain Adaptor | **Domain** |

Common에 \`OAuthTokenErrorCode\` enum이 이미 존재해서 그쪽에 새 코드(OAUTH_012~014) 이어 붙임.

## Clock 주입
- \`ConnectGoogleUseCase\`에 \`Clock\` 주입 (테스트에서 fixed Clock 사용)
- \`TeacherGoogleAccount.connectedAt\` 기본값 제거 — 호출자가 명시적으로 \`LocalDateTime.now(clock)\` 전달
- 테스트에서 \`fixedNow\`로 시각 검증 (\`assertEquals(fixedNow, response.connectedAt)\`)

## 도메인 패키지 구조

\`\`\`
SClass-Domain/.../domains/oauth/
├── domain/      TeacherGoogleAccount
├── repository/  TeacherGoogleAccountRepository
├── adaptor/     TeacherGoogleAccountAdaptor
└── exception/   OAuthErrorCode + TeacherGoogleAccountNotFoundException
\`\`\`

## 환경변수
- \`GOOGLE_CLIENT_SECRET\` 신규 추가
- \`application.yml.example\` (Supporters/Backoffice) 반영
- \`infra/env/variables.tf\` — variable 선언
- \`infra/env/ssm.tf\` — SSM SecureString 파라미터
- \`infra/env/ecs.tf\` — ECS task env 주입
- \`infra/env/envs/dev.secrets.tfvars\`, \`prod.secrets.tfvars\` — 실제 값 (gitignored)

IAM SSM read 정책은 \`/sclass/<env>/*\` 와일드카드라 새 파라미터 자동 적용.

## FE 작업 명세 (별도 전달)

FE는 다음 흐름 구현:
1. \`https://accounts.google.com/o/oauth2/v2/auth\` 로 redirect (계정 연결 버튼)
2. 필수 파라미터: \`scope=...calendar.events\`, \`access_type=offline\`, \`prompt=consent\`
3. 콜백에서 받은 code를 \`POST /api/v1/teachers/me/google/connect\`로 전달

## Test plan

- [x] \`ConnectGoogleUseCaseTest\` — 신규/재연결, refresh_token 누락, 토큰 암호화 검증
- [x] \`DisconnectGoogleUseCaseTest\` — 정상, 미연결, 복호화/revoke 실패해도 DB 삭제
- [x] \`GetGoogleConnectionStatusUseCaseTest\` — 연결 있음/없음
- [x] \`GoogleAuthorizationCodeClientTest\` — exchange/refresh/userinfo + 4xx 에러 변환
- [x] \`./gradlew build\` 통과
- [x] \`./gradlew ktlintCheck\` 통과
- [x] **로컬 dev 환경에서 실제 Google 계정으로 연동 동작 확인** (FE와 함께)

## 후속 작업 (별도 PR)

- #292 — Google Calendar API 클라이언트 (Meet 링크 발급)
- #293 — Lesson에 Meet 링크 통합

Production 배포 전 Todo:
- Google verification 신청 (sensitive scope이라 필요)
- 데모 영상 제작 후 unlisted YouTube 업로드
- GCP 프로젝트 분리 (현재 \"Vidio\" AI Studio 관리형 프로젝트 재사용 중)

🤖 Generated with [Claude Code](https://claude.com/claude-code)