### PR TITLE
feat: Google OAuth state 검증 추가

### DIFF
--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/controller/GoogleConnectionController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/controller/GoogleConnectionController.kt
@@ -7,9 +7,11 @@ import com.sclass.common.exception.ForbiddenException
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
 import com.sclass.supporters.oauth.dto.GoogleConnectionStatusResponse
+import com.sclass.supporters.oauth.dto.GoogleOAuthStateResponse
 import com.sclass.supporters.oauth.usecase.ConnectGoogleUseCase
 import com.sclass.supporters.oauth.usecase.DisconnectGoogleUseCase
 import com.sclass.supporters.oauth.usecase.GetGoogleConnectionStatusUseCase
+import com.sclass.supporters.oauth.usecase.IssueGoogleOAuthStateUseCase
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -24,6 +26,7 @@ class GoogleConnectionController(
     private val connectGoogleUseCase: ConnectGoogleUseCase,
     private val disconnectGoogleUseCase: DisconnectGoogleUseCase,
     private val getStatusUseCase: GetGoogleConnectionStatusUseCase,
+    private val issueStateUseCase: IssueGoogleOAuthStateUseCase,
 ) {
     @PostMapping("/connect")
     fun connect(
@@ -53,6 +56,15 @@ class GoogleConnectionController(
         requireTeacherRole(role)
         return ApiResponse.success(getStatusUseCase.execute(userId))
     }
+
+    @GetMapping("/state")
+    fun issue(
+        @CurrentUserId userId: String,
+        @CurrentUserRole role: String,
+    ): ApiResponse<GoogleOAuthStateResponse> =
+        ApiResponse.success(
+            issueStateUseCase.execute(userId, requireTeacherRole(role)),
+        )
 
     private fun requireTeacherRole(role: String): Role {
         val currentRole =

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/controller/GoogleConnectionController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/controller/GoogleConnectionController.kt
@@ -7,12 +7,12 @@ import com.sclass.common.exception.ForbiddenException
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
 import com.sclass.supporters.oauth.dto.GoogleConnectionStatusResponse
-import com.sclass.supporters.oauth.dto.GoogleOAuthStateResponse
 import com.sclass.supporters.oauth.usecase.ConnectGoogleUseCase
 import com.sclass.supporters.oauth.usecase.DisconnectGoogleUseCase
 import com.sclass.supporters.oauth.usecase.GetGoogleConnectionStatusUseCase
 import com.sclass.supporters.oauth.usecase.IssueGoogleOAuthStateUseCase
 import jakarta.validation.Valid
+import org.springframework.http.CacheControl
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -57,14 +57,18 @@ class GoogleConnectionController(
         return ApiResponse.success(getStatusUseCase.execute(userId))
     }
 
-    @GetMapping("/state")
-    fun issue(
+    @PostMapping("/state")
+    fun issueState(
         @CurrentUserId userId: String,
         @CurrentUserRole role: String,
-    ): ApiResponse<GoogleOAuthStateResponse> =
-        ApiResponse.success(
-            issueStateUseCase.execute(userId, requireTeacherRole(role)),
-        )
+    ) = ApiResponse.success(
+        data =
+            issueStateUseCase.execute(
+                userId,
+                requireTeacherRole(role),
+            ),
+        cacheControl = CacheControl.noStore(),
+    )
 
     private fun requireTeacherRole(role: String): Role {
         val currentRole =

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/dto/ConnectGoogleRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/dto/ConnectGoogleRequest.kt
@@ -5,4 +5,5 @@ import jakarta.validation.constraints.NotBlank
 data class ConnectGoogleRequest(
     @field:NotBlank val code: String,
     @field:NotBlank val redirectUri: String,
+    @field:NotBlank val state: String,
 )

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/dto/GoogleOAuthStateResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/dto/GoogleOAuthStateResponse.kt
@@ -1,0 +1,6 @@
+package com.sclass.supporters.oauth.dto
+
+data class GoogleOAuthStateResponse(
+    val state: String,
+    val expiresInSeconds: Long,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCase.kt
@@ -4,10 +4,12 @@ import com.sclass.common.annotation.UseCase
 import com.sclass.common.exception.ForbiddenException
 import com.sclass.common.exception.GoogleCalendarScopeMissingException
 import com.sclass.common.exception.GoogleIdentityScopeMissingException
+import com.sclass.common.exception.GoogleOAuthStateInvalidException
 import com.sclass.common.exception.GoogleRefreshTokenMissingException
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.user.domain.Role
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
 import com.sclass.infrastructure.redis.DistributedLock
 import com.sclass.infrastructure.redis.LockKey
 import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
@@ -18,6 +20,7 @@ class ConnectGoogleUseCase(
     private val googleClient: GoogleAuthorizationCodeClient,
     private val connectGoogleAccountLockedUseCase: ConnectGoogleAccountLockedUseCase,
     private val encryptor: AesTokenEncryptor,
+    private val stateStore: GoogleOAuthStateStore,
 ) {
     @DistributedLock(prefix = "teacher-google-account", waitTime = 30)
     fun execute(
@@ -26,6 +29,7 @@ class ConnectGoogleUseCase(
         request: ConnectGoogleRequest,
     ): GoogleConnectionStatusResponse {
         if (role != Role.TEACHER) throw ForbiddenException()
+        if (!stateStore.consume(userId, request.state)) throw GoogleOAuthStateInvalidException()
 
         val tokens = googleClient.exchangeCodeForTokens(request.code, request.redirectUri)
         val refreshToken = tokens.refreshToken ?: throw GoogleRefreshTokenMissingException()

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/IssueGoogleOAuthStateUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/oauth/usecase/IssueGoogleOAuthStateUseCase.kt
@@ -1,0 +1,29 @@
+package com.sclass.supporters.oauth.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.ForbiddenException
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
+import com.sclass.supporters.oauth.dto.GoogleOAuthStateResponse
+import java.time.Duration
+
+@UseCase
+class IssueGoogleOAuthStateUseCase(
+    private val stateStore: GoogleOAuthStateStore,
+) {
+    fun execute(
+        userId: String,
+        role: Role,
+    ): GoogleOAuthStateResponse {
+        if (role != Role.TEACHER) throw ForbiddenException()
+
+        return GoogleOAuthStateResponse(
+            state = stateStore.issue(userId, STATE_TTL),
+            expiresInSeconds = STATE_TTL.seconds,
+        )
+    }
+
+    companion object {
+        private val STATE_TTL = Duration.ofMinutes(5)
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/controller/GoogleConnectionControllerTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/controller/GoogleConnectionControllerTest.kt
@@ -1,0 +1,72 @@
+package com.sclass.supporters.oauth.controller
+
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.supporters.oauth.dto.GoogleOAuthStateResponse
+import com.sclass.supporters.oauth.usecase.ConnectGoogleUseCase
+import com.sclass.supporters.oauth.usecase.DisconnectGoogleUseCase
+import com.sclass.supporters.oauth.usecase.GetGoogleConnectionStatusUseCase
+import com.sclass.supporters.oauth.usecase.IssueGoogleOAuthStateUseCase
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+
+class GoogleConnectionControllerTest {
+    private lateinit var issueStateUseCase: IssueGoogleOAuthStateUseCase
+    private lateinit var controller: GoogleConnectionController
+
+    @BeforeEach
+    fun setUp() {
+        issueStateUseCase = mockk()
+        controller =
+            GoogleConnectionController(
+                connectGoogleUseCase = mockk<ConnectGoogleUseCase>(),
+                disconnectGoogleUseCase = mockk<DisconnectGoogleUseCase>(),
+                getStatusUseCase = mockk<GetGoogleConnectionStatusUseCase>(),
+                issueStateUseCase = issueStateUseCase,
+            )
+    }
+
+    @Test
+    fun `state 발급 endpoint는 POST로 노출된다`() {
+        val method =
+            GoogleConnectionController::class.java.getDeclaredMethod(
+                "issueState",
+                String::class.java,
+                String::class.java,
+            )
+        val postMapping = method.getAnnotation(PostMapping::class.java)
+
+        assertAll(
+            { assertNotNull(postMapping) },
+            { assertEquals("/state", postMapping.value.single()) },
+            { assertNull(method.getAnnotation(GetMapping::class.java)) },
+        )
+    }
+
+    @Test
+    fun `state 발급 응답은 캐시를 금지한다`() {
+        every { issueStateUseCase.execute("teacher-user-id", Role.TEACHER) } returns
+            GoogleOAuthStateResponse(
+                state = "state-abc",
+                expiresInSeconds = 300,
+            )
+
+        val response = controller.issueState("teacher-user-id", Role.TEACHER.name)
+
+        assertAll(
+            { assertEquals(HttpStatus.OK, response.statusCode) },
+            { assertEquals("no-store", response.headers.cacheControl) },
+            { assertEquals(true, response.body?.success) },
+            { assertEquals("state-abc", response.body?.data?.state) },
+            { assertEquals(300L, response.body?.data?.expiresInSeconds) },
+        )
+    }
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/ConnectGoogleUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.sclass.supporters.oauth.usecase
 import com.sclass.common.exception.ForbiddenException
 import com.sclass.common.exception.GoogleCalendarScopeMissingException
 import com.sclass.common.exception.GoogleIdentityScopeMissingException
+import com.sclass.common.exception.GoogleOAuthStateInvalidException
 import com.sclass.common.exception.GoogleRefreshTokenMissingException
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.oauth.domain.TeacherGoogleAccount
@@ -10,6 +11,7 @@ import com.sclass.domain.domains.user.domain.Role
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
 import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
 import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
+import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
 import com.sclass.infrastructure.redis.DistributedLock
 import com.sclass.infrastructure.redis.LockKey
 import com.sclass.supporters.oauth.dto.ConnectGoogleRequest
@@ -29,10 +31,12 @@ class ConnectGoogleUseCaseTest {
     private lateinit var googleClient: GoogleAuthorizationCodeClient
     private lateinit var connectGoogleAccountLockedUseCase: ConnectGoogleAccountLockedUseCase
     private lateinit var encryptor: AesTokenEncryptor
+    private lateinit var stateStore: GoogleOAuthStateStore
     private lateinit var useCase: ConnectGoogleUseCase
 
     private val userId = "user-id-00000000000000001"
     private val redirectUri = "http://localhost:3000/oauth/google/callback"
+    private val oauthState = "google-oauth-state"
     private val grantedScope =
         listOf(
             "openid",
@@ -47,9 +51,11 @@ class ConnectGoogleUseCaseTest {
         googleClient = mockk()
         connectGoogleAccountLockedUseCase = mockk()
         encryptor = mockk()
-        useCase = ConnectGoogleUseCase(googleClient, connectGoogleAccountLockedUseCase, encryptor)
+        stateStore = mockk()
+        useCase = ConnectGoogleUseCase(googleClient, connectGoogleAccountLockedUseCase, encryptor, stateStore)
 
         every { encryptor.encrypt(any()) } answers { "encrypted-${firstArg<String>()}" }
+        every { stateStore.consume(userId, any()) } returns true
     }
 
     private fun tokenResponse(
@@ -84,6 +90,15 @@ class ConnectGoogleUseCaseTest {
         connectedAt = connectedAt,
     )
 
+    private fun connectRequest(
+        code: String,
+        state: String = oauthState,
+    ) = ConnectGoogleRequest(
+        code = code,
+        redirectUri = redirectUri,
+        state = state,
+    )
+
     @Test
     fun `신규 연결 시 새 TeacherGoogleAccount가 저장된다`() {
         every { googleClient.exchangeCodeForTokens("code-1", redirectUri) } returns tokenResponse()
@@ -101,7 +116,7 @@ class ConnectGoogleUseCaseTest {
             useCase.execute(
                 userId,
                 Role.TEACHER,
-                ConnectGoogleRequest(code = "code-1", redirectUri = redirectUri),
+                connectRequest("code-1"),
             )
 
         assertAll(
@@ -110,6 +125,7 @@ class ConnectGoogleUseCaseTest {
             { assertEquals(fixedNow, response.connectedAt) },
             { assertEquals(grantedScope, response.scope) },
         )
+        verify { stateStore.consume(userId, oauthState) }
         verify { encryptor.encrypt("refresh-token-xyz") }
         verify {
             connectGoogleAccountLockedUseCase.execute(
@@ -145,7 +161,7 @@ class ConnectGoogleUseCaseTest {
             useCase.execute(
                 userId,
                 Role.TEACHER,
-                ConnectGoogleRequest(code = "code-2", redirectUri = redirectUri),
+                connectRequest("code-2"),
             )
 
         assertAll(
@@ -166,9 +182,26 @@ class ConnectGoogleUseCaseTest {
             useCase.execute(
                 userId,
                 Role.TEACHER,
-                ConnectGoogleRequest(code = "code-3", redirectUri = redirectUri),
+                connectRequest("code-3"),
             )
         }
+        verify(exactly = 0) { connectGoogleAccountLockedUseCase.execute(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `OAuth state가 유효하지 않으면 token exchange 전에 실패한다`() {
+        every { stateStore.consume(userId, "invalid-state") } returns false
+
+        assertThrows<GoogleOAuthStateInvalidException> {
+            useCase.execute(
+                userId,
+                Role.TEACHER,
+                connectRequest(code = "code-invalid-state", state = "invalid-state"),
+            )
+        }
+
+        verify { stateStore.consume(userId, "invalid-state") }
+        verify(exactly = 0) { googleClient.exchangeCodeForTokens(any(), any()) }
         verify(exactly = 0) { connectGoogleAccountLockedUseCase.execute(any(), any(), any(), any()) }
     }
 
@@ -178,10 +211,11 @@ class ConnectGoogleUseCaseTest {
             useCase.execute(
                 userId,
                 Role.STUDENT,
-                ConnectGoogleRequest(code = "code-3", redirectUri = redirectUri),
+                connectRequest("code-3"),
             )
         }
 
+        verify(exactly = 0) { stateStore.consume(any(), any()) }
         verify(exactly = 0) { googleClient.exchangeCodeForTokens(any(), any()) }
         verify(exactly = 0) { connectGoogleAccountLockedUseCase.execute(any(), any(), any(), any()) }
     }
@@ -196,7 +230,7 @@ class ConnectGoogleUseCaseTest {
             useCase.execute(
                 userId,
                 Role.TEACHER,
-                ConnectGoogleRequest(code = "code-5", redirectUri = redirectUri),
+                connectRequest("code-5"),
             )
         }
 
@@ -214,7 +248,7 @@ class ConnectGoogleUseCaseTest {
             useCase.execute(
                 userId,
                 Role.TEACHER,
-                ConnectGoogleRequest(code = "code-6", redirectUri = redirectUri),
+                connectRequest("code-6"),
             )
         }
 
@@ -232,7 +266,7 @@ class ConnectGoogleUseCaseTest {
             useCase.execute(
                 userId,
                 Role.TEACHER,
-                ConnectGoogleRequest(code = "code-7", redirectUri = redirectUri),
+                connectRequest("code-7"),
             )
         }
 
@@ -256,7 +290,7 @@ class ConnectGoogleUseCaseTest {
         useCase.execute(
             userId,
             Role.TEACHER,
-            ConnectGoogleRequest(code = "code-4", redirectUri = redirectUri),
+            connectRequest("code-4"),
         )
 
         verify { encryptor.encrypt("raw-token") }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/IssueGoogleOAuthStateUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/oauth/usecase/IssueGoogleOAuthStateUseCaseTest.kt
@@ -1,0 +1,49 @@
+package com.sclass.supporters.oauth.usecase
+
+import com.sclass.common.exception.ForbiddenException
+import com.sclass.domain.domains.user.domain.Role
+import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Duration
+
+class IssueGoogleOAuthStateUseCaseTest {
+    private lateinit var stateStore: GoogleOAuthStateStore
+    private lateinit var useCase: IssueGoogleOAuthStateUseCase
+
+    @BeforeEach
+    fun setUp() {
+        stateStore = mockk()
+        useCase = IssueGoogleOAuthStateUseCase(stateStore)
+    }
+
+    @Test
+    fun `선생님이면 Google OAuth state를 5분 TTL로 발급한다`() {
+        val ttlSlot = slot<Duration>()
+        every { stateStore.issue("teacher-user-id", capture(ttlSlot)) } returns "state-abc"
+
+        val response = useCase.execute("teacher-user-id", Role.TEACHER)
+
+        assertAll(
+            { assertEquals("state-abc", response.state) },
+            { assertEquals(300L, response.expiresInSeconds) },
+            { assertEquals(Duration.ofMinutes(5), ttlSlot.captured) },
+        )
+    }
+
+    @Test
+    fun `선생님 권한이 아니면 state를 발급하지 않는다`() {
+        assertThrows<ForbiddenException> {
+            useCase.execute("student-user-id", Role.STUDENT)
+        }
+
+        verify(exactly = 0) { stateStore.issue(any(), any()) }
+    }
+}

--- a/SClass-Common/src/main/kotlin/com/sclass/common/dto/ApiResponse.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/dto/ApiResponse.kt
@@ -1,5 +1,8 @@
 package com.sclass.common.dto
 
+import org.springframework.http.CacheControl
+import org.springframework.http.ResponseEntity
+
 data class ApiResponse<T>(
     val success: Boolean,
     val data: T? = null,
@@ -7,6 +10,15 @@ data class ApiResponse<T>(
 ) {
     companion object {
         fun <T> success(data: T? = null): ApiResponse<T> = ApiResponse(success = true, data = data)
+
+        fun <T> success(
+            data: T? = null,
+            cacheControl: CacheControl,
+        ): ResponseEntity<ApiResponse<T>> =
+            ResponseEntity
+                .ok()
+                .cacheControl(cacheControl)
+                .body(success(data))
 
         fun error(error: ErrorResponse): ApiResponse<Nothing> = ApiResponse(success = false, error = error)
     }

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleOAuthStateInvalidException.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleOAuthStateInvalidException.kt
@@ -1,0 +1,3 @@
+package com.sclass.common.exception
+
+class GoogleOAuthStateInvalidException : BusinessException(OAuthTokenErrorCode.GOOGLE_OAUTH_STATE_INVALID)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
@@ -13,4 +13,5 @@ enum class OAuthTokenErrorCode(
     GOOGLE_IDENTITY_SCOPE_MISSING("OAUTH_016", "Google 계정 이메일 조회를 위한 email scope가 필요합니다", 400),
     GOOGLE_CALENDAR_SCOPE_MISSING("OAUTH_017", "Google Calendar 연동을 위한 calendar.events scope가 필요합니다", 400),
     GOOGLE_OAUTH_PROVIDER_UNAVAILABLE("OAUTH_018", "Google OAuth 서버가 일시적으로 응답하지 않습니다", 503),
+    GOOGLE_OAUTH_STATE_INVALID("OAUTH_019", "Google OAuth state가 유효하지 않습니다", 400),
 }

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/state/GoogleOAuthStateStore.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/state/GoogleOAuthStateStore.kt
@@ -1,0 +1,15 @@
+package com.sclass.infrastructure.oauth.state
+
+import java.time.Duration
+
+interface GoogleOAuthStateStore {
+    fun issue(
+        userId: String,
+        ttl: Duration,
+    ): String
+
+    fun consume(
+        userId: String,
+        state: String,
+    ): Boolean
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/state/RedisGoogleOAuthStateStore.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/state/RedisGoogleOAuthStateStore.kt
@@ -1,0 +1,44 @@
+package com.sclass.infrastructure.oauth.state
+
+import org.redisson.api.RedissonClient
+import org.springframework.stereotype.Component
+import java.security.SecureRandom
+import java.time.Duration
+import java.util.Base64
+
+@Component
+class RedisGoogleOAuthStateStore(
+    private val redissonClient: RedissonClient,
+) : GoogleOAuthStateStore {
+    private val secureRandom = SecureRandom()
+
+    override fun issue(
+        userId: String,
+        ttl: Duration,
+    ): String {
+        val state = generateState()
+        redissonClient
+            .getBucket<String>(key(userId, state))
+            .set("1", ttl)
+        return state
+    }
+
+    override fun consume(
+        userId: String,
+        state: String,
+    ): Boolean {
+        val bucket = redissonClient.getBucket<String>(key(userId, state))
+        return bucket.getAndDelete() != null
+    }
+
+    private fun key(
+        userId: String,
+        state: String,
+    ): String = "oauth:google:state:$userId:$state"
+
+    private fun generateState(): String {
+        val bytes = ByteArray(32)
+        secureRandom.nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/state/RedisGoogleOAuthStateStore.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/state/RedisGoogleOAuthStateStore.kt
@@ -2,6 +2,7 @@ package com.sclass.infrastructure.oauth.state
 
 import org.redisson.api.RedissonClient
 import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
 import java.time.Duration
 import java.util.Base64
@@ -34,7 +35,13 @@ class RedisGoogleOAuthStateStore(
     private fun key(
         userId: String,
         state: String,
-    ): String = "oauth:google:state:$userId:$state"
+    ): String = "oauth:google:state:${encodeUserId(userId)}:$state"
+
+    private fun encodeUserId(userId: String): String =
+        Base64
+            .getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(userId.toByteArray(StandardCharsets.UTF_8))
 
     private fun generateState(): String {
         val bytes = ByteArray(32)

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/state/RedisGoogleOAuthStateStoreTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/state/RedisGoogleOAuthStateStoreTest.kt
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.redisson.api.RBucket
 import org.redisson.api.RedissonClient
+import java.nio.charset.StandardCharsets
 import java.time.Duration
+import java.util.Base64
 
 class RedisGoogleOAuthStateStoreTest {
     private lateinit var redissonClient: RedissonClient
@@ -34,7 +36,7 @@ class RedisGoogleOAuthStateStoreTest {
 
         assertAll(
             { assertTrue(state.isNotBlank()) },
-            { assertTrue(keySlot.captured.startsWith("oauth:google:state:teacher-user-id:")) },
+            { assertTrue(keySlot.captured.startsWith("oauth:google:state:${encoded("teacher-user-id")}:")) },
             { assertTrue(keySlot.captured.endsWith(state)) },
         )
         verify { bucket.set("1", Duration.ofMinutes(5)) }
@@ -42,7 +44,7 @@ class RedisGoogleOAuthStateStoreTest {
 
     @Test
     fun `저장된 state를 원자적으로 consume하면 true를 반환한다`() {
-        every { redissonClient.getBucket<String>("oauth:google:state:user-1:state-1") } returns bucket
+        every { redissonClient.getBucket<String>("oauth:google:state:${encoded("user-1")}:state-1") } returns bucket
         every { bucket.getAndDelete() } returns "1"
 
         val consumed = store.consume("user-1", "state-1")
@@ -52,11 +54,27 @@ class RedisGoogleOAuthStateStoreTest {
 
     @Test
     fun `저장된 state가 없으면 consume은 false를 반환한다`() {
-        every { redissonClient.getBucket<String>("oauth:google:state:user-1:missing-state") } returns bucket
+        every { redissonClient.getBucket<String>("oauth:google:state:${encoded("user-1")}:missing-state") } returns bucket
         every { bucket.getAndDelete() } returns null
 
         val consumed = store.consume("user-1", "missing-state")
 
         assertFalse(consumed)
     }
+
+    @Test
+    fun `userId에 구분자가 포함되어도 인코딩된 Redis key를 사용한다`() {
+        every { redissonClient.getBucket<String>("oauth:google:state:${encoded("user:1")}:state-1") } returns bucket
+        every { bucket.getAndDelete() } returns "1"
+
+        val consumed = store.consume("user:1", "state-1")
+
+        assertTrue(consumed)
+    }
+
+    private fun encoded(value: String): String =
+        Base64
+            .getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(value.toByteArray(StandardCharsets.UTF_8))
 }

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/state/RedisGoogleOAuthStateStoreTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/state/RedisGoogleOAuthStateStoreTest.kt
@@ -1,0 +1,62 @@
+package com.sclass.infrastructure.oauth.state
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.redisson.api.RBucket
+import org.redisson.api.RedissonClient
+import java.time.Duration
+
+class RedisGoogleOAuthStateStoreTest {
+    private lateinit var redissonClient: RedissonClient
+    private lateinit var bucket: RBucket<String>
+    private lateinit var store: RedisGoogleOAuthStateStore
+
+    @BeforeEach
+    fun setUp() {
+        redissonClient = mockk()
+        bucket = mockk(relaxed = true)
+        store = RedisGoogleOAuthStateStore(redissonClient)
+    }
+
+    @Test
+    fun `state를 생성하고 TTL과 함께 Redis에 저장한다`() {
+        val keySlot = slot<String>()
+        every { redissonClient.getBucket<String>(capture(keySlot)) } returns bucket
+
+        val state = store.issue("teacher-user-id", Duration.ofMinutes(5))
+
+        assertAll(
+            { assertTrue(state.isNotBlank()) },
+            { assertTrue(keySlot.captured.startsWith("oauth:google:state:teacher-user-id:")) },
+            { assertTrue(keySlot.captured.endsWith(state)) },
+        )
+        verify { bucket.set("1", Duration.ofMinutes(5)) }
+    }
+
+    @Test
+    fun `저장된 state를 원자적으로 consume하면 true를 반환한다`() {
+        every { redissonClient.getBucket<String>("oauth:google:state:user-1:state-1") } returns bucket
+        every { bucket.getAndDelete() } returns "1"
+
+        val consumed = store.consume("user-1", "state-1")
+
+        assertTrue(consumed)
+    }
+
+    @Test
+    fun `저장된 state가 없으면 consume은 false를 반환한다`() {
+        every { redissonClient.getBucket<String>("oauth:google:state:user-1:missing-state") } returns bucket
+        every { bucket.getAndDelete() } returns null
+
+        val consumed = store.consume("user-1", "missing-state")
+
+        assertFalse(consumed)
+    }
+}


### PR DESCRIPTION
## 요약
- Google OAuth 연결 전 state 발급 API를 추가했습니다.
- Redis 기반 one-time state store로 state를 저장하고, connect 시 consume 검증하도록 했습니다.
- 유효하지 않은 state는 Google token exchange 전에 차단하고 관련 테스트를 추가했습니다.

## 테스트
- ./gradlew :SClass-Api-Supporters:test --tests '*ConnectGoogleUseCaseTest' --tests '*IssueGoogleOAuthStateUseCaseTest' :SClass-Infrastructure:test --tests '*RedisGoogleOAuthStateStoreTest'
- ./gradlew :SClass-Api-Supporters:ktlintCheck :SClass-Infrastructure:ktlintCheck :SClass-Common:ktlintCheck
- pre-commit hook: ktlintFormat + build

Closes #296