### PR TITLE
feat: Google Calendar API 클라이언트 추가

### DIFF
--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleCalendarRequestFailedException.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleCalendarRequestFailedException.kt
@@ -1,0 +1,3 @@
+package com.sclass.common.exception
+
+class GoogleCalendarRequestFailedException : BusinessException(OAuthTokenErrorCode.GOOGLE_CALENDAR_REQUEST_FAILED)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleCalendarUnauthorizedException.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleCalendarUnauthorizedException.kt
@@ -1,0 +1,3 @@
+package com.sclass.common.exception
+
+class GoogleCalendarUnauthorizedException : BusinessException(OAuthTokenErrorCode.GOOGLE_CALENDAR_UNAUTHORIZED)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
@@ -14,4 +14,6 @@ enum class OAuthTokenErrorCode(
     GOOGLE_CALENDAR_SCOPE_MISSING("OAUTH_017", "Google Calendar 연동을 위한 calendar.events scope가 필요합니다", 400),
     GOOGLE_OAUTH_PROVIDER_UNAVAILABLE("OAUTH_018", "Google OAuth 서버가 일시적으로 응답하지 않습니다", 503),
     GOOGLE_OAUTH_STATE_INVALID("OAUTH_019", "Google OAuth state가 유효하지 않습니다", 400),
+    GOOGLE_CALENDAR_REQUEST_FAILED("OAUTH_020", "Google Calendar 요청에 실패했습니다", 400),
+    GOOGLE_CALENDAR_UNAUTHORIZED("OAUTH_021", "Google Calendar 인증에 실패했습니다", 401),
 }

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
@@ -34,7 +34,10 @@ class GoogleCalendarClient(
             val refreshedAccessToken =
                 runCatching {
                     authorizationCodeClient.refreshAccessToken(command.refreshToken)
-                }.getOrElse { throw GoogleCalendarUnauthorizedException() }
+                }.getOrElse {
+                    if (it is GoogleOAuthProviderUnavailableException) throw it
+                    throw GoogleCalendarUnauthorizedException()
+                }
 
             try {
                 createMeetEvent(command, refreshedAccessToken)
@@ -48,13 +51,14 @@ class GoogleCalendarClient(
         command: CreateGoogleCalendarEventCommand,
         accessToken: String,
     ): GoogleCalendarEventResult {
+        val request = command.toRequest()
         val response =
             try {
                 webClient
                     .post()
                     .uri(CALENDAR_EVENTS_URI)
                     .header("Authorization", "Bearer $accessToken")
-                    .bodyValue(command.toRequest())
+                    .bodyValue(request)
                     .retrieve()
                     .bodyToMono(GoogleCalendarEventResponse::class.java)
                     .block()

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
@@ -1,0 +1,125 @@
+package com.sclass.infrastructure.calendar
+
+import com.sclass.common.exception.GoogleCalendarRequestFailedException
+import com.sclass.common.exception.GoogleCalendarUnauthorizedException
+import com.sclass.common.exception.GoogleOAuthProviderUnavailableException
+import com.sclass.infrastructure.calendar.dto.CreateGoogleCalendarEventCommand
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarConferenceCreateRequest
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarConferenceData
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventDateTime
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventRequest
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResponse
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
+import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import java.util.UUID
+
+@Component
+class GoogleCalendarClient(
+    @param:Qualifier("oAuthWebClient") private val webClient: WebClient,
+    private val authorizationCodeClient: GoogleAuthorizationCodeClient,
+) {
+    private val log = LoggerFactory.getLogger(GoogleCalendarClient::class.java)
+
+    fun createMeetEvent(command: CreateGoogleCalendarEventCommand): GoogleCalendarEventResult =
+        try {
+            createMeetEvent(command, command.accessToken)
+        } catch (e: WebClientResponseException) {
+            if (!e.isAuthorizationFailure()) throw e
+
+            val refreshedAccessToken =
+                runCatching {
+                    authorizationCodeClient.refreshAccessToken(command.refreshToken)
+                }.getOrElse { throw GoogleCalendarUnauthorizedException() }
+
+            try {
+                createMeetEvent(command, refreshedAccessToken)
+            } catch (retryException: WebClientResponseException) {
+                if (retryException.isAuthorizationFailure()) throw GoogleCalendarUnauthorizedException()
+                throw retryException
+            }
+        }
+
+    private fun createMeetEvent(
+        command: CreateGoogleCalendarEventCommand,
+        accessToken: String,
+    ): GoogleCalendarEventResult {
+        val response =
+            try {
+                webClient
+                    .post()
+                    .uri(CALENDAR_EVENTS_URI)
+                    .header("Authorization", "Bearer $accessToken")
+                    .bodyValue(command.toRequest())
+                    .retrieve()
+                    .bodyToMono(GoogleCalendarEventResponse::class.java)
+                    .block()
+            } catch (e: WebClientResponseException) {
+                log.warn("Google Calendar event create failed: ${e.responseBodyAsString}", e)
+                if (e.isAuthorizationFailure()) throw e
+                if (e.statusCode.is5xxServerError || e.statusCode.value() == TOO_MANY_REQUESTS_STATUS) {
+                    throw GoogleOAuthProviderUnavailableException()
+                }
+                throw GoogleCalendarRequestFailedException()
+            } catch (e: Exception) {
+                log.warn("Google Calendar event create failed", e)
+                throw GoogleOAuthProviderUnavailableException()
+            }
+
+        return response.toResult()
+    }
+
+    private fun CreateGoogleCalendarEventCommand.toRequest(): GoogleCalendarEventRequest =
+        GoogleCalendarEventRequest(
+            summary = summary,
+            start =
+                GoogleCalendarEventDateTime(
+                    dateTime = startAt.toOffsetDateTime().toString(),
+                    timeZone = startAt.zone.id,
+                ),
+            end =
+                GoogleCalendarEventDateTime(
+                    dateTime = endAt.toOffsetDateTime().toString(),
+                    timeZone = endAt.zone.id,
+                ),
+            conferenceData =
+                GoogleCalendarConferenceData(
+                    createRequest =
+                        GoogleCalendarConferenceCreateRequest(
+                            requestId = UUID.randomUUID().toString(),
+                        ),
+                ),
+        )
+
+    private fun GoogleCalendarEventResponse?.toResult(): GoogleCalendarEventResult {
+        val eventId = this?.id ?: throw GoogleCalendarRequestFailedException()
+        val meetJoinUrl =
+            conferenceData
+                ?.entryPoints
+                ?.firstOrNull { it.entryPointType == "video" && !it.uri.isNullOrBlank() }
+                ?.uri
+                ?: hangoutLink
+
+        if (meetJoinUrl.isNullOrBlank()) throw GoogleCalendarRequestFailedException()
+
+        return GoogleCalendarEventResult(
+            eventId = eventId,
+            meetJoinUrl = meetJoinUrl,
+        )
+    }
+
+    private fun WebClientResponseException.isAuthorizationFailure(): Boolean =
+        statusCode.value() == UNAUTHORIZED_STATUS || statusCode.value() == FORBIDDEN_STATUS
+
+    private companion object {
+        const val CALENDAR_EVENTS_URI =
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1"
+        const val UNAUTHORIZED_STATUS = 401
+        const val FORBIDDEN_STATUS = 403
+        const val TOO_MANY_REQUESTS_STATUS = 429
+    }
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
@@ -1,5 +1,6 @@
 package com.sclass.infrastructure.calendar
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.sclass.common.exception.GoogleCalendarRequestFailedException
 import com.sclass.common.exception.GoogleCalendarUnauthorizedException
 import com.sclass.common.exception.GoogleOAuthProviderUnavailableException
@@ -24,6 +25,7 @@ class GoogleCalendarClient(
     private val authorizationCodeClient: GoogleAuthorizationCodeClient,
 ) {
     private val log = LoggerFactory.getLogger(GoogleCalendarClient::class.java)
+    private val objectMapper = ObjectMapper()
 
     fun createMeetEvent(command: CreateGoogleCalendarEventCommand): GoogleCalendarEventResult =
         try {
@@ -64,10 +66,10 @@ class GoogleCalendarClient(
                     .block()
             } catch (e: WebClientResponseException) {
                 log.warn("Google Calendar event create failed: ${e.responseBodyAsString}", e)
-                if (e.isAuthorizationFailure()) throw e
-                if (e.statusCode.is5xxServerError || e.statusCode.value() == TOO_MANY_REQUESTS_STATUS) {
+                if (e.isRetryableProviderFailure()) {
                     throw GoogleOAuthProviderUnavailableException()
                 }
+                if (e.isAuthorizationFailure()) throw e
                 throw GoogleCalendarRequestFailedException()
             } catch (e: Exception) {
                 log.warn("Google Calendar event create failed", e)
@@ -119,11 +121,40 @@ class GoogleCalendarClient(
     private fun WebClientResponseException.isAuthorizationFailure(): Boolean =
         statusCode.value() == UNAUTHORIZED_STATUS || statusCode.value() == FORBIDDEN_STATUS
 
+    private fun WebClientResponseException.isRetryableProviderFailure(): Boolean =
+        statusCode.is5xxServerError ||
+            statusCode.value() == TOO_MANY_REQUESTS_STATUS ||
+            isForbiddenRateLimitFailure()
+
+    private fun WebClientResponseException.isForbiddenRateLimitFailure(): Boolean {
+        if (statusCode.value() != FORBIDDEN_STATUS) return false
+
+        return runCatching {
+            val error = objectMapper.readTree(responseBodyAsString).path("error")
+            val status = error.path("status").asText()
+            val reasons =
+                error
+                    .path("errors")
+                    .mapNotNull { it.path("reason").asText(null) }
+
+            status == GOOGLE_RESOURCE_EXHAUSTED_STATUS ||
+                reasons.any { it in GOOGLE_CALENDAR_RETRYABLE_FORBIDDEN_REASONS }
+        }.getOrDefault(false)
+    }
+
     private companion object {
         const val CALENDAR_EVENTS_URI =
             "https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1"
         const val UNAUTHORIZED_STATUS = 401
         const val FORBIDDEN_STATUS = 403
         const val TOO_MANY_REQUESTS_STATUS = 429
+        const val GOOGLE_RESOURCE_EXHAUSTED_STATUS = "RESOURCE_EXHAUSTED"
+        val GOOGLE_CALENDAR_RETRYABLE_FORBIDDEN_REASONS =
+            setOf(
+                "dailyLimitExceeded",
+                "quotaExceeded",
+                "rateLimitExceeded",
+                "userRateLimitExceeded",
+            )
     }
 }

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/CreateGoogleCalendarEventCommand.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/CreateGoogleCalendarEventCommand.kt
@@ -1,0 +1,11 @@
+package com.sclass.infrastructure.calendar.dto
+
+import java.time.ZonedDateTime
+
+data class CreateGoogleCalendarEventCommand(
+    val accessToken: String,
+    val refreshToken: String,
+    val summary: String,
+    val startAt: ZonedDateTime,
+    val endAt: ZonedDateTime,
+)

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventRequest.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventRequest.kt
@@ -1,0 +1,27 @@
+package com.sclass.infrastructure.calendar.dto
+
+data class GoogleCalendarEventRequest(
+    val summary: String,
+    val start: GoogleCalendarEventDateTime,
+    val end: GoogleCalendarEventDateTime,
+    val conferenceData: GoogleCalendarConferenceData,
+)
+
+data class GoogleCalendarEventDateTime(
+    val dateTime: String,
+    val timeZone: String,
+)
+
+data class GoogleCalendarConferenceData(
+    val createRequest: GoogleCalendarConferenceCreateRequest,
+)
+
+data class GoogleCalendarConferenceCreateRequest(
+    val requestId: String,
+    val conferenceSolutionKey: GoogleCalendarConferenceSolutionKey =
+        GoogleCalendarConferenceSolutionKey(type = "hangoutsMeet"),
+)
+
+data class GoogleCalendarConferenceSolutionKey(
+    val type: String,
+)

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventResponse.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventResponse.kt
@@ -1,0 +1,16 @@
+package com.sclass.infrastructure.calendar.dto
+
+data class GoogleCalendarEventResponse(
+    val id: String?,
+    val hangoutLink: String?,
+    val conferenceData: GoogleCalendarConferenceResponse?,
+)
+
+data class GoogleCalendarConferenceResponse(
+    val entryPoints: List<GoogleCalendarEntryPoint> = emptyList(),
+)
+
+data class GoogleCalendarEntryPoint(
+    val entryPointType: String?,
+    val uri: String?,
+)

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventResult.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventResult.kt
@@ -1,0 +1,6 @@
+package com.sclass.infrastructure.calendar.dto
+
+data class GoogleCalendarEventResult(
+    val eventId: String,
+    val meetJoinUrl: String,
+)

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
@@ -133,6 +133,18 @@ class GoogleCalendarClientTest {
     }
 
     @Test
+    fun `refresh token 갱신 중 Google 서버 장애는 provider unavailable 예외를 유지한다`() {
+        mockCreateEventCall()
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.error(webClientException(HttpStatus.UNAUTHORIZED))
+        every { authorizationCodeClient.refreshAccessToken("refresh-token") } throws GoogleOAuthProviderUnavailableException()
+
+        assertThrows<GoogleOAuthProviderUnavailableException> {
+            client.createMeetEvent(command)
+        }
+    }
+
+    @Test
     fun `refresh 후 재시도도 인증 실패하면 GoogleCalendarUnauthorizedException`() {
         mockCreateEventCall()
         every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returnsMany

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
@@ -1,0 +1,229 @@
+package com.sclass.infrastructure.calendar
+
+import com.sclass.common.exception.GoogleCalendarRequestFailedException
+import com.sclass.common.exception.GoogleCalendarUnauthorizedException
+import com.sclass.common.exception.GoogleOAuthProviderUnavailableException
+import com.sclass.infrastructure.calendar.dto.CreateGoogleCalendarEventCommand
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarConferenceResponse
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEntryPoint
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventRequest
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResponse
+import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Mono
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class GoogleCalendarClientTest {
+    private lateinit var webClient: WebClient
+    private lateinit var requestBodyUriSpec: WebClient.RequestBodyUriSpec
+    private lateinit var requestBodySpec: WebClient.RequestBodySpec
+    private lateinit var requestHeadersSpec: WebClient.RequestHeadersSpec<*>
+    private lateinit var responseSpec: WebClient.ResponseSpec
+    private lateinit var authorizationCodeClient: GoogleAuthorizationCodeClient
+    private lateinit var client: GoogleCalendarClient
+
+    private val command =
+        CreateGoogleCalendarEventCommand(
+            accessToken = "expired-access-token",
+            refreshToken = "refresh-token",
+            summary = "수학 1회차",
+            startAt = ZonedDateTime.of(2026, 4, 26, 14, 0, 0, 0, ZoneId.of("Asia/Seoul")),
+            endAt = ZonedDateTime.of(2026, 4, 26, 15, 0, 0, 0, ZoneId.of("Asia/Seoul")),
+        )
+
+    @BeforeEach
+    fun setUp() {
+        webClient = mockk()
+        requestBodyUriSpec = mockk()
+        requestBodySpec = mockk()
+        requestHeadersSpec = mockk()
+        responseSpec = mockk()
+        authorizationCodeClient = mockk()
+        client = GoogleCalendarClient(webClient, authorizationCodeClient)
+    }
+
+    private fun mockCreateEventCall(requestSlot: MutableList<GoogleCalendarEventRequest> = mutableListOf()) {
+        every { webClient.post() } returns requestBodyUriSpec
+        every { requestBodyUriSpec.uri(CALENDAR_EVENTS_URI) } returns requestBodySpec
+        every { requestBodySpec.header(HttpHeaders.AUTHORIZATION, any()) } returns requestBodySpec
+        every { requestBodySpec.bodyValue(capture(requestSlot)) } returns requestHeadersSpec
+        every { requestHeadersSpec.retrieve() } returns responseSpec
+    }
+
+    @Test
+    fun `Calendar event 생성 응답에서 video entryPoint를 Meet 링크로 반환한다`() {
+        val requestSlot = mutableListOf<GoogleCalendarEventRequest>()
+        mockCreateEventCall(requestSlot)
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.just(calendarResponse(meetUri = "https://meet.google.com/abc-defg-hij"))
+
+        val result = client.createMeetEvent(command)
+
+        assertAll(
+            { assertEquals("event-id-1", result.eventId) },
+            { assertEquals("https://meet.google.com/abc-defg-hij", result.meetJoinUrl) },
+            { assertEquals("수학 1회차", requestSlot.single().summary) },
+            { assertEquals("2026-04-26T14:00+09:00", requestSlot.single().start.dateTime) },
+            { assertEquals("Asia/Seoul", requestSlot.single().start.timeZone) },
+            {
+                assertEquals(
+                    "hangoutsMeet",
+                    requestSlot
+                        .single()
+                        .conferenceData
+                        .createRequest
+                        .conferenceSolutionKey
+                        .type,
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `video entryPoint가 없으면 hangoutLink를 Meet 링크로 반환한다`() {
+        mockCreateEventCall()
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.just(calendarResponse(meetUri = null, hangoutLink = "https://meet.google.com/hangout-link"))
+
+        val result = client.createMeetEvent(command)
+
+        assertEquals("https://meet.google.com/hangout-link", result.meetJoinUrl)
+    }
+
+    @Test
+    fun `access token 인증 실패 시 refresh token으로 갱신 후 한 번 재시도한다`() {
+        mockCreateEventCall()
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returnsMany
+            listOf(
+                Mono.error(webClientException(HttpStatus.UNAUTHORIZED)),
+                Mono.just(calendarResponse(meetUri = "https://meet.google.com/refreshed")),
+            )
+        every { authorizationCodeClient.refreshAccessToken("refresh-token") } returns "refreshed-access-token"
+
+        val result = client.createMeetEvent(command)
+
+        assertEquals("https://meet.google.com/refreshed", result.meetJoinUrl)
+        verify { requestBodySpec.header(HttpHeaders.AUTHORIZATION, "Bearer expired-access-token") }
+        verify { requestBodySpec.header(HttpHeaders.AUTHORIZATION, "Bearer refreshed-access-token") }
+        verify { authorizationCodeClient.refreshAccessToken("refresh-token") }
+    }
+
+    @Test
+    fun `refresh token 갱신에 실패하면 GoogleCalendarUnauthorizedException`() {
+        mockCreateEventCall()
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.error(webClientException(HttpStatus.UNAUTHORIZED))
+        every { authorizationCodeClient.refreshAccessToken("refresh-token") } throws RuntimeException("revoked")
+
+        assertThrows<GoogleCalendarUnauthorizedException> {
+            client.createMeetEvent(command)
+        }
+    }
+
+    @Test
+    fun `refresh 후 재시도도 인증 실패하면 GoogleCalendarUnauthorizedException`() {
+        mockCreateEventCall()
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returnsMany
+            listOf(
+                Mono.error(webClientException(HttpStatus.UNAUTHORIZED)),
+                Mono.error(webClientException(HttpStatus.FORBIDDEN)),
+            )
+        every { authorizationCodeClient.refreshAccessToken("refresh-token") } returns "refreshed-access-token"
+
+        assertThrows<GoogleCalendarUnauthorizedException> {
+            client.createMeetEvent(command)
+        }
+    }
+
+    @Test
+    fun `Google Calendar 4xx 응답은 GoogleCalendarRequestFailedException`() {
+        mockCreateEventCall()
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.error(webClientException(HttpStatus.BAD_REQUEST))
+
+        assertThrows<GoogleCalendarRequestFailedException> {
+            client.createMeetEvent(command)
+        }
+    }
+
+    @Test
+    fun `Google Calendar 5xx 응답은 GoogleOAuthProviderUnavailableException`() {
+        mockCreateEventCall()
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.error(webClientException(HttpStatus.SERVICE_UNAVAILABLE))
+
+        assertThrows<GoogleOAuthProviderUnavailableException> {
+            client.createMeetEvent(command)
+        }
+    }
+
+    @Test
+    fun `응답에 event id가 없으면 GoogleCalendarRequestFailedException`() {
+        mockCreateEventCall()
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.just(calendarResponse(id = null, meetUri = "https://meet.google.com/abc-defg-hij"))
+
+        assertThrows<GoogleCalendarRequestFailedException> {
+            client.createMeetEvent(command)
+        }
+    }
+
+    @Test
+    fun `응답에 Meet 링크가 없으면 GoogleCalendarRequestFailedException`() {
+        mockCreateEventCall()
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.just(calendarResponse(meetUri = null, hangoutLink = null))
+
+        assertThrows<GoogleCalendarRequestFailedException> {
+            client.createMeetEvent(command)
+        }
+    }
+
+    private fun calendarResponse(
+        id: String? = "event-id-1",
+        meetUri: String?,
+        hangoutLink: String? = null,
+    ): GoogleCalendarEventResponse =
+        GoogleCalendarEventResponse(
+            id = id,
+            hangoutLink = hangoutLink,
+            conferenceData =
+                GoogleCalendarConferenceResponse(
+                    entryPoints =
+                        listOfNotNull(
+                            meetUri?.let {
+                                GoogleCalendarEntryPoint(
+                                    entryPointType = "video",
+                                    uri = it,
+                                )
+                            },
+                        ),
+                ),
+        )
+
+    private fun webClientException(status: HttpStatus): WebClientResponseException =
+        WebClientResponseException.create(
+            status.value(),
+            status.reasonPhrase,
+            HttpHeaders.EMPTY,
+            ByteArray(0),
+            null,
+        )
+
+    private companion object {
+        const val CALENDAR_EVENTS_URI =
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1"
+    }
+}

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
@@ -182,6 +182,36 @@ class GoogleCalendarClientTest {
     }
 
     @Test
+    fun `Google Calendar 403 rate limit 응답은 GoogleOAuthProviderUnavailableException`() {
+        mockCreateEventCall()
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.error(
+                webClientException(
+                    status = HttpStatus.FORBIDDEN,
+                    responseBody =
+                        """
+                        {
+                          "error": {
+                            "code": 403,
+                            "status": "RESOURCE_EXHAUSTED",
+                            "errors": [
+                              {
+                                "reason": "rateLimitExceeded"
+                              }
+                            ]
+                          }
+                        }
+                        """.trimIndent(),
+                ),
+            )
+
+        assertThrows<GoogleOAuthProviderUnavailableException> {
+            client.createMeetEvent(command)
+        }
+        verify(exactly = 0) { authorizationCodeClient.refreshAccessToken(any()) }
+    }
+
+    @Test
     fun `응답에 event id가 없으면 GoogleCalendarRequestFailedException`() {
         mockCreateEventCall()
         every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
@@ -225,13 +255,16 @@ class GoogleCalendarClientTest {
                 ),
         )
 
-    private fun webClientException(status: HttpStatus): WebClientResponseException =
+    private fun webClientException(
+        status: HttpStatus,
+        responseBody: String = "",
+    ): WebClientResponseException =
         WebClientResponseException.create(
             status.value(),
             status.reasonPhrase,
             HttpHeaders.EMPTY,
-            ByteArray(0),
-            null,
+            responseBody.toByteArray(),
+            Charsets.UTF_8,
         )
 
     private companion object {


### PR DESCRIPTION
## 요약
- Google Calendar events.insert 기반 Meet 링크 발급 클라이언트를 추가했습니다.
- conferenceData createRequest 요청/응답 DTO와 eventId/meetJoinUrl 결과 DTO를 추가했습니다.
- 401/403 응답 시 refresh token으로 access token을 갱신한 뒤 1회 재시도하도록 구현했습니다.

## 범위
- Infrastructure 클라이언트 구현까지만 포함합니다.
- Lesson 엔티티 저장 및 lesson 생성 흐름 연결은 후속 #293에서 처리합니다.

## 테스트
- GoogleCalendarClientTest
- pre-commit hook: ktlintFormat + build

Closes #292