### PR TITLE
feat: commission 목록 수업 진행 상태 반영

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/dto/CommissionPageResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/commission/dto/CommissionPageResponse.kt
@@ -24,7 +24,7 @@ data class CommissionListResponse(
     val commissionPolicyId: String,
     val outputFormat: OutputFormat,
     val activityType: ActivityType,
-    val status: CommissionStatus,
+    val status: CommissionListStatus,
     val guideSubject: String,
     val createdAt: LocalDateTime,
     val lesson: LessonSummary?,
@@ -61,10 +61,38 @@ data class CommissionListResponse(
                 commissionPolicyId = dto.commission.commissionPolicyId,
                 outputFormat = dto.commission.outputFormat,
                 activityType = dto.commission.activityType,
-                status = dto.commission.status,
+                status = CommissionListStatus.from(dto),
                 guideSubject = dto.commission.guideInfo.subject,
                 createdAt = dto.commission.createdAt,
                 lesson = dto.lesson?.let { LessonSummary.from(it) },
             )
+    }
+}
+
+enum class CommissionListStatus {
+    REQUESTED,
+    TOPIC_PROPOSED,
+    ACCEPTED,
+    IN_PROGRESS,
+    REJECTED,
+    CANCELLED,
+    COMPLETED,
+    ;
+
+    companion object {
+        fun from(dto: CommissionWithDetailDto): CommissionListStatus {
+            when (dto.lesson?.status) {
+                LessonStatus.IN_PROGRESS -> return IN_PROGRESS
+                LessonStatus.COMPLETED -> return COMPLETED
+                else -> Unit
+            }
+            return when (dto.commission.status) {
+                CommissionStatus.REQUESTED -> REQUESTED
+                CommissionStatus.TOPIC_PROPOSED -> TOPIC_PROPOSED
+                CommissionStatus.ACCEPTED -> ACCEPTED
+                CommissionStatus.REJECTED -> REJECTED
+                CommissionStatus.CANCELLED -> CANCELLED
+            }
+        }
     }
 }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/commission/usecase/GetCommissionListUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/commission/usecase/GetCommissionListUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.sclass.backoffice.commission.usecase
 
+import com.sclass.backoffice.commission.dto.CommissionListStatus
 import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
 import com.sclass.domain.domains.commission.domain.ActivityType
 import com.sclass.domain.domains.commission.domain.Commission
@@ -46,7 +47,7 @@ class GetCommissionListUseCaseTest {
             ),
     )
 
-    private fun createLesson() =
+    private fun createLesson(status: LessonStatus = LessonStatus.SCHEDULED) =
         Lesson(
             id = 1L,
             lessonType = LessonType.COMMISSION,
@@ -54,7 +55,7 @@ class GetCommissionListUseCaseTest {
             studentUserId = "student01",
             assignedTeacherUserId = "teacher01",
             name = "탐구 수업 1회차",
-            status = LessonStatus.SCHEDULED,
+            status = status,
         )
 
     private fun createDto(
@@ -135,7 +136,7 @@ class GetCommissionListUseCaseTest {
 
         assertAll(
             { assertEquals(1, result.totalElements) },
-            { assertEquals(CommissionStatus.ACCEPTED, result.content[0].status) },
+            { assertEquals(CommissionListStatus.ACCEPTED, result.content[0].status) },
         )
     }
 
@@ -154,6 +155,30 @@ class GetCommissionListUseCaseTest {
             { assertEquals("탐구 수업 1회차", result.content[0].lesson!!.name) },
             { assertEquals(LessonStatus.SCHEDULED, result.content[0].lesson!!.status) },
         )
+    }
+
+    @Test
+    fun `lesson이 진행 상태이면 목록 status를 IN_PROGRESS로 반환한다`() {
+        val lesson = createLesson(status = LessonStatus.IN_PROGRESS)
+        val dto = createDto(status = CommissionStatus.ACCEPTED, lesson = lesson)
+        val pageable = PageRequest.of(0, 20)
+        every { commissionAdaptor.searchCommissions(null, null, null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, null, null, pageable)
+
+        assertEquals(CommissionListStatus.IN_PROGRESS, result.content[0].status)
+    }
+
+    @Test
+    fun `lesson이 완료 상태이면 목록 status를 COMPLETED로 반환한다`() {
+        val lesson = createLesson(status = LessonStatus.COMPLETED)
+        val dto = createDto(status = CommissionStatus.ACCEPTED, lesson = lesson)
+        val pageable = PageRequest.of(0, 20)
+        every { commissionAdaptor.searchCommissions(null, null, null, pageable) } returns PageImpl(listOf(dto), pageable, 1)
+
+        val result = useCase.execute(null, null, null, pageable)
+
+        assertEquals(CommissionListStatus.COMPLETED, result.content[0].status)
     }
 
     @Test

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/dto/CommissionListResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/dto/CommissionListResponse.kt
@@ -4,15 +4,26 @@ import com.sclass.domain.domains.commission.domain.ActivityType
 import com.sclass.domain.domains.commission.domain.Commission
 import com.sclass.domain.domains.commission.domain.CommissionStatus
 import com.sclass.domain.domains.commission.domain.OutputFormat
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
 import java.time.LocalDateTime
 
 data class CommissionListResponse(
     val commissions: List<CommissionSummary>,
 ) {
     companion object {
-        fun from(commissions: List<Commission>): CommissionListResponse =
+        fun from(
+            commissions: List<Commission>,
+            lessonsById: Map<Long, Lesson> = emptyMap(),
+        ): CommissionListResponse =
             CommissionListResponse(
-                commissions = commissions.map { CommissionSummary.from(it) },
+                commissions =
+                    commissions.map { commission ->
+                        CommissionSummary.from(
+                            commission = commission,
+                            lesson = commission.acceptedLessonId?.let { lessonsById[it] },
+                        )
+                    },
             )
     }
 }
@@ -21,19 +32,53 @@ data class CommissionSummary(
     val id: Long,
     val outputFormat: OutputFormat,
     val activityType: ActivityType,
-    val status: CommissionStatus,
+    val status: CommissionSummaryStatus,
     val subject: String,
     val createdAt: LocalDateTime,
 ) {
     companion object {
-        fun from(commission: Commission): CommissionSummary =
+        fun from(
+            commission: Commission,
+            lesson: Lesson? = null,
+        ): CommissionSummary =
             CommissionSummary(
                 id = commission.id,
                 outputFormat = commission.outputFormat,
                 activityType = commission.activityType,
-                status = commission.status,
+                status = CommissionSummaryStatus.from(commission, lesson),
                 subject = commission.guideInfo.subject,
                 createdAt = commission.createdAt,
             )
+    }
+}
+
+enum class CommissionSummaryStatus {
+    REQUESTED,
+    TOPIC_PROPOSED,
+    ACCEPTED,
+    IN_PROGRESS,
+    REJECTED,
+    CANCELLED,
+    COMPLETED,
+    ;
+
+    companion object {
+        fun from(
+            commission: Commission,
+            lesson: Lesson?,
+        ): CommissionSummaryStatus {
+            when (lesson?.status) {
+                LessonStatus.IN_PROGRESS -> return IN_PROGRESS
+                LessonStatus.COMPLETED -> return COMPLETED
+                else -> Unit
+            }
+            return when (commission.status) {
+                CommissionStatus.REQUESTED -> REQUESTED
+                CommissionStatus.TOPIC_PROPOSED -> TOPIC_PROPOSED
+                CommissionStatus.ACCEPTED -> ACCEPTED
+                CommissionStatus.REJECTED -> REJECTED
+                CommissionStatus.CANCELLED -> CANCELLED
+            }
+        }
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/GetCommissionListUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/commission/usecase/GetCommissionListUseCase.kt
@@ -3,7 +3,10 @@ package com.sclass.supporters.commission.usecase
 import com.sclass.common.annotation.UseCase
 import com.sclass.common.exception.BusinessException
 import com.sclass.domain.domains.commission.adaptor.CommissionAdaptor
+import com.sclass.domain.domains.commission.domain.Commission
 import com.sclass.domain.domains.commission.exception.CommissionErrorCode
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.supporters.commission.dto.CommissionListResponse
 import org.springframework.transaction.annotation.Transactional
@@ -11,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional
 @UseCase
 class GetCommissionListUseCase(
     private val commissionAdaptor: CommissionAdaptor,
+    private val lessonAdaptor: LessonAdaptor,
 ) {
     @Transactional(readOnly = true)
     fun execute(
@@ -23,6 +27,13 @@ class GetCommissionListUseCase(
                 Role.TEACHER -> commissionAdaptor.findByTeacherUserId(userId)
                 else -> throw BusinessException(CommissionErrorCode.UNAUTHORIZED_ACCESS)
             }
-        return CommissionListResponse.from(commissions)
+        val lessonsById = findAcceptedLessonsById(commissions)
+        return CommissionListResponse.from(commissions, lessonsById)
+    }
+
+    private fun findAcceptedLessonsById(commissions: List<Commission>): Map<Long, Lesson> {
+        val lessonIds = commissions.mapNotNull { it.acceptedLessonId }.distinct()
+        if (lessonIds.isEmpty()) return emptyMap()
+        return lessonAdaptor.findAllByIds(lessonIds).associateBy { it.id }
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonInquiryPlanUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonInquiryPlanUseCase.kt
@@ -3,25 +3,36 @@ package com.sclass.supporters.lesson.usecase
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.inquiryplan.domain.InquiryPlanSourceType
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonInvalidStatusTransitionException
 import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
 import com.sclass.supporters.inquiry.dto.CreateInquiryPlanRequest
 import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
 import com.sclass.supporters.inquiry.usecase.CreateInquiryPlanUseCase
 import com.sclass.supporters.lesson.dto.CreateLessonInquiryPlanRequest
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
 
 @UseCase
 class CreateLessonInquiryPlanUseCase(
     private val lessonAdaptor: LessonAdaptor,
     private val createInquiryPlanUseCase: CreateInquiryPlanUseCase,
+    private val txTemplate: TransactionTemplate,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
     fun execute(
         userId: String,
         lessonId: Long,
         request: CreateLessonInquiryPlanRequest,
     ): InquiryPlanResponse {
-        val lesson = lessonAdaptor.findById(lessonId)
-        if (!lesson.isTeacher(userId)) {
-            throw LessonUnauthorizedAccessException()
+        txTemplate.execute {
+            val lesson = lessonAdaptor.findById(lessonId)
+            if (!lesson.isTeacher(userId)) {
+                throw LessonUnauthorizedAccessException()
+            }
+            startCommissionLessonIfNeeded(lesson, userId)
         }
         return createInquiryPlanUseCase.execute(
             userId,
@@ -32,5 +43,20 @@ class CreateLessonInquiryPlanUseCase(
                 sourceRefId = lessonId,
             ),
         )
+    }
+
+    private fun startCommissionLessonIfNeeded(
+        lesson: Lesson,
+        userId: String,
+    ) {
+        if (lesson.lessonType != LessonType.COMMISSION) return
+        when (lesson.status) {
+            LessonStatus.SCHEDULED -> {
+                lesson.start(actualTeacherUserId = userId, clock = clock)
+                lessonAdaptor.save(lesson)
+            }
+            LessonStatus.IN_PROGRESS -> Unit
+            LessonStatus.COMPLETED, LessonStatus.CANCELLED -> throw LessonInvalidStatusTransitionException()
+        }
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/GetCommissionListUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/commission/usecase/GetCommissionListUseCaseTest.kt
@@ -6,28 +6,39 @@ import com.sclass.domain.domains.commission.domain.Commission
 import com.sclass.domain.domains.commission.domain.CommissionStatus
 import com.sclass.domain.domains.commission.domain.GuideInfo
 import com.sclass.domain.domains.commission.domain.OutputFormat
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
 import com.sclass.domain.domains.user.domain.Role
+import com.sclass.supporters.commission.dto.CommissionSummaryStatus
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
 
 class GetCommissionListUseCaseTest {
     private lateinit var commissionAdaptor: CommissionAdaptor
+    private lateinit var lessonAdaptor: LessonAdaptor
     private lateinit var useCase: GetCommissionListUseCase
 
     @BeforeEach
     fun setUp() {
         commissionAdaptor = mockk()
-        useCase = GetCommissionListUseCase(commissionAdaptor)
+        lessonAdaptor = mockk()
+        useCase = GetCommissionListUseCase(commissionAdaptor, lessonAdaptor)
     }
 
     private fun createCommission(
         id: Long,
         studentUserId: String = "student-id",
         teacherUserId: String = "teacher-id",
+        status: CommissionStatus = CommissionStatus.REQUESTED,
+        acceptedLessonId: Long? = null,
     ) = Commission(
         id = id,
         studentUserId = studentUserId,
@@ -35,7 +46,7 @@ class GetCommissionListUseCaseTest {
         commissionPolicyId = "policy-id-0000000000000001",
         outputFormat = OutputFormat.REPORT,
         activityType = ActivityType.CAREER_EXPLORATION,
-        status = CommissionStatus.REQUESTED,
+        status = status,
         guideInfo =
             GuideInfo(
                 subject = "미시경제학",
@@ -43,6 +54,22 @@ class GetCommissionListUseCaseTest {
                 gradingCriteria = "평가기준",
                 teacherEmphasis = "강조사항",
             ),
+        acceptedLessonId = acceptedLessonId,
+    )
+
+    private fun createLesson(
+        id: Long,
+        status: LessonStatus = LessonStatus.SCHEDULED,
+        completedAt: LocalDateTime? = null,
+    ) = Lesson(
+        id = id,
+        lessonType = LessonType.COMMISSION,
+        sourceCommissionId = 1L,
+        studentUserId = "student-id",
+        assignedTeacherUserId = "teacher-id",
+        name = "의뢰 수업",
+        status = status,
+        completedAt = completedAt,
     )
 
     @Test
@@ -54,6 +81,7 @@ class GetCommissionListUseCaseTest {
 
         assertEquals(2, result.commissions.size)
         verify { commissionAdaptor.findByStudentUserId("user-id") }
+        verify(exactly = 0) { lessonAdaptor.findAllByIds(any()) }
     }
 
     @Test
@@ -65,6 +93,7 @@ class GetCommissionListUseCaseTest {
 
         assertEquals(1, result.commissions.size)
         verify { commissionAdaptor.findByTeacherUserId("user-id") }
+        verify(exactly = 0) { lessonAdaptor.findAllByIds(any()) }
     }
 
     @Test
@@ -74,5 +103,57 @@ class GetCommissionListUseCaseTest {
         val result = useCase.execute("user-id", Role.STUDENT)
 
         assertEquals(0, result.commissions.size)
+        verify(exactly = 0) { lessonAdaptor.findAllByIds(any()) }
+    }
+
+    @Test
+    fun `연결된 lesson이 완료 상태이면 목록 status를 COMPLETED로 반환한다`() {
+        val completedAt = LocalDateTime.of(2026, 4, 26, 10, 30)
+        val commissions =
+            listOf(
+                createCommission(id = 1L, status = CommissionStatus.ACCEPTED, acceptedLessonId = 100L),
+                createCommission(id = 2L, status = CommissionStatus.REQUESTED),
+            )
+        val lesson = createLesson(id = 100L, status = LessonStatus.COMPLETED, completedAt = completedAt)
+        every { commissionAdaptor.findByStudentUserId("user-id") } returns commissions
+        every { lessonAdaptor.findAllByIds(listOf(100L)) } returns listOf(lesson)
+
+        val result = useCase.execute("user-id", Role.STUDENT)
+
+        assertAll(
+            { assertEquals(CommissionSummaryStatus.COMPLETED, result.commissions[0].status) },
+            { assertEquals(CommissionSummaryStatus.REQUESTED, result.commissions[1].status) },
+        )
+        verify { lessonAdaptor.findAllByIds(listOf(100L)) }
+    }
+
+    @Test
+    fun `연결된 lesson이 완료 전이면 기존 commission status를 반환한다`() {
+        val commissions =
+            listOf(
+                createCommission(id = 1L, status = CommissionStatus.ACCEPTED, acceptedLessonId = 100L),
+            )
+        val lesson = createLesson(id = 100L, status = LessonStatus.SCHEDULED)
+        every { commissionAdaptor.findByStudentUserId("user-id") } returns commissions
+        every { lessonAdaptor.findAllByIds(listOf(100L)) } returns listOf(lesson)
+
+        val result = useCase.execute("user-id", Role.STUDENT)
+
+        assertEquals(CommissionSummaryStatus.ACCEPTED, result.commissions[0].status)
+    }
+
+    @Test
+    fun `연결된 lesson이 진행 상태이면 목록 status를 IN_PROGRESS로 반환한다`() {
+        val commissions =
+            listOf(
+                createCommission(id = 1L, status = CommissionStatus.ACCEPTED, acceptedLessonId = 100L),
+            )
+        val lesson = createLesson(id = 100L, status = LessonStatus.IN_PROGRESS)
+        every { commissionAdaptor.findByStudentUserId("user-id") } returns commissions
+        every { lessonAdaptor.findAllByIds(listOf(100L)) } returns listOf(lesson)
+
+        val result = useCase.execute("user-id", Role.STUDENT)
+
+        assertEquals(CommissionSummaryStatus.IN_PROGRESS, result.commissions[0].status)
     }
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonInquiryPlanUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonInquiryPlanUseCaseTest.kt
@@ -3,7 +3,9 @@ package com.sclass.supporters.lesson.usecase
 import com.sclass.domain.domains.inquiryplan.domain.InquiryPlanSourceType
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
 import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonInvalidStatusTransitionException
 import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
 import com.sclass.supporters.inquiry.dto.CreateInquiryPlanRequest
 import com.sclass.supporters.inquiry.dto.InquiryPlanResponse
@@ -18,32 +20,50 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 class CreateLessonInquiryPlanUseCaseTest {
     private lateinit var lessonAdaptor: LessonAdaptor
     private lateinit var createInquiryPlanUseCase: CreateInquiryPlanUseCase
+    private lateinit var txTemplate: TransactionTemplate
     private lateinit var useCase: CreateLessonInquiryPlanUseCase
 
     private val teacherUserId = "teacher-user-id-00000000001"
     private val studentUserId = "student-user-id-0000000001"
+    private val zoneId = ZoneId.of("Asia/Seoul")
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 10, 30)
+    private val clock = Clock.fixed(fixedNow.atZone(zoneId).toInstant(), zoneId)
 
     @BeforeEach
     fun setUp() {
         lessonAdaptor = mockk()
         createInquiryPlanUseCase = mockk()
-        useCase = CreateLessonInquiryPlanUseCase(lessonAdaptor, createInquiryPlanUseCase)
+        txTemplate = mockk()
+        every { txTemplate.execute(any<TransactionCallback<Any?>>()) } answers {
+            firstArg<TransactionCallback<Any?>>().doInTransaction(mockk())
+        }
+        useCase = CreateLessonInquiryPlanUseCase(lessonAdaptor, createInquiryPlanUseCase, txTemplate, clock)
     }
 
-    private fun lesson(id: Long = 1L) =
-        Lesson(
-            id = id,
-            lessonType = LessonType.COURSE,
-            enrollmentId = 1L,
-            studentUserId = studentUserId,
-            assignedTeacherUserId = teacherUserId,
-            lessonNumber = 1,
-            name = "수학 1회차",
-        )
+    private fun lesson(
+        id: Long = 1L,
+        lessonType: LessonType = LessonType.COURSE,
+        status: LessonStatus = LessonStatus.SCHEDULED,
+    ) = Lesson(
+        id = id,
+        lessonType = lessonType,
+        enrollmentId = 1L,
+        sourceCommissionId = if (lessonType == LessonType.COMMISSION) 1L else null,
+        studentUserId = studentUserId,
+        assignedTeacherUserId = teacherUserId,
+        lessonNumber = 1,
+        name = "수학 1회차",
+        status = status,
+    )
 
     @Test
     fun `선생님이 담당 레슨의 탐구 계획을 생성한다`() {
@@ -62,6 +82,64 @@ class CreateLessonInquiryPlanUseCaseTest {
             { assertEquals("탐구 내용", requestSlot.captured.paragraph) },
         )
         verify(exactly = 1) { createInquiryPlanUseCase.execute(any(), any()) }
+        verify(exactly = 0) { lessonAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `commission lesson에서 계획을 생성하면 lesson을 진행 상태로 전환한다`() {
+        val lesson = lesson(lessonType = LessonType.COMMISSION)
+        val mockResponse = mockk<InquiryPlanResponse>()
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.save(lesson) } returns lesson
+        every { createInquiryPlanUseCase.execute(any(), any()) } returns mockResponse
+
+        useCase.execute(teacherUserId, 1L, CreateLessonInquiryPlanRequest(paragraph = "탐구 내용"))
+
+        assertAll(
+            { assertEquals(LessonStatus.IN_PROGRESS, lesson.status) },
+            { assertEquals(teacherUserId, lesson.actualTeacherUserId) },
+            { assertEquals(fixedNow, lesson.startedAt) },
+        )
+        verify(exactly = 1) { lessonAdaptor.save(lesson) }
+    }
+
+    @Test
+    fun `이미 진행 중인 commission lesson은 다시 시작하지 않고 계획을 생성한다`() {
+        val lesson = lesson(lessonType = LessonType.COMMISSION, status = LessonStatus.IN_PROGRESS)
+        val mockResponse = mockk<InquiryPlanResponse>()
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every { createInquiryPlanUseCase.execute(any(), any()) } returns mockResponse
+
+        useCase.execute(teacherUserId, 1L, CreateLessonInquiryPlanRequest(paragraph = "탐구 내용"))
+
+        verify(exactly = 0) { lessonAdaptor.save(any()) }
+        verify(exactly = 1) { createInquiryPlanUseCase.execute(any(), any()) }
+    }
+
+    @Test
+    fun `완료된 commission lesson은 계획을 생성할 수 없다`() {
+        every { lessonAdaptor.findById(1L) } returns
+            lesson(lessonType = LessonType.COMMISSION, status = LessonStatus.COMPLETED)
+
+        assertThrows<LessonInvalidStatusTransitionException> {
+            useCase.execute(teacherUserId, 1L, CreateLessonInquiryPlanRequest(paragraph = "탐구 내용"))
+        }
+        verify(exactly = 0) { lessonAdaptor.save(any()) }
+        verify(exactly = 0) { createInquiryPlanUseCase.execute(any(), any()) }
+    }
+
+    @Test
+    fun `취소된 commission lesson은 계획을 생성할 수 없다`() {
+        every { lessonAdaptor.findById(1L) } returns
+            lesson(lessonType = LessonType.COMMISSION, status = LessonStatus.CANCELLED)
+
+        assertThrows<LessonInvalidStatusTransitionException> {
+            useCase.execute(teacherUserId, 1L, CreateLessonInquiryPlanRequest(paragraph = "탐구 내용"))
+        }
+        verify(exactly = 0) { lessonAdaptor.save(any()) }
+        verify(exactly = 0) { createInquiryPlanUseCase.execute(any(), any()) }
     }
 
     @Test

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/adaptor/LessonAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/adaptor/LessonAdaptor.kt
@@ -19,6 +19,8 @@ class LessonAdaptor(
 
     fun findByIdOrNull(id: Long): Lesson? = lessonRepository.findByIdOrNull(id)
 
+    fun findAllByIds(ids: Collection<Long>): List<Lesson> = lessonRepository.findAllById(ids)
+
     fun findAllByEnrollment(enrollmentId: Long): List<Lesson> =
         lessonRepository.findAllByEnrollmentIdOrderByLessonNumberAscCreatedAtAsc(enrollmentId)
 


### PR DESCRIPTION
## 요약
- commission 목록 응답의 `status`에 연결된 commission lesson 진행 상태를 반영했습니다.
- supporters/backoffice commission 목록 모두 `IN_PROGRESS`, `COMPLETED`가 내려올 수 있도록 맞췄습니다.
- commission lesson에서 계획표를 생성하면 `SCHEDULED` lesson을 자동으로 `IN_PROGRESS`로 전환합니다.

## FE 변경사항
- `GET /api/v1/commissions` 목록의 각 item `status` 값이 확장됩니다.
- 기존 값: `REQUESTED`, `TOPIC_PROPOSED`, `ACCEPTED`, `REJECTED`, `CANCELLED`
- 추가 가능 값: `IN_PROGRESS`, `COMPLETED`
- 상태 매핑:
  - commission `ACCEPTED` + lesson `SCHEDULED` -> `ACCEPTED`
  - commission `ACCEPTED` + lesson `IN_PROGRESS` -> `IN_PROGRESS`
  - commission `ACCEPTED` + lesson `COMPLETED` -> `COMPLETED`
- 백오피스 목록도 동일하게 top-level `status`가 위 규칙으로 내려옵니다.

## 동작 변경
- commission lesson에서 `POST /api/v1/lessons/{lessonId}/inquiry-plans` 호출 시 lesson이 `SCHEDULED`면 `IN_PROGRESS`로 전환됩니다.
- commission lesson이 이미 `IN_PROGRESS`면 계획표 생성만 진행합니다.
- commission lesson이 `COMPLETED` 또는 `CANCELLED`면 계획표 생성을 막습니다.
- course lesson은 계획표 생성 시 자동 start 처리하지 않고 기존 동작을 유지합니다.

## 테스트
- `GetCommissionListUseCaseTest` (supporters)
- `CreateLessonInquiryPlanUseCaseTest` (supporters)
- `GetCommissionListUseCaseTest` (backoffice)
- pre-commit build
