### PR TITLE
feat: 중앙 Google Calendar 계정 관리 추가

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/controller/CentralGoogleConnectionController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/controller/CentralGoogleConnectionController.kt
@@ -1,0 +1,51 @@
+package com.sclass.backoffice.oauth.controller
+
+import com.sclass.backoffice.oauth.dto.CentralGoogleConnectionStatusResponse
+import com.sclass.backoffice.oauth.dto.ConnectCentralGoogleRequest
+import com.sclass.backoffice.oauth.usecase.ConnectCentralGoogleUseCase
+import com.sclass.backoffice.oauth.usecase.DisconnectCentralGoogleUseCase
+import com.sclass.backoffice.oauth.usecase.GetCentralGoogleConnectionStatusUseCase
+import com.sclass.backoffice.oauth.usecase.IssueCentralGoogleOAuthStateUseCase
+import com.sclass.common.annotation.CurrentUserId
+import com.sclass.common.dto.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.CacheControl
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/google/calendar/central")
+class CentralGoogleConnectionController(
+    private val connectCentralGoogleUseCase: ConnectCentralGoogleUseCase,
+    private val disconnectCentralGoogleUseCase: DisconnectCentralGoogleUseCase,
+    private val getCentralGoogleConnectionStatusUseCase: GetCentralGoogleConnectionStatusUseCase,
+    private val issueCentralGoogleOAuthStateUseCase: IssueCentralGoogleOAuthStateUseCase,
+) {
+    @PostMapping("/connect")
+    fun connect(
+        @CurrentUserId adminUserId: String,
+        @Valid @RequestBody request: ConnectCentralGoogleRequest,
+    ): ApiResponse<CentralGoogleConnectionStatusResponse> = ApiResponse.success(connectCentralGoogleUseCase.execute(adminUserId, request))
+
+    @DeleteMapping
+    fun disconnect(): ApiResponse<Unit> {
+        disconnectCentralGoogleUseCase.execute()
+        return ApiResponse.success(Unit)
+    }
+
+    @GetMapping
+    fun status(): ApiResponse<CentralGoogleConnectionStatusResponse> =
+        ApiResponse.success(getCentralGoogleConnectionStatusUseCase.execute())
+
+    @PostMapping("/state")
+    fun issueState(
+        @CurrentUserId adminUserId: String,
+    ) = ApiResponse.success(
+        data = issueCentralGoogleOAuthStateUseCase.execute(adminUserId),
+        cacheControl = CacheControl.noStore(),
+    )
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/dto/CentralGoogleConnectionStatusResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/dto/CentralGoogleConnectionStatusResponse.kt
@@ -1,0 +1,35 @@
+package com.sclass.backoffice.oauth.dto
+
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import java.time.LocalDateTime
+
+data class CentralGoogleConnectionStatusResponse(
+    val connected: Boolean,
+    val googleEmail: String? = null,
+    val allowedEmail: String? = null,
+    val connectedByAdminUserId: String? = null,
+    val connectedAt: LocalDateTime? = null,
+    val lastUsedAt: LocalDateTime? = null,
+    val scope: String? = null,
+) {
+    companion object {
+        fun connected(
+            account: CentralGoogleAccount,
+            allowedEmail: String,
+        ) = CentralGoogleConnectionStatusResponse(
+            connected = true,
+            googleEmail = account.googleEmail,
+            allowedEmail = allowedEmail,
+            connectedByAdminUserId = account.connectedByAdminUserId,
+            connectedAt = account.connectedAt,
+            lastUsedAt = account.lastUsedAt,
+            scope = account.scope,
+        )
+
+        fun notConnected(allowedEmail: String? = null) =
+            CentralGoogleConnectionStatusResponse(
+                connected = false,
+                allowedEmail = allowedEmail,
+            )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/dto/CentralGoogleOAuthStateResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/dto/CentralGoogleOAuthStateResponse.kt
@@ -3,4 +3,6 @@ package com.sclass.backoffice.oauth.dto
 data class CentralGoogleOAuthStateResponse(
     val state: String,
     val expiresInSeconds: Long,
+    val clientId: String,
+    val scopes: List<String>,
 )

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/dto/CentralGoogleOAuthStateResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/dto/CentralGoogleOAuthStateResponse.kt
@@ -1,0 +1,6 @@
+package com.sclass.backoffice.oauth.dto
+
+data class CentralGoogleOAuthStateResponse(
+    val state: String,
+    val expiresInSeconds: Long,
+)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/dto/ConnectCentralGoogleRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/dto/ConnectCentralGoogleRequest.kt
@@ -1,0 +1,12 @@
+package com.sclass.backoffice.oauth.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class ConnectCentralGoogleRequest(
+    @field:NotBlank
+    val code: String,
+    @field:NotBlank
+    val redirectUri: String,
+    @field:NotBlank
+    val state: String,
+)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/CentralGoogleOAuthScopes.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/CentralGoogleOAuthScopes.kt
@@ -1,0 +1,20 @@
+package com.sclass.backoffice.oauth.usecase
+
+object CentralGoogleOAuthScopes {
+    const val GOOGLE_CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
+    const val GOOGLE_DRIVE_MEET_READONLY_SCOPE = "https://www.googleapis.com/auth/drive.meet.readonly"
+
+    val authorizationScopes =
+        listOf(
+            "openid",
+            "https://www.googleapis.com/auth/userinfo.email",
+            GOOGLE_CALENDAR_EVENTS_SCOPE,
+            GOOGLE_DRIVE_MEET_READONLY_SCOPE,
+        )
+
+    val googleEmailScopes =
+        setOf(
+            "email",
+            "https://www.googleapis.com/auth/userinfo.email",
+        )
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleAccountLockedUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleAccountLockedUseCase.kt
@@ -1,0 +1,51 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+
+@UseCase
+class ConnectCentralGoogleAccountLockedUseCase(
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    @DistributedLock(prefix = "central-google-account", waitTime = 30)
+    @Transactional
+    fun execute(
+        @LockKey provider: String,
+        googleEmail: String,
+        encryptedRefreshToken: String,
+        scope: String,
+        adminUserId: String,
+    ): CentralGoogleAccount {
+        val existing = centralGoogleAccountAdaptor.findGoogleOrNull()
+        val now = LocalDateTime.now(clock)
+
+        return if (existing != null) {
+            existing.reconnect(
+                newGoogleEmail = googleEmail,
+                newEncryptedRefreshToken = encryptedRefreshToken,
+                newScope = scope,
+                adminUserId = adminUserId,
+                at = now,
+            )
+            centralGoogleAccountAdaptor.save(existing)
+        } else {
+            centralGoogleAccountAdaptor.save(
+                CentralGoogleAccount(
+                    provider = provider,
+                    googleEmail = googleEmail,
+                    encryptedRefreshToken = encryptedRefreshToken,
+                    scope = scope,
+                    connectedByAdminUserId = adminUserId,
+                    connectedAt = now,
+                ),
+            )
+        }
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleLockedUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleLockedUseCase.kt
@@ -1,0 +1,72 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.backoffice.oauth.dto.CentralGoogleConnectionStatusResponse
+import com.sclass.backoffice.oauth.dto.ConnectCentralGoogleRequest
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
+import com.sclass.common.exception.GoogleCalendarScopeMissingException
+import com.sclass.common.exception.GoogleDriveScopeMissingException
+import com.sclass.common.exception.GoogleIdentityScopeMissingException
+import com.sclass.common.exception.GoogleOAuthStateInvalidException
+import com.sclass.common.exception.GoogleRefreshTokenMissingException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.oauth.exception.CentralGoogleAccountEmailNotAllowedException
+import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
+import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
+import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+
+@UseCase
+class ConnectCentralGoogleLockedUseCase(
+    private val googleClient: CentralGoogleAuthorizationCodeClient,
+    private val connectCentralGoogleAccountLockedUseCase: ConnectCentralGoogleAccountLockedUseCase,
+    private val encryptor: AesTokenEncryptor,
+    private val stateStore: GoogleOAuthStateStore,
+    private val properties: GoogleCentralCalendarProperties,
+) {
+    @DistributedLock(prefix = "central-google-account", waitTime = 30)
+    fun execute(
+        @LockKey provider: String,
+        adminUserId: String,
+        request: ConnectCentralGoogleRequest,
+    ): CentralGoogleConnectionStatusResponse {
+        if (!properties.enabled) throw GoogleCalendarCentralDisabledException()
+        if (!stateStore.consume(adminUserId, request.state)) throw GoogleOAuthStateInvalidException()
+
+        val allowedEmail = properties.requireAllowedEmail()
+        val tokens = googleClient.exchangeCodeForTokens(request.code, request.redirectUri)
+        val refreshToken = tokens.refreshToken ?: throw GoogleRefreshTokenMissingException()
+        val grantedScopes = tokens.scope.toScopeSet()
+        if (!grantedScopes.hasGoogleEmailScope()) throw GoogleIdentityScopeMissingException()
+        if (CentralGoogleOAuthScopes.GOOGLE_CALENDAR_EVENTS_SCOPE !in grantedScopes) throw GoogleCalendarScopeMissingException()
+        if (CentralGoogleOAuthScopes.GOOGLE_DRIVE_MEET_READONLY_SCOPE !in grantedScopes) throw GoogleDriveScopeMissingException()
+
+        val userInfo = googleClient.fetchUserInfo(tokens.accessToken)
+        if (!userInfo.email.equals(allowedEmail, ignoreCase = true)) {
+            throw CentralGoogleAccountEmailNotAllowedException()
+        }
+
+        val encryptedRefreshToken = encryptor.encrypt(refreshToken)
+        val account =
+            connectCentralGoogleAccountLockedUseCase.execute(
+                provider = provider,
+                googleEmail = userInfo.email,
+                encryptedRefreshToken = encryptedRefreshToken,
+                scope = tokens.scope,
+                adminUserId = adminUserId,
+            )
+
+        return CentralGoogleConnectionStatusResponse.connected(
+            account = account,
+            allowedEmail = allowedEmail,
+        )
+    }
+
+    private fun String.toScopeSet(): Set<String> =
+        split(" ")
+            .filter { it.isNotBlank() }
+            .toSet()
+
+    private fun Set<String>.hasGoogleEmailScope(): Boolean = any { it in CentralGoogleOAuthScopes.googleEmailScopes }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCase.kt
@@ -4,6 +4,7 @@ import com.sclass.backoffice.oauth.dto.CentralGoogleConnectionStatusResponse
 import com.sclass.backoffice.oauth.dto.ConnectCentralGoogleRequest
 import com.sclass.common.annotation.UseCase
 import com.sclass.common.exception.GoogleCalendarScopeMissingException
+import com.sclass.common.exception.GoogleDriveScopeMissingException
 import com.sclass.common.exception.GoogleIdentityScopeMissingException
 import com.sclass.common.exception.GoogleOAuthStateInvalidException
 import com.sclass.common.exception.GoogleRefreshTokenMissingException
@@ -12,7 +13,7 @@ import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
 import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
 import com.sclass.domain.domains.oauth.exception.CentralGoogleAccountEmailNotAllowedException
 import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
-import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
 import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
@@ -20,7 +21,7 @@ import java.time.LocalDateTime
 
 @UseCase
 class ConnectCentralGoogleUseCase(
-    private val googleClient: GoogleAuthorizationCodeClient,
+    private val googleClient: CentralGoogleAuthorizationCodeClient,
     private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
     private val encryptor: AesTokenEncryptor,
     private val stateStore: GoogleOAuthStateStore,
@@ -39,7 +40,8 @@ class ConnectCentralGoogleUseCase(
         val refreshToken = tokens.refreshToken ?: throw GoogleRefreshTokenMissingException()
         val grantedScopes = tokens.scope.toScopeSet()
         if (!grantedScopes.hasGoogleEmailScope()) throw GoogleIdentityScopeMissingException()
-        if (GOOGLE_CALENDAR_EVENTS_SCOPE !in grantedScopes) throw GoogleCalendarScopeMissingException()
+        if (CentralGoogleOAuthScopes.GOOGLE_CALENDAR_EVENTS_SCOPE !in grantedScopes) throw GoogleCalendarScopeMissingException()
+        if (CentralGoogleOAuthScopes.GOOGLE_DRIVE_MEET_READONLY_SCOPE !in grantedScopes) throw GoogleDriveScopeMissingException()
 
         val userInfo = googleClient.fetchUserInfo(tokens.accessToken)
         if (!userInfo.email.equals(allowedEmail, ignoreCase = true)) {
@@ -79,14 +81,5 @@ class ConnectCentralGoogleUseCase(
             .filter { it.isNotBlank() }
             .toSet()
 
-    private fun Set<String>.hasGoogleEmailScope(): Boolean = any { it in GOOGLE_EMAIL_SCOPES }
-
-    companion object {
-        private const val GOOGLE_CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
-        private val GOOGLE_EMAIL_SCOPES =
-            setOf(
-                "email",
-                "https://www.googleapis.com/auth/userinfo.email",
-            )
-    }
+    private fun Set<String>.hasGoogleEmailScope(): Boolean = any { it in CentralGoogleOAuthScopes.googleEmailScopes }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCase.kt
@@ -3,67 +3,19 @@ package com.sclass.backoffice.oauth.usecase
 import com.sclass.backoffice.oauth.dto.CentralGoogleConnectionStatusResponse
 import com.sclass.backoffice.oauth.dto.ConnectCentralGoogleRequest
 import com.sclass.common.annotation.UseCase
-import com.sclass.common.exception.GoogleCalendarCentralDisabledException
-import com.sclass.common.exception.GoogleCalendarScopeMissingException
-import com.sclass.common.exception.GoogleDriveScopeMissingException
-import com.sclass.common.exception.GoogleIdentityScopeMissingException
-import com.sclass.common.exception.GoogleOAuthStateInvalidException
-import com.sclass.common.exception.GoogleRefreshTokenMissingException
-import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
-import com.sclass.domain.domains.oauth.exception.CentralGoogleAccountEmailNotAllowedException
-import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
-import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
-import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
 
 @UseCase
 class ConnectCentralGoogleUseCase(
-    private val googleClient: CentralGoogleAuthorizationCodeClient,
-    private val connectCentralGoogleAccountLockedUseCase: ConnectCentralGoogleAccountLockedUseCase,
-    private val encryptor: AesTokenEncryptor,
-    private val stateStore: GoogleOAuthStateStore,
-    private val properties: GoogleCentralCalendarProperties,
+    private val connectCentralGoogleLockedUseCase: ConnectCentralGoogleLockedUseCase,
 ) {
     fun execute(
         adminUserId: String,
         request: ConnectCentralGoogleRequest,
-    ): CentralGoogleConnectionStatusResponse {
-        if (!properties.enabled) throw GoogleCalendarCentralDisabledException()
-        if (!stateStore.consume(adminUserId, request.state)) throw GoogleOAuthStateInvalidException()
-
-        val allowedEmail = properties.requireAllowedEmail()
-        val tokens = googleClient.exchangeCodeForTokens(request.code, request.redirectUri)
-        val refreshToken = tokens.refreshToken ?: throw GoogleRefreshTokenMissingException()
-        val grantedScopes = tokens.scope.toScopeSet()
-        if (!grantedScopes.hasGoogleEmailScope()) throw GoogleIdentityScopeMissingException()
-        if (CentralGoogleOAuthScopes.GOOGLE_CALENDAR_EVENTS_SCOPE !in grantedScopes) throw GoogleCalendarScopeMissingException()
-        if (CentralGoogleOAuthScopes.GOOGLE_DRIVE_MEET_READONLY_SCOPE !in grantedScopes) throw GoogleDriveScopeMissingException()
-
-        val userInfo = googleClient.fetchUserInfo(tokens.accessToken)
-        if (!userInfo.email.equals(allowedEmail, ignoreCase = true)) {
-            throw CentralGoogleAccountEmailNotAllowedException()
-        }
-
-        val encryptedRefreshToken = encryptor.encrypt(refreshToken)
-        val account =
-            connectCentralGoogleAccountLockedUseCase.execute(
-                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
-                googleEmail = userInfo.email,
-                encryptedRefreshToken = encryptedRefreshToken,
-                scope = tokens.scope,
-                adminUserId = adminUserId,
-            )
-
-        return CentralGoogleConnectionStatusResponse.connected(
-            account = account,
-            allowedEmail = allowedEmail,
+    ): CentralGoogleConnectionStatusResponse =
+        connectCentralGoogleLockedUseCase.execute(
+            provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+            adminUserId = adminUserId,
+            request = request,
         )
-    }
-
-    private fun String.toScopeSet(): Set<String> =
-        split(" ")
-            .filter { it.isNotBlank() }
-            .toSet()
-
-    private fun Set<String>.hasGoogleEmailScope(): Boolean = any { it in CentralGoogleOAuthScopes.googleEmailScopes }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCase.kt
@@ -3,36 +3,32 @@ package com.sclass.backoffice.oauth.usecase
 import com.sclass.backoffice.oauth.dto.CentralGoogleConnectionStatusResponse
 import com.sclass.backoffice.oauth.dto.ConnectCentralGoogleRequest
 import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
 import com.sclass.common.exception.GoogleCalendarScopeMissingException
 import com.sclass.common.exception.GoogleDriveScopeMissingException
 import com.sclass.common.exception.GoogleIdentityScopeMissingException
 import com.sclass.common.exception.GoogleOAuthStateInvalidException
 import com.sclass.common.exception.GoogleRefreshTokenMissingException
 import com.sclass.common.jwt.AesTokenEncryptor
-import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
 import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
 import com.sclass.domain.domains.oauth.exception.CentralGoogleAccountEmailNotAllowedException
 import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
 import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
 import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
-import org.springframework.transaction.annotation.Transactional
-import java.time.Clock
-import java.time.LocalDateTime
 
 @UseCase
 class ConnectCentralGoogleUseCase(
     private val googleClient: CentralGoogleAuthorizationCodeClient,
-    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val connectCentralGoogleAccountLockedUseCase: ConnectCentralGoogleAccountLockedUseCase,
     private val encryptor: AesTokenEncryptor,
     private val stateStore: GoogleOAuthStateStore,
     private val properties: GoogleCentralCalendarProperties,
-    private val clock: Clock = Clock.systemDefaultZone(),
 ) {
-    @Transactional
     fun execute(
         adminUserId: String,
         request: ConnectCentralGoogleRequest,
     ): CentralGoogleConnectionStatusResponse {
+        if (!properties.enabled) throw GoogleCalendarCentralDisabledException()
         if (!stateStore.consume(adminUserId, request.state)) throw GoogleOAuthStateInvalidException()
 
         val allowedEmail = properties.requireAllowedEmail()
@@ -48,30 +44,18 @@ class ConnectCentralGoogleUseCase(
             throw CentralGoogleAccountEmailNotAllowedException()
         }
 
-        val now = LocalDateTime.now(clock)
         val encryptedRefreshToken = encryptor.encrypt(refreshToken)
         val account =
-            centralGoogleAccountAdaptor
-                .findGoogleOrNull()
-                ?.apply {
-                    reconnect(
-                        newGoogleEmail = userInfo.email,
-                        newEncryptedRefreshToken = encryptedRefreshToken,
-                        newScope = tokens.scope,
-                        adminUserId = adminUserId,
-                        at = now,
-                    )
-                }
-                ?: CentralGoogleAccount(
-                    googleEmail = userInfo.email,
-                    encryptedRefreshToken = encryptedRefreshToken,
-                    scope = tokens.scope,
-                    connectedByAdminUserId = adminUserId,
-                    connectedAt = now,
-                )
+            connectCentralGoogleAccountLockedUseCase.execute(
+                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+                googleEmail = userInfo.email,
+                encryptedRefreshToken = encryptedRefreshToken,
+                scope = tokens.scope,
+                adminUserId = adminUserId,
+            )
 
         return CentralGoogleConnectionStatusResponse.connected(
-            account = centralGoogleAccountAdaptor.save(account),
+            account = account,
             allowedEmail = allowedEmail,
         )
     }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCase.kt
@@ -1,0 +1,92 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.backoffice.oauth.dto.CentralGoogleConnectionStatusResponse
+import com.sclass.backoffice.oauth.dto.ConnectCentralGoogleRequest
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.GoogleCalendarScopeMissingException
+import com.sclass.common.exception.GoogleIdentityScopeMissingException
+import com.sclass.common.exception.GoogleOAuthStateInvalidException
+import com.sclass.common.exception.GoogleRefreshTokenMissingException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.domain.domains.oauth.exception.CentralGoogleAccountEmailNotAllowedException
+import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
+import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+
+@UseCase
+class ConnectCentralGoogleUseCase(
+    private val googleClient: GoogleAuthorizationCodeClient,
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val encryptor: AesTokenEncryptor,
+    private val stateStore: GoogleOAuthStateStore,
+    private val properties: GoogleCentralCalendarProperties,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    @Transactional
+    fun execute(
+        adminUserId: String,
+        request: ConnectCentralGoogleRequest,
+    ): CentralGoogleConnectionStatusResponse {
+        if (!stateStore.consume(adminUserId, request.state)) throw GoogleOAuthStateInvalidException()
+
+        val allowedEmail = properties.requireAllowedEmail()
+        val tokens = googleClient.exchangeCodeForTokens(request.code, request.redirectUri)
+        val refreshToken = tokens.refreshToken ?: throw GoogleRefreshTokenMissingException()
+        val grantedScopes = tokens.scope.toScopeSet()
+        if (!grantedScopes.hasGoogleEmailScope()) throw GoogleIdentityScopeMissingException()
+        if (GOOGLE_CALENDAR_EVENTS_SCOPE !in grantedScopes) throw GoogleCalendarScopeMissingException()
+
+        val userInfo = googleClient.fetchUserInfo(tokens.accessToken)
+        if (!userInfo.email.equals(allowedEmail, ignoreCase = true)) {
+            throw CentralGoogleAccountEmailNotAllowedException()
+        }
+
+        val now = LocalDateTime.now(clock)
+        val encryptedRefreshToken = encryptor.encrypt(refreshToken)
+        val account =
+            centralGoogleAccountAdaptor
+                .findGoogleOrNull()
+                ?.apply {
+                    reconnect(
+                        newGoogleEmail = userInfo.email,
+                        newEncryptedRefreshToken = encryptedRefreshToken,
+                        newScope = tokens.scope,
+                        adminUserId = adminUserId,
+                        at = now,
+                    )
+                }
+                ?: CentralGoogleAccount(
+                    googleEmail = userInfo.email,
+                    encryptedRefreshToken = encryptedRefreshToken,
+                    scope = tokens.scope,
+                    connectedByAdminUserId = adminUserId,
+                    connectedAt = now,
+                )
+
+        return CentralGoogleConnectionStatusResponse.connected(
+            account = centralGoogleAccountAdaptor.save(account),
+            allowedEmail = allowedEmail,
+        )
+    }
+
+    private fun String.toScopeSet(): Set<String> =
+        split(" ")
+            .filter { it.isNotBlank() }
+            .toSet()
+
+    private fun Set<String>.hasGoogleEmailScope(): Boolean = any { it in GOOGLE_EMAIL_SCOPES }
+
+    companion object {
+        private const val GOOGLE_CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
+        private val GOOGLE_EMAIL_SCOPES =
+            setOf(
+                "email",
+                "https://www.googleapis.com/auth/userinfo.email",
+            )
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/DisconnectCentralGoogleAccountLockedUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/DisconnectCentralGoogleAccountLockedUseCase.kt
@@ -1,0 +1,35 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import org.slf4j.LoggerFactory
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class DisconnectCentralGoogleAccountLockedUseCase(
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val googleClient: CentralGoogleAuthorizationCodeClient,
+    private val encryptor: AesTokenEncryptor,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @DistributedLock(prefix = "central-google-account", waitTime = 30)
+    @Transactional
+    fun execute(
+        @LockKey provider: String,
+    ) {
+        val account = centralGoogleAccountAdaptor.findGoogleOrNull() ?: return
+
+        runCatching {
+            googleClient.revokeRefreshToken(encryptor.decrypt(account.encryptedRefreshToken))
+        }.onFailure {
+            log.warn("Central Google token revoke failed (DB delete continues)", it)
+        }
+
+        centralGoogleAccountAdaptor.deleteGoogle()
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/DisconnectCentralGoogleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/DisconnectCentralGoogleUseCase.kt
@@ -3,14 +3,14 @@ package com.sclass.backoffice.oauth.usecase
 import com.sclass.common.annotation.UseCase
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
-import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
 import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class DisconnectCentralGoogleUseCase(
     private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
-    private val googleClient: GoogleAuthorizationCodeClient,
+    private val googleClient: CentralGoogleAuthorizationCodeClient,
     private val encryptor: AesTokenEncryptor,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/DisconnectCentralGoogleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/DisconnectCentralGoogleUseCase.kt
@@ -1,0 +1,28 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import org.slf4j.LoggerFactory
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class DisconnectCentralGoogleUseCase(
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val googleClient: GoogleAuthorizationCodeClient,
+    private val encryptor: AesTokenEncryptor,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun execute() {
+        val account = centralGoogleAccountAdaptor.findGoogleOrNull() ?: return
+        runCatching {
+            googleClient.revokeRefreshToken(encryptor.decrypt(account.encryptedRefreshToken))
+        }.onFailure {
+            log.warn("Central Google token revoke failed (DB delete continues)", it)
+        }
+        centralGoogleAccountAdaptor.deleteGoogle()
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/DisconnectCentralGoogleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/DisconnectCentralGoogleUseCase.kt
@@ -1,28 +1,11 @@
 package com.sclass.backoffice.oauth.usecase
 
 import com.sclass.common.annotation.UseCase
-import com.sclass.common.jwt.AesTokenEncryptor
-import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
-import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
-import org.slf4j.LoggerFactory
-import org.springframework.transaction.annotation.Transactional
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
 
 @UseCase
 class DisconnectCentralGoogleUseCase(
-    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
-    private val googleClient: CentralGoogleAuthorizationCodeClient,
-    private val encryptor: AesTokenEncryptor,
+    private val disconnectCentralGoogleAccountLockedUseCase: DisconnectCentralGoogleAccountLockedUseCase,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
-
-    @Transactional
-    fun execute() {
-        val account = centralGoogleAccountAdaptor.findGoogleOrNull() ?: return
-        runCatching {
-            googleClient.revokeRefreshToken(encryptor.decrypt(account.encryptedRefreshToken))
-        }.onFailure {
-            log.warn("Central Google token revoke failed (DB delete continues)", it)
-        }
-        centralGoogleAccountAdaptor.deleteGoogle()
-    }
+    fun execute() = disconnectCentralGoogleAccountLockedUseCase.execute(CentralGoogleAccount.PROVIDER_GOOGLE)
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/GetCentralGoogleConnectionStatusUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/GetCentralGoogleConnectionStatusUseCase.kt
@@ -1,0 +1,23 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.backoffice.oauth.dto.CentralGoogleConnectionStatusResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class GetCentralGoogleConnectionStatusUseCase(
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val properties: GoogleCentralCalendarProperties,
+) {
+    @Transactional(readOnly = true)
+    fun execute(): CentralGoogleConnectionStatusResponse {
+        val allowedEmail = properties.allowedEmail.takeIf { it.isNotBlank() }
+        val account = centralGoogleAccountAdaptor.findGoogleOrNull()
+
+        return account
+            ?.let { CentralGoogleConnectionStatusResponse.connected(it, allowedEmail.orEmpty()) }
+            ?: CentralGoogleConnectionStatusResponse.notConnected(allowedEmail)
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/IssueCentralGoogleOAuthStateUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/IssueCentralGoogleOAuthStateUseCase.kt
@@ -2,17 +2,21 @@ package com.sclass.backoffice.oauth.usecase
 
 import com.sclass.backoffice.oauth.dto.CentralGoogleOAuthStateResponse
 import com.sclass.common.annotation.UseCase
+import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
 import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
 import java.time.Duration
 
 @UseCase
 class IssueCentralGoogleOAuthStateUseCase(
     private val stateStore: GoogleOAuthStateStore,
+    private val properties: GoogleCentralCalendarProperties,
 ) {
     fun execute(adminUserId: String): CentralGoogleOAuthStateResponse =
         CentralGoogleOAuthStateResponse(
             state = stateStore.issue(adminUserId, STATE_TTL),
             expiresInSeconds = STATE_TTL.seconds,
+            clientId = properties.requireClientId(),
+            scopes = CentralGoogleOAuthScopes.authorizationScopes,
         )
 
     companion object {

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/IssueCentralGoogleOAuthStateUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/IssueCentralGoogleOAuthStateUseCase.kt
@@ -2,6 +2,7 @@ package com.sclass.backoffice.oauth.usecase
 
 import com.sclass.backoffice.oauth.dto.CentralGoogleOAuthStateResponse
 import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
 import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
 import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
 import java.time.Duration
@@ -11,13 +12,16 @@ class IssueCentralGoogleOAuthStateUseCase(
     private val stateStore: GoogleOAuthStateStore,
     private val properties: GoogleCentralCalendarProperties,
 ) {
-    fun execute(adminUserId: String): CentralGoogleOAuthStateResponse =
-        CentralGoogleOAuthStateResponse(
+    fun execute(adminUserId: String): CentralGoogleOAuthStateResponse {
+        if (!properties.enabled) throw GoogleCalendarCentralDisabledException()
+
+        return CentralGoogleOAuthStateResponse(
             state = stateStore.issue(adminUserId, STATE_TTL),
             expiresInSeconds = STATE_TTL.seconds,
             clientId = properties.requireClientId(),
             scopes = CentralGoogleOAuthScopes.authorizationScopes,
         )
+    }
 
     companion object {
         private val STATE_TTL = Duration.ofMinutes(5)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/IssueCentralGoogleOAuthStateUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/oauth/usecase/IssueCentralGoogleOAuthStateUseCase.kt
@@ -1,0 +1,21 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.backoffice.oauth.dto.CentralGoogleOAuthStateResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
+import java.time.Duration
+
+@UseCase
+class IssueCentralGoogleOAuthStateUseCase(
+    private val stateStore: GoogleOAuthStateStore,
+) {
+    fun execute(adminUserId: String): CentralGoogleOAuthStateResponse =
+        CentralGoogleOAuthStateResponse(
+            state = stateStore.issue(adminUserId, STATE_TTL),
+            expiresInSeconds = STATE_TTL.seconds,
+        )
+
+    companion object {
+        private val STATE_TTL = Duration.ofMinutes(5)
+    }
+}

--- a/SClass-Api-Backoffice/src/main/resources/application.yml.example
+++ b/SClass-Api-Backoffice/src/main/resources/application.yml.example
@@ -62,6 +62,13 @@ oauth2:
     kakao:
       client-id: ${KAKAO_CLIENT_ID:}
 
+google:
+  calendar:
+    central:
+      enabled: ${GOOGLE_CALENDAR_CENTRAL_ENABLED:false}
+      calendar-id: ${GOOGLE_CALENDAR_CENTRAL_CALENDAR_ID:primary}
+      allowed-email: ${GOOGLE_CALENDAR_CENTRAL_ALLOWED_EMAIL:}
+
 alimtalk:
   enabled: ${ALIMTALK_ENABLED:false}
   service-id: ${ALIMTALK_SERVICE_ID:}

--- a/SClass-Api-Backoffice/src/main/resources/application.yml.example
+++ b/SClass-Api-Backoffice/src/main/resources/application.yml.example
@@ -68,6 +68,8 @@ google:
       enabled: ${GOOGLE_CALENDAR_CENTRAL_ENABLED:false}
       calendar-id: ${GOOGLE_CALENDAR_CENTRAL_CALENDAR_ID:primary}
       allowed-email: ${GOOGLE_CALENDAR_CENTRAL_ALLOWED_EMAIL:}
+      client-id: ${GOOGLE_CENTRAL_CLIENT_ID:}
+      client-secret: ${GOOGLE_CENTRAL_CLIENT_SECRET:}
 
 alimtalk:
   enabled: ${ALIMTALK_ENABLED:false}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleAccountLockedUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleAccountLockedUseCaseTest.kt
@@ -1,0 +1,123 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class ConnectCentralGoogleAccountLockedUseCaseTest {
+    private lateinit var centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor
+    private lateinit var useCase: ConnectCentralGoogleAccountLockedUseCase
+
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
+    private val clock =
+        Clock.fixed(
+            fixedNow.atZone(ZoneId.systemDefault()).toInstant(),
+            ZoneId.systemDefault(),
+        )
+
+    @BeforeEach
+    fun setUp() {
+        centralGoogleAccountAdaptor = mockk()
+        useCase = ConnectCentralGoogleAccountLockedUseCase(centralGoogleAccountAdaptor, clock)
+
+        every { centralGoogleAccountAdaptor.save(any()) } answers { firstArg() }
+    }
+
+    @Test
+    fun `신규 연결 시 lock 안에서 새 CentralGoogleAccount를 저장한다`() {
+        every { centralGoogleAccountAdaptor.findGoogleOrNull() } returns null
+
+        val account =
+            useCase.execute(
+                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+                googleEmail = "central-google@example.com",
+                encryptedRefreshToken = "encrypted-refresh-token",
+                scope = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar.events",
+                adminUserId = "admin-user-id-0000000001",
+            )
+
+        assertAll(
+            { assertEquals(CentralGoogleAccount.PROVIDER_GOOGLE, account.provider) },
+            { assertEquals("central-google@example.com", account.googleEmail) },
+            { assertEquals("encrypted-refresh-token", account.encryptedRefreshToken) },
+            { assertEquals("admin-user-id-0000000001", account.connectedByAdminUserId) },
+            { assertEquals(fixedNow, account.connectedAt) },
+        )
+        verify {
+            centralGoogleAccountAdaptor.save(
+                match<CentralGoogleAccount> {
+                    it.provider == CentralGoogleAccount.PROVIDER_GOOGLE &&
+                        it.googleEmail == "central-google@example.com" &&
+                        it.encryptedRefreshToken == "encrypted-refresh-token" &&
+                        it.connectedAt == fixedNow
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `기존 연결이 있으면 lock 안에서 reconnect로 토큰과 이메일이 갱신된다`() {
+        val existing =
+            CentralGoogleAccount(
+                googleEmail = "old-central-google@example.com",
+                encryptedRefreshToken = "old-token",
+                scope = "old-scope",
+                connectedByAdminUserId = "old-admin-user-id-00001",
+                connectedAt = fixedNow.minusDays(1),
+            )
+        every { centralGoogleAccountAdaptor.findGoogleOrNull() } returns existing
+
+        val account =
+            useCase.execute(
+                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+                googleEmail = "central-google@example.com",
+                encryptedRefreshToken = "new-encrypted-refresh-token",
+                scope = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar.events",
+                adminUserId = "admin-user-id-0000000001",
+            )
+
+        assertAll(
+            { assertEquals(existing, account) },
+            { assertEquals("central-google@example.com", existing.googleEmail) },
+            { assertEquals("new-encrypted-refresh-token", existing.encryptedRefreshToken) },
+            { assertEquals("admin-user-id-0000000001", existing.connectedByAdminUserId) },
+            { assertEquals(fixedNow, existing.connectedAt) },
+        )
+        verify { centralGoogleAccountAdaptor.save(existing) }
+    }
+
+    @Test
+    fun `동시 최초 연결 저장을 막기 위해 provider 기반 분산 락이 적용된다`() {
+        val method =
+            ConnectCentralGoogleAccountLockedUseCase::class.java.getDeclaredMethod(
+                "execute",
+                String::class.java,
+                String::class.java,
+                String::class.java,
+                String::class.java,
+                String::class.java,
+            )
+
+        val lock = method.getAnnotation(DistributedLock::class.java)
+
+        assertAll(
+            { assertNotNull(lock) },
+            { assertEquals("central-google-account", lock.prefix) },
+            { assertEquals(30L, lock.waitTime) },
+            { assertTrue(method.parameters[0].isAnnotationPresent(LockKey::class.java)) },
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleLockedUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleLockedUseCaseTest.kt
@@ -1,0 +1,220 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.backoffice.oauth.dto.ConnectCentralGoogleRequest
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
+import com.sclass.common.exception.GoogleDriveScopeMissingException
+import com.sclass.common.exception.GoogleOAuthStateInvalidException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.domain.domains.oauth.exception.CentralGoogleAccountEmailNotAllowedException
+import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
+import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
+import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
+import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
+import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class ConnectCentralGoogleLockedUseCaseTest {
+    private val grantedScope = CentralGoogleOAuthScopes.authorizationScopes.joinToString(" ")
+
+    private val googleClient: CentralGoogleAuthorizationCodeClient = mockk()
+    private val connectCentralGoogleAccountLockedUseCase: ConnectCentralGoogleAccountLockedUseCase = mockk()
+    private val encryptor: AesTokenEncryptor = mockk()
+    private val stateStore: GoogleOAuthStateStore = mockk()
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
+    private val properties =
+        GoogleCentralCalendarProperties().apply {
+            enabled = true
+            allowedEmail = "central-google@example.com"
+        }
+    private val useCase =
+        ConnectCentralGoogleLockedUseCase(
+            googleClient = googleClient,
+            connectCentralGoogleAccountLockedUseCase = connectCentralGoogleAccountLockedUseCase,
+            encryptor = encryptor,
+            stateStore = stateStore,
+            properties = properties,
+        )
+
+    @Test
+    fun `허용된 중앙 Google 계정이면 refresh token을 암호화하고 locked usecase에 저장을 위임한다`() {
+        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
+        val account =
+            CentralGoogleAccount(
+                googleEmail = "central-google@example.com",
+                encryptedRefreshToken = "encrypted-refresh-token",
+                scope = grantedScope,
+                connectedByAdminUserId = "admin-user-id-0000000001",
+                connectedAt = fixedNow,
+            )
+        every { stateStore.consume("admin-user-id-0000000001", "state") } returns true
+        every { googleClient.exchangeCodeForTokens("auth-code", "https://backoffice/callback") } returns
+            GoogleTokenExchangeResponse(
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                scope = grantedScope,
+            )
+        every { googleClient.fetchUserInfo("access-token") } returns
+            GoogleUserInfoResponse(
+                id = "google-user-id",
+                email = "central-google@example.com",
+            )
+        every { encryptor.encrypt("refresh-token") } returns "encrypted-refresh-token"
+        every {
+            connectCentralGoogleAccountLockedUseCase.execute(
+                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+                googleEmail = "central-google@example.com",
+                encryptedRefreshToken = "encrypted-refresh-token",
+                scope = grantedScope,
+                adminUserId = "admin-user-id-0000000001",
+            )
+        } returns account
+
+        val response =
+            useCase.execute(
+                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+                adminUserId = "admin-user-id-0000000001",
+                request = request,
+            )
+
+        assertAll(
+            { assertEquals(true, response.connected) },
+            { assertEquals("central-google@example.com", response.googleEmail) },
+            { assertEquals("central-google@example.com", response.allowedEmail) },
+            { assertEquals("admin-user-id-0000000001", response.connectedByAdminUserId) },
+            { assertEquals(fixedNow, response.connectedAt) },
+            { assertEquals(grantedScope, response.scope) },
+        )
+        verify {
+            connectCentralGoogleAccountLockedUseCase.execute(
+                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+                googleEmail = "central-google@example.com",
+                encryptedRefreshToken = "encrypted-refresh-token",
+                scope = grantedScope,
+                adminUserId = "admin-user-id-0000000001",
+            )
+        }
+    }
+
+    @Test
+    fun `중앙 Google Calendar 연동이 비활성화되어 있으면 state를 소비하지 않는다`() {
+        val disabledUseCase =
+            ConnectCentralGoogleLockedUseCase(
+                googleClient = googleClient,
+                connectCentralGoogleAccountLockedUseCase = connectCentralGoogleAccountLockedUseCase,
+                encryptor = encryptor,
+                stateStore = stateStore,
+                properties = GoogleCentralCalendarProperties(),
+            )
+        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
+
+        assertThrows<GoogleCalendarCentralDisabledException> {
+            disabledUseCase.execute(
+                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+                adminUserId = "admin-user-id-0000000001",
+                request = request,
+            )
+        }
+
+        verify(exactly = 0) { stateStore.consume(any(), any()) }
+        verify(exactly = 0) { googleClient.exchangeCodeForTokens(any(), any()) }
+    }
+
+    @Test
+    fun `허용 이메일과 다른 Google 계정이면 저장하지 않는다`() {
+        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
+        every { stateStore.consume("admin-user-id-0000000001", "state") } returns true
+        every { googleClient.exchangeCodeForTokens("auth-code", "https://backoffice/callback") } returns
+            GoogleTokenExchangeResponse(
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                scope = grantedScope,
+            )
+        every { googleClient.fetchUserInfo("access-token") } returns
+            GoogleUserInfoResponse(
+                id = "google-user-id",
+                email = "other@example.com",
+            )
+
+        assertThrows<CentralGoogleAccountEmailNotAllowedException> {
+            useCase.execute(
+                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+                adminUserId = "admin-user-id-0000000001",
+                request = request,
+            )
+        }
+
+        verify(exactly = 0) { encryptor.encrypt(any()) }
+        verify(exactly = 0) { connectCentralGoogleAccountLockedUseCase.execute(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `state가 유효하지 않으면 Google token exchange를 호출하지 않는다`() {
+        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
+        every { stateStore.consume("admin-user-id-0000000001", "state") } returns false
+
+        assertThrows<GoogleOAuthStateInvalidException> {
+            useCase.execute(
+                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+                adminUserId = "admin-user-id-0000000001",
+                request = request,
+            )
+        }
+
+        verify(exactly = 0) { googleClient.exchangeCodeForTokens(any(), any()) }
+    }
+
+    @Test
+    fun `Google Meet 녹화 파일 조회 scope가 없으면 실패한다`() {
+        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
+        every { stateStore.consume("admin-user-id-0000000001", "state") } returns true
+        every { googleClient.exchangeCodeForTokens("auth-code", "https://backoffice/callback") } returns
+            GoogleTokenExchangeResponse(
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                scope = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar.events",
+            )
+
+        assertThrows<GoogleDriveScopeMissingException> {
+            useCase.execute(
+                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+                adminUserId = "admin-user-id-0000000001",
+                request = request,
+            )
+        }
+
+        verify(exactly = 0) { googleClient.fetchUserInfo(any()) }
+        verify(exactly = 0) { connectCentralGoogleAccountLockedUseCase.execute(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `connect와 disconnect 경합을 막기 위해 provider 기반 분산 락이 전체 연결 흐름에 적용된다`() {
+        val method =
+            ConnectCentralGoogleLockedUseCase::class.java.getDeclaredMethod(
+                "execute",
+                String::class.java,
+                String::class.java,
+                ConnectCentralGoogleRequest::class.java,
+            )
+
+        val lock = method.getAnnotation(DistributedLock::class.java)
+
+        assertAll(
+            { assertNotNull(lock) },
+            { assertEquals("central-google-account", lock.prefix) },
+            { assertEquals(30L, lock.waitTime) },
+            { assertTrue(method.parameters[0].isAnnotationPresent(LockKey::class.java)) },
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCaseTest.kt
@@ -1,175 +1,42 @@
 package com.sclass.backoffice.oauth.usecase
 
+import com.sclass.backoffice.oauth.dto.CentralGoogleConnectionStatusResponse
 import com.sclass.backoffice.oauth.dto.ConnectCentralGoogleRequest
-import com.sclass.common.exception.GoogleCalendarCentralDisabledException
-import com.sclass.common.exception.GoogleDriveScopeMissingException
-import com.sclass.common.exception.GoogleOAuthStateInvalidException
-import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
-import com.sclass.domain.domains.oauth.exception.CentralGoogleAccountEmailNotAllowedException
-import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
-import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
-import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
-import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
-import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.assertAll
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
-import java.time.LocalDateTime
 
 class ConnectCentralGoogleUseCaseTest {
-    private val grantedScope = CentralGoogleOAuthScopes.authorizationScopes.joinToString(" ")
-
-    private val googleClient: CentralGoogleAuthorizationCodeClient = mockk()
-    private val connectCentralGoogleAccountLockedUseCase: ConnectCentralGoogleAccountLockedUseCase = mockk()
-    private val encryptor: AesTokenEncryptor = mockk()
-    private val stateStore: GoogleOAuthStateStore = mockk()
-    private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
-    private val properties =
-        GoogleCentralCalendarProperties().apply {
-            enabled = true
-            allowedEmail = "central-google@example.com"
-        }
+    private val connectCentralGoogleLockedUseCase: ConnectCentralGoogleLockedUseCase = mockk()
     private val useCase =
         ConnectCentralGoogleUseCase(
-            googleClient = googleClient,
-            connectCentralGoogleAccountLockedUseCase = connectCentralGoogleAccountLockedUseCase,
-            encryptor = encryptor,
-            stateStore = stateStore,
-            properties = properties,
+            connectCentralGoogleLockedUseCase = connectCentralGoogleLockedUseCase,
         )
 
     @Test
-    fun `허용된 중앙 Google 계정이면 refresh token을 암호화하고 locked usecase에 저장을 위임한다`() {
+    fun `중앙 Google provider key로 locked usecase에 위임한다`() {
         val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
-        val account =
-            CentralGoogleAccount(
-                googleEmail = "central-google@example.com",
-                encryptedRefreshToken = "encrypted-refresh-token",
-                scope = grantedScope,
-                connectedByAdminUserId = "admin-user-id-0000000001",
-                connectedAt = fixedNow,
-            )
-        every { stateStore.consume("admin-user-id-0000000001", "state") } returns true
-        every { googleClient.exchangeCodeForTokens("auth-code", "https://backoffice/callback") } returns
-            GoogleTokenExchangeResponse(
-                accessToken = "access-token",
-                refreshToken = "refresh-token",
-                scope = grantedScope,
-            )
-        every { googleClient.fetchUserInfo("access-token") } returns
-            GoogleUserInfoResponse(
-                id = "google-user-id",
-                email = "central-google@example.com",
-            )
-        every { encryptor.encrypt("refresh-token") } returns "encrypted-refresh-token"
+        val expected = CentralGoogleConnectionStatusResponse.notConnected("central-google@example.com")
         every {
-            connectCentralGoogleAccountLockedUseCase.execute(
+            connectCentralGoogleLockedUseCase.execute(
                 provider = CentralGoogleAccount.PROVIDER_GOOGLE,
-                googleEmail = "central-google@example.com",
-                encryptedRefreshToken = "encrypted-refresh-token",
-                scope = grantedScope,
                 adminUserId = "admin-user-id-0000000001",
+                request = request,
             )
-        } returns account
+        } returns expected
 
         val response = useCase.execute("admin-user-id-0000000001", request)
 
-        assertAll(
-            { assertEquals(true, response.connected) },
-            { assertEquals("central-google@example.com", response.googleEmail) },
-            { assertEquals("central-google@example.com", response.allowedEmail) },
-            { assertEquals("admin-user-id-0000000001", response.connectedByAdminUserId) },
-            { assertEquals(fixedNow, response.connectedAt) },
-            { assertEquals(grantedScope, response.scope) },
-        )
+        assertSame(expected, response)
         verify {
-            connectCentralGoogleAccountLockedUseCase.execute(
+            connectCentralGoogleLockedUseCase.execute(
                 provider = CentralGoogleAccount.PROVIDER_GOOGLE,
-                googleEmail = "central-google@example.com",
-                encryptedRefreshToken = "encrypted-refresh-token",
-                scope = grantedScope,
                 adminUserId = "admin-user-id-0000000001",
+                request = request,
             )
         }
-    }
-
-    @Test
-    fun `중앙 Google Calendar 연동이 비활성화되어 있으면 state를 소비하지 않는다`() {
-        val disabledUseCase =
-            ConnectCentralGoogleUseCase(
-                googleClient = googleClient,
-                connectCentralGoogleAccountLockedUseCase = connectCentralGoogleAccountLockedUseCase,
-                encryptor = encryptor,
-                stateStore = stateStore,
-                properties = GoogleCentralCalendarProperties(),
-            )
-        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
-
-        assertThrows<GoogleCalendarCentralDisabledException> {
-            disabledUseCase.execute("admin-user-id-0000000001", request)
-        }
-
-        verify(exactly = 0) { stateStore.consume(any(), any()) }
-        verify(exactly = 0) { googleClient.exchangeCodeForTokens(any(), any()) }
-    }
-
-    @Test
-    fun `허용 이메일과 다른 Google 계정이면 저장하지 않는다`() {
-        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
-        every { stateStore.consume("admin-user-id-0000000001", "state") } returns true
-        every { googleClient.exchangeCodeForTokens("auth-code", "https://backoffice/callback") } returns
-            GoogleTokenExchangeResponse(
-                accessToken = "access-token",
-                refreshToken = "refresh-token",
-                scope = grantedScope,
-            )
-        every { googleClient.fetchUserInfo("access-token") } returns
-            GoogleUserInfoResponse(
-                id = "google-user-id",
-                email = "other@example.com",
-            )
-
-        assertThrows<CentralGoogleAccountEmailNotAllowedException> {
-            useCase.execute("admin-user-id-0000000001", request)
-        }
-
-        verify(exactly = 0) { encryptor.encrypt(any()) }
-        verify(exactly = 0) { connectCentralGoogleAccountLockedUseCase.execute(any(), any(), any(), any(), any()) }
-    }
-
-    @Test
-    fun `state가 유효하지 않으면 Google token exchange를 호출하지 않는다`() {
-        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
-        every { stateStore.consume("admin-user-id-0000000001", "state") } returns false
-
-        assertThrows<GoogleOAuthStateInvalidException> {
-            useCase.execute("admin-user-id-0000000001", request)
-        }
-
-        verify(exactly = 0) { googleClient.exchangeCodeForTokens(any(), any()) }
-    }
-
-    @Test
-    fun `Google Meet 녹화 파일 조회 scope가 없으면 실패한다`() {
-        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
-        every { stateStore.consume("admin-user-id-0000000001", "state") } returns true
-        every { googleClient.exchangeCodeForTokens("auth-code", "https://backoffice/callback") } returns
-            GoogleTokenExchangeResponse(
-                accessToken = "access-token",
-                refreshToken = "refresh-token",
-                scope = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar.events",
-            )
-
-        assertThrows<GoogleDriveScopeMissingException> {
-            useCase.execute("admin-user-id-0000000001", request)
-        }
-
-        verify(exactly = 0) { googleClient.fetchUserInfo(any()) }
-        verify(exactly = 0) { connectCentralGoogleAccountLockedUseCase.execute(any(), any(), any(), any(), any()) }
     }
 }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCaseTest.kt
@@ -1,13 +1,14 @@
 package com.sclass.backoffice.oauth.usecase
 
 import com.sclass.backoffice.oauth.dto.ConnectCentralGoogleRequest
+import com.sclass.common.exception.GoogleDriveScopeMissingException
 import com.sclass.common.exception.GoogleOAuthStateInvalidException
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
 import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
 import com.sclass.domain.domains.oauth.exception.CentralGoogleAccountEmailNotAllowedException
 import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
-import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
 import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
 import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
 import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
@@ -23,7 +24,9 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 
 class ConnectCentralGoogleUseCaseTest {
-    private val googleClient: GoogleAuthorizationCodeClient = mockk()
+    private val grantedScope = CentralGoogleOAuthScopes.authorizationScopes.joinToString(" ")
+
+    private val googleClient: CentralGoogleAuthorizationCodeClient = mockk()
     private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor = mockk()
     private val encryptor: AesTokenEncryptor = mockk()
     private val stateStore: GoogleOAuthStateStore = mockk()
@@ -55,7 +58,7 @@ class ConnectCentralGoogleUseCaseTest {
             GoogleTokenExchangeResponse(
                 accessToken = "access-token",
                 refreshToken = "refresh-token",
-                scope = "email https://www.googleapis.com/auth/calendar.events",
+                scope = grantedScope,
             )
         every { googleClient.fetchUserInfo("access-token") } returns
             GoogleUserInfoResponse(
@@ -74,7 +77,7 @@ class ConnectCentralGoogleUseCaseTest {
             { assertEquals("central-google@example.com", response.allowedEmail) },
             { assertEquals("admin-user-id-0000000001", response.connectedByAdminUserId) },
             { assertEquals(fixedNow, response.connectedAt) },
-            { assertEquals("email https://www.googleapis.com/auth/calendar.events", response.scope) },
+            { assertEquals(grantedScope, response.scope) },
         )
         verify {
             centralGoogleAccountAdaptor.save(
@@ -96,7 +99,7 @@ class ConnectCentralGoogleUseCaseTest {
             GoogleTokenExchangeResponse(
                 accessToken = "access-token",
                 refreshToken = "refresh-token",
-                scope = "email https://www.googleapis.com/auth/calendar.events",
+                scope = grantedScope,
             )
         every { googleClient.fetchUserInfo("access-token") } returns
             GoogleUserInfoResponse(
@@ -140,7 +143,7 @@ class ConnectCentralGoogleUseCaseTest {
             GoogleTokenExchangeResponse(
                 accessToken = "access-token",
                 refreshToken = "refresh-token",
-                scope = "email https://www.googleapis.com/auth/calendar.events",
+                scope = grantedScope,
             )
         every { googleClient.fetchUserInfo("access-token") } returns
             GoogleUserInfoResponse(
@@ -157,7 +160,26 @@ class ConnectCentralGoogleUseCaseTest {
             { assertEquals("new-encrypted-refresh-token", existing.encryptedRefreshToken) },
             { assertEquals("admin-user-id-0000000001", existing.connectedByAdminUserId) },
             { assertEquals(fixedNow, existing.connectedAt) },
-            { assertEquals("email https://www.googleapis.com/auth/calendar.events", existing.scope) },
+            { assertEquals(grantedScope, existing.scope) },
         )
+    }
+
+    @Test
+    fun `Google Meet 녹화 파일 조회 scope가 없으면 실패한다`() {
+        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
+        every { stateStore.consume("admin-user-id-0000000001", "state") } returns true
+        every { googleClient.exchangeCodeForTokens("auth-code", "https://backoffice/callback") } returns
+            GoogleTokenExchangeResponse(
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                scope = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar.events",
+            )
+
+        assertThrows<GoogleDriveScopeMissingException> {
+            useCase.execute("admin-user-id-0000000001", request)
+        }
+
+        verify(exactly = 0) { googleClient.fetchUserInfo(any()) }
+        verify(exactly = 0) { centralGoogleAccountAdaptor.save(any()) }
     }
 }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCaseTest.kt
@@ -1,0 +1,163 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.backoffice.oauth.dto.ConnectCentralGoogleRequest
+import com.sclass.common.exception.GoogleOAuthStateInvalidException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.domain.domains.oauth.exception.CentralGoogleAccountEmailNotAllowedException
+import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
+import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
+import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
+import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class ConnectCentralGoogleUseCaseTest {
+    private val googleClient: GoogleAuthorizationCodeClient = mockk()
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor = mockk()
+    private val encryptor: AesTokenEncryptor = mockk()
+    private val stateStore: GoogleOAuthStateStore = mockk()
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
+    private val clock =
+        Clock.fixed(
+            fixedNow.atZone(ZoneId.systemDefault()).toInstant(),
+            ZoneId.systemDefault(),
+        )
+    private val properties =
+        GoogleCentralCalendarProperties().apply {
+            allowedEmail = "central-google@example.com"
+        }
+    private val useCase =
+        ConnectCentralGoogleUseCase(
+            googleClient = googleClient,
+            centralGoogleAccountAdaptor = centralGoogleAccountAdaptor,
+            encryptor = encryptor,
+            stateStore = stateStore,
+            properties = properties,
+            clock = clock,
+        )
+
+    @Test
+    fun `허용된 중앙 Google 계정이면 refresh token을 암호화 저장한다`() {
+        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
+        every { stateStore.consume("admin-user-id-0000000001", "state") } returns true
+        every { googleClient.exchangeCodeForTokens("auth-code", "https://backoffice/callback") } returns
+            GoogleTokenExchangeResponse(
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                scope = "email https://www.googleapis.com/auth/calendar.events",
+            )
+        every { googleClient.fetchUserInfo("access-token") } returns
+            GoogleUserInfoResponse(
+                id = "google-user-id",
+                email = "central-google@example.com",
+            )
+        every { encryptor.encrypt("refresh-token") } returns "encrypted-refresh-token"
+        every { centralGoogleAccountAdaptor.findGoogleOrNull() } returns null
+        every { centralGoogleAccountAdaptor.save(any()) } answers { firstArg() }
+
+        val response = useCase.execute("admin-user-id-0000000001", request)
+
+        assertAll(
+            { assertEquals(true, response.connected) },
+            { assertEquals("central-google@example.com", response.googleEmail) },
+            { assertEquals("central-google@example.com", response.allowedEmail) },
+            { assertEquals("admin-user-id-0000000001", response.connectedByAdminUserId) },
+            { assertEquals(fixedNow, response.connectedAt) },
+            { assertEquals("email https://www.googleapis.com/auth/calendar.events", response.scope) },
+        )
+        verify {
+            centralGoogleAccountAdaptor.save(
+                match<CentralGoogleAccount> {
+                    it.googleEmail == "central-google@example.com" &&
+                        it.encryptedRefreshToken == "encrypted-refresh-token" &&
+                        it.connectedByAdminUserId == "admin-user-id-0000000001" &&
+                        it.connectedAt == fixedNow
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `허용 이메일과 다른 Google 계정이면 저장하지 않는다`() {
+        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
+        every { stateStore.consume("admin-user-id-0000000001", "state") } returns true
+        every { googleClient.exchangeCodeForTokens("auth-code", "https://backoffice/callback") } returns
+            GoogleTokenExchangeResponse(
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                scope = "email https://www.googleapis.com/auth/calendar.events",
+            )
+        every { googleClient.fetchUserInfo("access-token") } returns
+            GoogleUserInfoResponse(
+                id = "google-user-id",
+                email = "other@example.com",
+            )
+
+        assertThrows<CentralGoogleAccountEmailNotAllowedException> {
+            useCase.execute("admin-user-id-0000000001", request)
+        }
+
+        verify(exactly = 0) { encryptor.encrypt(any()) }
+        verify(exactly = 0) { centralGoogleAccountAdaptor.save(any()) }
+    }
+
+    @Test
+    fun `state가 유효하지 않으면 Google token exchange를 호출하지 않는다`() {
+        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
+        every { stateStore.consume("admin-user-id-0000000001", "state") } returns false
+
+        assertThrows<GoogleOAuthStateInvalidException> {
+            useCase.execute("admin-user-id-0000000001", request)
+        }
+
+        verify(exactly = 0) { googleClient.exchangeCodeForTokens(any(), any()) }
+    }
+
+    @Test
+    fun `기존 중앙 계정이 있으면 재연결 정보로 갱신한다`() {
+        val existing =
+            CentralGoogleAccount(
+                googleEmail = "central-google@example.com",
+                encryptedRefreshToken = "old-token",
+                scope = "old-scope",
+                connectedByAdminUserId = "old-admin-user-id-00001",
+                connectedAt = fixedNow.minusDays(1),
+            )
+        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
+        every { stateStore.consume("admin-user-id-0000000001", "state") } returns true
+        every { googleClient.exchangeCodeForTokens("auth-code", "https://backoffice/callback") } returns
+            GoogleTokenExchangeResponse(
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                scope = "email https://www.googleapis.com/auth/calendar.events",
+            )
+        every { googleClient.fetchUserInfo("access-token") } returns
+            GoogleUserInfoResponse(
+                id = "google-user-id",
+                email = "central-google@example.com",
+            )
+        every { encryptor.encrypt("refresh-token") } returns "new-encrypted-refresh-token"
+        every { centralGoogleAccountAdaptor.findGoogleOrNull() } returns existing
+        every { centralGoogleAccountAdaptor.save(existing) } returns existing
+
+        useCase.execute("admin-user-id-0000000001", request)
+
+        assertAll(
+            { assertEquals("new-encrypted-refresh-token", existing.encryptedRefreshToken) },
+            { assertEquals("admin-user-id-0000000001", existing.connectedByAdminUserId) },
+            { assertEquals(fixedNow, existing.connectedAt) },
+            { assertEquals("email https://www.googleapis.com/auth/calendar.events", existing.scope) },
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/ConnectCentralGoogleUseCaseTest.kt
@@ -1,10 +1,10 @@
 package com.sclass.backoffice.oauth.usecase
 
 import com.sclass.backoffice.oauth.dto.ConnectCentralGoogleRequest
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
 import com.sclass.common.exception.GoogleDriveScopeMissingException
 import com.sclass.common.exception.GoogleOAuthStateInvalidException
 import com.sclass.common.jwt.AesTokenEncryptor
-import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
 import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
 import com.sclass.domain.domains.oauth.exception.CentralGoogleAccountEmailNotAllowedException
 import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
@@ -19,40 +19,41 @@ import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.time.Clock
 import java.time.LocalDateTime
-import java.time.ZoneId
 
 class ConnectCentralGoogleUseCaseTest {
     private val grantedScope = CentralGoogleOAuthScopes.authorizationScopes.joinToString(" ")
 
     private val googleClient: CentralGoogleAuthorizationCodeClient = mockk()
-    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor = mockk()
+    private val connectCentralGoogleAccountLockedUseCase: ConnectCentralGoogleAccountLockedUseCase = mockk()
     private val encryptor: AesTokenEncryptor = mockk()
     private val stateStore: GoogleOAuthStateStore = mockk()
     private val fixedNow = LocalDateTime.of(2026, 4, 26, 14, 0)
-    private val clock =
-        Clock.fixed(
-            fixedNow.atZone(ZoneId.systemDefault()).toInstant(),
-            ZoneId.systemDefault(),
-        )
     private val properties =
         GoogleCentralCalendarProperties().apply {
+            enabled = true
             allowedEmail = "central-google@example.com"
         }
     private val useCase =
         ConnectCentralGoogleUseCase(
             googleClient = googleClient,
-            centralGoogleAccountAdaptor = centralGoogleAccountAdaptor,
+            connectCentralGoogleAccountLockedUseCase = connectCentralGoogleAccountLockedUseCase,
             encryptor = encryptor,
             stateStore = stateStore,
             properties = properties,
-            clock = clock,
         )
 
     @Test
-    fun `허용된 중앙 Google 계정이면 refresh token을 암호화 저장한다`() {
+    fun `허용된 중앙 Google 계정이면 refresh token을 암호화하고 locked usecase에 저장을 위임한다`() {
         val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
+        val account =
+            CentralGoogleAccount(
+                googleEmail = "central-google@example.com",
+                encryptedRefreshToken = "encrypted-refresh-token",
+                scope = grantedScope,
+                connectedByAdminUserId = "admin-user-id-0000000001",
+                connectedAt = fixedNow,
+            )
         every { stateStore.consume("admin-user-id-0000000001", "state") } returns true
         every { googleClient.exchangeCodeForTokens("auth-code", "https://backoffice/callback") } returns
             GoogleTokenExchangeResponse(
@@ -66,8 +67,15 @@ class ConnectCentralGoogleUseCaseTest {
                 email = "central-google@example.com",
             )
         every { encryptor.encrypt("refresh-token") } returns "encrypted-refresh-token"
-        every { centralGoogleAccountAdaptor.findGoogleOrNull() } returns null
-        every { centralGoogleAccountAdaptor.save(any()) } answers { firstArg() }
+        every {
+            connectCentralGoogleAccountLockedUseCase.execute(
+                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+                googleEmail = "central-google@example.com",
+                encryptedRefreshToken = "encrypted-refresh-token",
+                scope = grantedScope,
+                adminUserId = "admin-user-id-0000000001",
+            )
+        } returns account
 
         val response = useCase.execute("admin-user-id-0000000001", request)
 
@@ -80,15 +88,34 @@ class ConnectCentralGoogleUseCaseTest {
             { assertEquals(grantedScope, response.scope) },
         )
         verify {
-            centralGoogleAccountAdaptor.save(
-                match<CentralGoogleAccount> {
-                    it.googleEmail == "central-google@example.com" &&
-                        it.encryptedRefreshToken == "encrypted-refresh-token" &&
-                        it.connectedByAdminUserId == "admin-user-id-0000000001" &&
-                        it.connectedAt == fixedNow
-                },
+            connectCentralGoogleAccountLockedUseCase.execute(
+                provider = CentralGoogleAccount.PROVIDER_GOOGLE,
+                googleEmail = "central-google@example.com",
+                encryptedRefreshToken = "encrypted-refresh-token",
+                scope = grantedScope,
+                adminUserId = "admin-user-id-0000000001",
             )
         }
+    }
+
+    @Test
+    fun `중앙 Google Calendar 연동이 비활성화되어 있으면 state를 소비하지 않는다`() {
+        val disabledUseCase =
+            ConnectCentralGoogleUseCase(
+                googleClient = googleClient,
+                connectCentralGoogleAccountLockedUseCase = connectCentralGoogleAccountLockedUseCase,
+                encryptor = encryptor,
+                stateStore = stateStore,
+                properties = GoogleCentralCalendarProperties(),
+            )
+        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
+
+        assertThrows<GoogleCalendarCentralDisabledException> {
+            disabledUseCase.execute("admin-user-id-0000000001", request)
+        }
+
+        verify(exactly = 0) { stateStore.consume(any(), any()) }
+        verify(exactly = 0) { googleClient.exchangeCodeForTokens(any(), any()) }
     }
 
     @Test
@@ -112,7 +139,7 @@ class ConnectCentralGoogleUseCaseTest {
         }
 
         verify(exactly = 0) { encryptor.encrypt(any()) }
-        verify(exactly = 0) { centralGoogleAccountAdaptor.save(any()) }
+        verify(exactly = 0) { connectCentralGoogleAccountLockedUseCase.execute(any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -125,43 +152,6 @@ class ConnectCentralGoogleUseCaseTest {
         }
 
         verify(exactly = 0) { googleClient.exchangeCodeForTokens(any(), any()) }
-    }
-
-    @Test
-    fun `기존 중앙 계정이 있으면 재연결 정보로 갱신한다`() {
-        val existing =
-            CentralGoogleAccount(
-                googleEmail = "central-google@example.com",
-                encryptedRefreshToken = "old-token",
-                scope = "old-scope",
-                connectedByAdminUserId = "old-admin-user-id-00001",
-                connectedAt = fixedNow.minusDays(1),
-            )
-        val request = ConnectCentralGoogleRequest(code = "auth-code", redirectUri = "https://backoffice/callback", state = "state")
-        every { stateStore.consume("admin-user-id-0000000001", "state") } returns true
-        every { googleClient.exchangeCodeForTokens("auth-code", "https://backoffice/callback") } returns
-            GoogleTokenExchangeResponse(
-                accessToken = "access-token",
-                refreshToken = "refresh-token",
-                scope = grantedScope,
-            )
-        every { googleClient.fetchUserInfo("access-token") } returns
-            GoogleUserInfoResponse(
-                id = "google-user-id",
-                email = "central-google@example.com",
-            )
-        every { encryptor.encrypt("refresh-token") } returns "new-encrypted-refresh-token"
-        every { centralGoogleAccountAdaptor.findGoogleOrNull() } returns existing
-        every { centralGoogleAccountAdaptor.save(existing) } returns existing
-
-        useCase.execute("admin-user-id-0000000001", request)
-
-        assertAll(
-            { assertEquals("new-encrypted-refresh-token", existing.encryptedRefreshToken) },
-            { assertEquals("admin-user-id-0000000001", existing.connectedByAdminUserId) },
-            { assertEquals(fixedNow, existing.connectedAt) },
-            { assertEquals(grantedScope, existing.scope) },
-        )
     }
 
     @Test
@@ -180,6 +170,6 @@ class ConnectCentralGoogleUseCaseTest {
         }
 
         verify(exactly = 0) { googleClient.fetchUserInfo(any()) }
-        verify(exactly = 0) { centralGoogleAccountAdaptor.save(any()) }
+        verify(exactly = 0) { connectCentralGoogleAccountLockedUseCase.execute(any(), any(), any(), any(), any()) }
     }
 }

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/DisconnectCentralGoogleAccountLockedUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/DisconnectCentralGoogleAccountLockedUseCaseTest.kt
@@ -1,0 +1,104 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
+import com.sclass.infrastructure.redis.DistributedLock
+import com.sclass.infrastructure.redis.LockKey
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class DisconnectCentralGoogleAccountLockedUseCaseTest {
+    private lateinit var centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor
+    private lateinit var googleClient: CentralGoogleAuthorizationCodeClient
+    private lateinit var encryptor: AesTokenEncryptor
+    private lateinit var useCase: DisconnectCentralGoogleAccountLockedUseCase
+
+    @BeforeEach
+    fun setUp() {
+        centralGoogleAccountAdaptor = mockk()
+        googleClient = mockk()
+        encryptor = mockk()
+        useCase = DisconnectCentralGoogleAccountLockedUseCase(centralGoogleAccountAdaptor, googleClient, encryptor)
+    }
+
+    private fun account() =
+        CentralGoogleAccount(
+            googleEmail = "central-google@example.com",
+            encryptedRefreshToken = "encrypted-refresh-token",
+            scope = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar.events",
+            connectedByAdminUserId = "admin-user-id-0000000001",
+            connectedAt = LocalDateTime.of(2026, 4, 26, 14, 0),
+        )
+
+    @Test
+    fun `연결된 중앙 계정이 있으면 Google revoke 후 DB 삭제`() {
+        every { centralGoogleAccountAdaptor.findGoogleOrNull() } returns account()
+        every { encryptor.decrypt("encrypted-refresh-token") } returns "raw-refresh-token"
+        every { googleClient.revokeRefreshToken("raw-refresh-token") } just Runs
+        every { centralGoogleAccountAdaptor.deleteGoogle() } just Runs
+
+        useCase.execute(CentralGoogleAccount.PROVIDER_GOOGLE)
+
+        verify { googleClient.revokeRefreshToken("raw-refresh-token") }
+        verify { centralGoogleAccountAdaptor.deleteGoogle() }
+    }
+
+    @Test
+    fun `연결된 중앙 계정이 없으면 아무 동작 없이 종료`() {
+        every { centralGoogleAccountAdaptor.findGoogleOrNull() } returns null
+
+        useCase.execute(CentralGoogleAccount.PROVIDER_GOOGLE)
+
+        verify(exactly = 0) { googleClient.revokeRefreshToken(any()) }
+        verify(exactly = 0) { centralGoogleAccountAdaptor.deleteGoogle() }
+    }
+
+    @Test
+    fun `복호화 실패해도 DB 삭제는 진행된다`() {
+        every { centralGoogleAccountAdaptor.findGoogleOrNull() } returns account()
+        every { encryptor.decrypt(any()) } throws RuntimeException("decrypt failed")
+        every { centralGoogleAccountAdaptor.deleteGoogle() } just Runs
+
+        useCase.execute(CentralGoogleAccount.PROVIDER_GOOGLE)
+
+        verify(exactly = 0) { googleClient.revokeRefreshToken(any()) }
+        verify { centralGoogleAccountAdaptor.deleteGoogle() }
+    }
+
+    @Test
+    fun `Google revoke 호출이 예외를 던져도 DB 삭제는 진행된다`() {
+        every { centralGoogleAccountAdaptor.findGoogleOrNull() } returns account()
+        every { encryptor.decrypt(any()) } returns "raw-refresh-token"
+        every { googleClient.revokeRefreshToken(any()) } throws RuntimeException("revoke failed")
+        every { centralGoogleAccountAdaptor.deleteGoogle() } just Runs
+
+        useCase.execute(CentralGoogleAccount.PROVIDER_GOOGLE)
+
+        verify { centralGoogleAccountAdaptor.deleteGoogle() }
+    }
+
+    @Test
+    fun `connect와 disconnect 경합을 막기 위해 provider 기반 분산 락이 적용된다`() {
+        val method = DisconnectCentralGoogleAccountLockedUseCase::class.java.getDeclaredMethod("execute", String::class.java)
+        val lock = method.getAnnotation(DistributedLock::class.java)
+
+        assertAll(
+            { assertNotNull(lock) },
+            { assertEquals("central-google-account", lock.prefix) },
+            { assertEquals(30L, lock.waitTime) },
+            { assertTrue(method.parameters[0].isAnnotationPresent(LockKey::class.java)) },
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/DisconnectCentralGoogleUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/DisconnectCentralGoogleUseCaseTest.kt
@@ -1,0 +1,26 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+class DisconnectCentralGoogleUseCaseTest {
+    private val disconnectCentralGoogleAccountLockedUseCase: DisconnectCentralGoogleAccountLockedUseCase = mockk()
+    private val useCase =
+        DisconnectCentralGoogleUseCase(
+            disconnectCentralGoogleAccountLockedUseCase = disconnectCentralGoogleAccountLockedUseCase,
+        )
+
+    @Test
+    fun `중앙 Google provider key로 locked usecase에 위임한다`() {
+        every { disconnectCentralGoogleAccountLockedUseCase.execute(CentralGoogleAccount.PROVIDER_GOOGLE) } just Runs
+
+        useCase.execute()
+
+        verify { disconnectCentralGoogleAccountLockedUseCase.execute(CentralGoogleAccount.PROVIDER_GOOGLE) }
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/GetCentralGoogleConnectionStatusUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/GetCentralGoogleConnectionStatusUseCaseTest.kt
@@ -29,7 +29,7 @@ class GetCentralGoogleConnectionStatusUseCaseTest {
             CentralGoogleAccount(
                 googleEmail = "central-google@example.com",
                 encryptedRefreshToken = "encrypted-token",
-                scope = "email https://www.googleapis.com/auth/calendar.events",
+                scope = CentralGoogleOAuthScopes.authorizationScopes.joinToString(" "),
                 connectedByAdminUserId = "admin-user-id-0000000001",
                 connectedAt = connectedAt,
             )

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/GetCentralGoogleConnectionStatusUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/GetCentralGoogleConnectionStatusUseCaseTest.kt
@@ -1,0 +1,60 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class GetCentralGoogleConnectionStatusUseCaseTest {
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor = mockk()
+    private val properties =
+        GoogleCentralCalendarProperties().apply {
+            allowedEmail = "central-google@example.com"
+        }
+    private val useCase =
+        GetCentralGoogleConnectionStatusUseCase(
+            centralGoogleAccountAdaptor = centralGoogleAccountAdaptor,
+            properties = properties,
+        )
+
+    @Test
+    fun `연결된 중앙 Google 계정 상태를 반환한다`() {
+        val connectedAt = LocalDateTime.of(2026, 4, 26, 14, 0)
+        every { centralGoogleAccountAdaptor.findGoogleOrNull() } returns
+            CentralGoogleAccount(
+                googleEmail = "central-google@example.com",
+                encryptedRefreshToken = "encrypted-token",
+                scope = "email https://www.googleapis.com/auth/calendar.events",
+                connectedByAdminUserId = "admin-user-id-0000000001",
+                connectedAt = connectedAt,
+            )
+
+        val response = useCase.execute()
+
+        assertAll(
+            { assertEquals(true, response.connected) },
+            { assertEquals("central-google@example.com", response.googleEmail) },
+            { assertEquals("central-google@example.com", response.allowedEmail) },
+            { assertEquals("admin-user-id-0000000001", response.connectedByAdminUserId) },
+            { assertEquals(connectedAt, response.connectedAt) },
+        )
+    }
+
+    @Test
+    fun `연결된 중앙 Google 계정이 없으면 not connected를 반환한다`() {
+        every { centralGoogleAccountAdaptor.findGoogleOrNull() } returns null
+
+        val response = useCase.execute()
+
+        assertAll(
+            { assertEquals(false, response.connected) },
+            { assertEquals(null, response.googleEmail) },
+            { assertEquals("central-google@example.com", response.allowedEmail) },
+        )
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/IssueCentralGoogleOAuthStateUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/IssueCentralGoogleOAuthStateUseCaseTest.kt
@@ -1,0 +1,33 @@
+package com.sclass.backoffice.oauth.usecase
+
+import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
+import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class IssueCentralGoogleOAuthStateUseCaseTest {
+    private val stateStore: GoogleOAuthStateStore = mockk()
+    private val properties =
+        GoogleCentralCalendarProperties().apply {
+            clientId = "central-client-id"
+        }
+    private val useCase =
+        IssueCentralGoogleOAuthStateUseCase(
+            stateStore = stateStore,
+            properties = properties,
+        )
+
+    @Test
+    fun `중앙 Google OAuth 연결에 필요한 client id와 scope를 함께 반환한다`() {
+        every { stateStore.issue("admin-user-id-0000000001", any()) } returns "issued-state"
+
+        val response = useCase.execute("admin-user-id-0000000001")
+
+        assertEquals("issued-state", response.state)
+        assertEquals(300, response.expiresInSeconds)
+        assertEquals("central-client-id", response.clientId)
+        assertEquals(CentralGoogleOAuthScopes.authorizationScopes, response.scopes)
+    }
+}

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/IssueCentralGoogleOAuthStateUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/oauth/usecase/IssueCentralGoogleOAuthStateUseCaseTest.kt
@@ -1,16 +1,20 @@
 package com.sclass.backoffice.oauth.usecase
 
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
 import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
 import com.sclass.infrastructure.oauth.state.GoogleOAuthStateStore
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class IssueCentralGoogleOAuthStateUseCaseTest {
     private val stateStore: GoogleOAuthStateStore = mockk()
     private val properties =
         GoogleCentralCalendarProperties().apply {
+            enabled = true
             clientId = "central-client-id"
         }
     private val useCase =
@@ -29,5 +33,21 @@ class IssueCentralGoogleOAuthStateUseCaseTest {
         assertEquals(300, response.expiresInSeconds)
         assertEquals("central-client-id", response.clientId)
         assertEquals(CentralGoogleOAuthScopes.authorizationScopes, response.scopes)
+    }
+
+    @Test
+    fun `중앙 Google Calendar 연동이 비활성화되어 있으면 state를 발급하지 않는다`() {
+        val disabledStateStore: GoogleOAuthStateStore = mockk()
+        val disabledUseCase =
+            IssueCentralGoogleOAuthStateUseCase(
+                stateStore = disabledStateStore,
+                properties = GoogleCentralCalendarProperties(),
+            )
+
+        assertThrows<GoogleCalendarCentralDisabledException> {
+            disabledUseCase.execute("admin-user-id-0000000001")
+        }
+
+        verify(exactly = 0) { disabledStateStore.issue(any(), any()) }
     }
 }

--- a/SClass-Api-Supporters/src/main/resources/application.yml.example
+++ b/SClass-Api-Supporters/src/main/resources/application.yml.example
@@ -70,6 +70,13 @@ oauth2:
     kakao:
       client-id: ${KAKAO_CLIENT_ID:}
 
+google:
+  calendar:
+    central:
+      enabled: ${GOOGLE_CALENDAR_CENTRAL_ENABLED:false}
+      calendar-id: ${GOOGLE_CALENDAR_CENTRAL_CALENDAR_ID:primary}
+      allowed-email: ${GOOGLE_CALENDAR_CENTRAL_ALLOWED_EMAIL:}
+
 alimtalk:
   enabled: ${ALIMTALK_ENABLED:false}
   service-id: ${ALIMTALK_SERVICE_ID:}

--- a/SClass-Api-Supporters/src/main/resources/application.yml.example
+++ b/SClass-Api-Supporters/src/main/resources/application.yml.example
@@ -76,6 +76,8 @@ google:
       enabled: ${GOOGLE_CALENDAR_CENTRAL_ENABLED:false}
       calendar-id: ${GOOGLE_CALENDAR_CENTRAL_CALENDAR_ID:primary}
       allowed-email: ${GOOGLE_CALENDAR_CENTRAL_ALLOWED_EMAIL:}
+      client-id: ${GOOGLE_CENTRAL_CLIENT_ID:}
+      client-secret: ${GOOGLE_CENTRAL_CLIENT_SECRET:}
 
 alimtalk:
   enabled: ${ALIMTALK_ENABLED:false}

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleCalendarCentralDisabledException.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleCalendarCentralDisabledException.kt
@@ -1,0 +1,3 @@
+package com.sclass.common.exception
+
+class GoogleCalendarCentralDisabledException : BusinessException(OAuthTokenErrorCode.GOOGLE_CALENDAR_CENTRAL_DISABLED)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleDriveScopeMissingException.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/GoogleDriveScopeMissingException.kt
@@ -1,0 +1,3 @@
+package com.sclass.common.exception
+
+class GoogleDriveScopeMissingException : BusinessException(OAuthTokenErrorCode.GOOGLE_DRIVE_SCOPE_MISSING)

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
@@ -16,5 +16,6 @@ enum class OAuthTokenErrorCode(
     GOOGLE_OAUTH_STATE_INVALID("OAUTH_019", "Google OAuth state가 유효하지 않습니다", 400),
     GOOGLE_CALENDAR_REQUEST_FAILED("OAUTH_020", "Google Calendar 요청에 실패했습니다", 400),
     GOOGLE_CALENDAR_UNAUTHORIZED("OAUTH_021", "Google Calendar 인증에 실패했습니다", 401),
-    GOOGLE_DRIVE_SCOPE_MISSING("OAUTH_022", "Google Meet 녹화 파일 조회를 위한 drive.meet.readonly scope가 필요합니다", 400),
+    GOOGLE_DRIVE_SCOPE_MISSING("OAUTH_024", "Google Meet 녹화 파일 조회를 위한 drive.meet.readonly scope가 필요합니다", 400),
+    GOOGLE_CALENDAR_CENTRAL_DISABLED("OAUTH_025", "중앙 Google Calendar 연동이 비활성화되어 있습니다", 503),
 }

--- a/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
+++ b/SClass-Common/src/main/kotlin/com/sclass/common/exception/OAuthTokenErrorCode.kt
@@ -16,4 +16,5 @@ enum class OAuthTokenErrorCode(
     GOOGLE_OAUTH_STATE_INVALID("OAUTH_019", "Google OAuth state가 유효하지 않습니다", 400),
     GOOGLE_CALENDAR_REQUEST_FAILED("OAUTH_020", "Google Calendar 요청에 실패했습니다", 400),
     GOOGLE_CALENDAR_UNAUTHORIZED("OAUTH_021", "Google Calendar 인증에 실패했습니다", 401),
+    GOOGLE_DRIVE_SCOPE_MISSING("OAUTH_022", "Google Meet 녹화 파일 조회를 위한 drive.meet.readonly scope가 필요합니다", 400),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/adaptor/CentralGoogleAccountAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/adaptor/CentralGoogleAccountAdaptor.kt
@@ -1,0 +1,20 @@
+package com.sclass.domain.domains.oauth.adaptor
+
+import com.sclass.common.annotation.Adaptor
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.domain.domains.oauth.exception.CentralGoogleAccountNotFoundException
+import com.sclass.domain.domains.oauth.repository.CentralGoogleAccountRepository
+import org.springframework.data.repository.findByIdOrNull
+
+@Adaptor
+class CentralGoogleAccountAdaptor(
+    private val repository: CentralGoogleAccountRepository,
+) {
+    fun save(account: CentralGoogleAccount): CentralGoogleAccount = repository.save(account)
+
+    fun findGoogle(): CentralGoogleAccount = findGoogleOrNull() ?: throw CentralGoogleAccountNotFoundException()
+
+    fun findGoogleOrNull(): CentralGoogleAccount? = repository.findByIdOrNull(CentralGoogleAccount.PROVIDER_GOOGLE)
+
+    fun deleteGoogle() = repository.deleteById(CentralGoogleAccount.PROVIDER_GOOGLE)
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/domain/CentralGoogleAccount.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/domain/CentralGoogleAccount.kt
@@ -1,0 +1,56 @@
+package com.sclass.domain.domains.oauth.domain
+
+import com.sclass.domain.common.model.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "central_google_accounts",
+    indexes = [
+        Index(name = "idx_central_google_email", columnList = "google_email"),
+    ],
+)
+class CentralGoogleAccount(
+    @Id
+    @Column(length = 20)
+    val provider: String = PROVIDER_GOOGLE,
+    @Column(name = "google_email", nullable = false, length = 320)
+    var googleEmail: String,
+    @Column(name = "encrypted_refresh_token", nullable = false, columnDefinition = "TEXT")
+    var encryptedRefreshToken: String,
+    @Column(nullable = false, length = 500)
+    var scope: String,
+    @Column(name = "connected_by_admin_user_id", nullable = false, length = 26)
+    var connectedByAdminUserId: String,
+    @Column(name = "connected_at", nullable = false)
+    var connectedAt: LocalDateTime,
+    @Column(name = "last_used_at")
+    var lastUsedAt: LocalDateTime? = null,
+) : BaseTimeEntity() {
+    fun reconnect(
+        newGoogleEmail: String,
+        newEncryptedRefreshToken: String,
+        newScope: String,
+        adminUserId: String,
+        at: LocalDateTime,
+    ) {
+        this.googleEmail = newGoogleEmail
+        this.encryptedRefreshToken = newEncryptedRefreshToken
+        this.scope = newScope
+        this.connectedByAdminUserId = adminUserId
+        this.connectedAt = at
+    }
+
+    fun markUsed(at: LocalDateTime) {
+        this.lastUsedAt = at
+    }
+
+    companion object {
+        const val PROVIDER_GOOGLE = "GOOGLE"
+    }
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/exception/CentralGoogleAccountExceptions.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/exception/CentralGoogleAccountExceptions.kt
@@ -1,0 +1,7 @@
+package com.sclass.domain.domains.oauth.exception
+
+import com.sclass.common.exception.BusinessException
+
+class CentralGoogleAccountNotFoundException : BusinessException(OAuthErrorCode.CENTRAL_GOOGLE_ACCOUNT_NOT_FOUND)
+
+class CentralGoogleAccountEmailNotAllowedException : BusinessException(OAuthErrorCode.CENTRAL_GOOGLE_ACCOUNT_EMAIL_NOT_ALLOWED)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/exception/OAuthErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/exception/OAuthErrorCode.kt
@@ -8,4 +8,6 @@ enum class OAuthErrorCode(
     override val httpStatus: Int,
 ) : ErrorCode {
     TEACHER_GOOGLE_ACCOUNT_NOT_FOUND("OAUTH_015", "연결된 Google 계정이 없습니다", 404),
+    CENTRAL_GOOGLE_ACCOUNT_NOT_FOUND("OAUTH_022", "연결된 중앙 Google 계정이 없습니다", 404),
+    CENTRAL_GOOGLE_ACCOUNT_EMAIL_NOT_ALLOWED("OAUTH_023", "허용된 중앙 Google 계정 이메일이 아닙니다", 400),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/repository/CentralGoogleAccountRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/oauth/repository/CentralGoogleAccountRepository.kt
@@ -1,0 +1,6 @@
+package com.sclass.domain.domains.oauth.repository
+
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CentralGoogleAccountRepository : JpaRepository<CentralGoogleAccount, String>

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClient.kt
@@ -2,14 +2,14 @@ package com.sclass.infrastructure.calendar
 
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
-import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnProperty(prefix = "google.calendar.central", name = ["enabled"], havingValue = "true")
 class CentralGoogleCalendarClient(
-    private val authorizationCodeClient: GoogleAuthorizationCodeClient,
+    private val authorizationCodeClient: CentralGoogleAuthorizationCodeClient,
     private val googleCalendarClient: GoogleCalendarClient,
     private val properties: GoogleCentralCalendarProperties,
 ) {

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClient.kt
@@ -1,0 +1,27 @@
+package com.sclass.infrastructure.calendar
+
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
+import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(prefix = "google.calendar.central", name = ["enabled"], havingValue = "true")
+class CentralGoogleCalendarClient(
+    private val authorizationCodeClient: GoogleAuthorizationCodeClient,
+    private val googleCalendarClient: GoogleCalendarClient,
+    private val properties: GoogleCentralCalendarProperties,
+) {
+    fun createMeetEventWithRefreshToken(
+        refreshToken: String,
+        command: GoogleCalendarEventCreateCommand,
+    ): GoogleCalendarEventResult {
+        val accessToken = authorizationCodeClient.refreshAccessToken(refreshToken)
+        return googleCalendarClient.createMeetEventWithAccessToken(
+            command = command,
+            accessToken = accessToken,
+            calendarId = properties.calendarId,
+        )
+    }
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClient.kt
@@ -1,10 +1,12 @@
 package com.sclass.infrastructure.calendar
 
+import com.sclass.common.exception.GoogleCalendarUnauthorizedException
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
 import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClientResponseException
 
 @Component
 @ConditionalOnProperty(prefix = "google.calendar.central", name = ["enabled"], havingValue = "true")
@@ -18,10 +20,23 @@ class CentralGoogleCalendarClient(
         command: GoogleCalendarEventCreateCommand,
     ): GoogleCalendarEventResult {
         val accessToken = authorizationCodeClient.refreshAccessToken(refreshToken)
-        return googleCalendarClient.createMeetEventWithAccessToken(
-            command = command,
-            accessToken = accessToken,
-            calendarId = properties.calendarId,
-        )
+        return try {
+            googleCalendarClient.createMeetEventWithAccessToken(
+                command = command,
+                accessToken = accessToken,
+                calendarId = properties.calendarId,
+            )
+        } catch (e: WebClientResponseException) {
+            if (e.isAuthorizationFailure()) throw GoogleCalendarUnauthorizedException()
+            throw e
+        }
+    }
+
+    private fun WebClientResponseException.isAuthorizationFailure(): Boolean =
+        statusCode.value() == UNAUTHORIZED_STATUS || statusCode.value() == FORBIDDEN_STATUS
+
+    private companion object {
+        const val UNAUTHORIZED_STATUS = 401
+        const val FORBIDDEN_STATUS = 403
     }
 }

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
@@ -5,8 +5,10 @@ import com.sclass.common.exception.GoogleCalendarRequestFailedException
 import com.sclass.common.exception.GoogleCalendarUnauthorizedException
 import com.sclass.common.exception.GoogleOAuthProviderUnavailableException
 import com.sclass.infrastructure.calendar.dto.CreateGoogleCalendarEventCommand
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarAttendee
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarConferenceCreateRequest
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarConferenceData
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventDateTime
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventRequest
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResponse
@@ -29,7 +31,7 @@ class GoogleCalendarClient(
 
     fun createMeetEvent(command: CreateGoogleCalendarEventCommand): GoogleCalendarEventResult =
         try {
-            createMeetEvent(command, command.accessToken)
+            createMeetEventWithAccessToken(command.toEventCreateCommand(), command.accessToken)
         } catch (e: WebClientResponseException) {
             if (!e.isAuthorizationFailure()) throw e
 
@@ -42,23 +44,24 @@ class GoogleCalendarClient(
                 }
 
             try {
-                createMeetEvent(command, refreshedAccessToken)
+                createMeetEventWithAccessToken(command.toEventCreateCommand(), refreshedAccessToken)
             } catch (retryException: WebClientResponseException) {
                 if (retryException.isAuthorizationFailure()) throw GoogleCalendarUnauthorizedException()
                 throw retryException
             }
         }
 
-    private fun createMeetEvent(
-        command: CreateGoogleCalendarEventCommand,
+    fun createMeetEventWithAccessToken(
+        command: GoogleCalendarEventCreateCommand,
         accessToken: String,
+        calendarId: String = PRIMARY_CALENDAR_ID,
     ): GoogleCalendarEventResult {
         val request = command.toRequest()
         val response =
             try {
                 webClient
                     .post()
-                    .uri(CALENDAR_EVENTS_URI)
+                    .uri(calendarEventsUri(calendarId, sendUpdates = command.attendeeEmails.isNotEmpty()))
                     .header("Authorization", "Bearer $accessToken")
                     .bodyValue(request)
                     .retrieve()
@@ -79,7 +82,7 @@ class GoogleCalendarClient(
         return response.toResult()
     }
 
-    private fun CreateGoogleCalendarEventCommand.toRequest(): GoogleCalendarEventRequest =
+    private fun GoogleCalendarEventCreateCommand.toRequest(): GoogleCalendarEventRequest =
         GoogleCalendarEventRequest(
             summary = summary,
             start =
@@ -99,6 +102,7 @@ class GoogleCalendarClient(
                             requestId = UUID.randomUUID().toString(),
                         ),
                 ),
+            attendees = attendeeEmails.map { GoogleCalendarAttendee(email = it) },
         )
 
     private fun GoogleCalendarEventResponse?.toResult(): GoogleCalendarEventResult {
@@ -120,6 +124,14 @@ class GoogleCalendarClient(
 
     private fun WebClientResponseException.isAuthorizationFailure(): Boolean =
         statusCode.value() == UNAUTHORIZED_STATUS || statusCode.value() == FORBIDDEN_STATUS
+
+    private fun calendarEventsUri(
+        calendarId: String,
+        sendUpdates: Boolean,
+    ): String {
+        val sendUpdatesQuery = if (sendUpdates) "&sendUpdates=all" else ""
+        return "https://www.googleapis.com/calendar/v3/calendars/$calendarId/events?conferenceDataVersion=1$sendUpdatesQuery"
+    }
 
     private fun WebClientResponseException.isRetryableProviderFailure(): Boolean =
         statusCode.is5xxServerError ||
@@ -143,8 +155,7 @@ class GoogleCalendarClient(
     }
 
     private companion object {
-        const val CALENDAR_EVENTS_URI =
-            "https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1"
+        const val PRIMARY_CALENDAR_ID = "primary"
         const val UNAUTHORIZED_STATUS = 401
         const val FORBIDDEN_STATUS = 403
         const val TOO_MANY_REQUESTS_STATUS = 429

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
@@ -19,6 +19,8 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 @Component
@@ -130,7 +132,8 @@ class GoogleCalendarClient(
         sendUpdates: Boolean,
     ): String {
         val sendUpdatesQuery = if (sendUpdates) "&sendUpdates=all" else ""
-        return "https://www.googleapis.com/calendar/v3/calendars/$calendarId/events?conferenceDataVersion=1$sendUpdatesQuery"
+        val encodedCalendarId = URLEncoder.encode(calendarId, StandardCharsets.UTF_8)
+        return "https://www.googleapis.com/calendar/v3/calendars/$encodedCalendarId/events?conferenceDataVersion=1$sendUpdatesQuery"
     }
 
     private fun WebClientResponseException.isRetryableProviderFailure(): Boolean =

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarConfig.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarConfig.kt
@@ -1,0 +1,8 @@
+package com.sclass.infrastructure.calendar
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(GoogleCentralCalendarProperties::class)
+class GoogleCalendarConfig

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCentralCalendarProperties.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCentralCalendarProperties.kt
@@ -1,0 +1,14 @@
+package com.sclass.infrastructure.calendar
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "google.calendar.central")
+class GoogleCentralCalendarProperties {
+    var enabled: Boolean = false
+    var calendarId: String = "primary"
+    var allowedEmail: String = ""
+
+    fun requireAllowedEmail(): String =
+        allowedEmail.takeIf { it.isNotBlank() }
+            ?: throw IllegalStateException("google.calendar.central.allowed-email is required")
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCentralCalendarProperties.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCentralCalendarProperties.kt
@@ -7,8 +7,18 @@ class GoogleCentralCalendarProperties {
     var enabled: Boolean = false
     var calendarId: String = "primary"
     var allowedEmail: String = ""
+    var clientId: String = ""
+    var clientSecret: String = ""
 
     fun requireAllowedEmail(): String =
         allowedEmail.takeIf { it.isNotBlank() }
             ?: throw IllegalStateException("google.calendar.central.allowed-email is required")
+
+    fun requireClientId(): String =
+        clientId.takeIf { it.isNotBlank() }
+            ?: throw IllegalStateException("google.calendar.central.client-id is required")
+
+    fun requireClientSecret(): String =
+        clientSecret.takeIf { it.isNotBlank() }
+            ?: throw IllegalStateException("google.calendar.central.client-secret is required")
 }

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/CreateGoogleCalendarEventCommand.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/CreateGoogleCalendarEventCommand.kt
@@ -8,4 +8,13 @@ data class CreateGoogleCalendarEventCommand(
     val summary: String,
     val startAt: ZonedDateTime,
     val endAt: ZonedDateTime,
-)
+    val attendeeEmails: List<String> = emptyList(),
+) {
+    fun toEventCreateCommand(): GoogleCalendarEventCreateCommand =
+        GoogleCalendarEventCreateCommand(
+            summary = summary,
+            startAt = startAt,
+            endAt = endAt,
+            attendeeEmails = attendeeEmails,
+        )
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventCreateCommand.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventCreateCommand.kt
@@ -1,0 +1,10 @@
+package com.sclass.infrastructure.calendar.dto
+
+import java.time.ZonedDateTime
+
+data class GoogleCalendarEventCreateCommand(
+    val summary: String,
+    val startAt: ZonedDateTime,
+    val endAt: ZonedDateTime,
+    val attendeeEmails: List<String> = emptyList(),
+)

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventRequest.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventRequest.kt
@@ -5,6 +5,7 @@ data class GoogleCalendarEventRequest(
     val start: GoogleCalendarEventDateTime,
     val end: GoogleCalendarEventDateTime,
     val conferenceData: GoogleCalendarConferenceData,
+    val attendees: List<GoogleCalendarAttendee> = emptyList(),
 )
 
 data class GoogleCalendarEventDateTime(
@@ -24,4 +25,8 @@ data class GoogleCalendarConferenceCreateRequest(
 
 data class GoogleCalendarConferenceSolutionKey(
     val type: String,
+)
+
+data class GoogleCalendarAttendee(
+    val email: String,
 )

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/CentralGoogleAuthorizationCodeClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/CentralGoogleAuthorizationCodeClient.kt
@@ -1,25 +1,15 @@
 package com.sclass.infrastructure.oauth.client
 
-import com.sclass.infrastructure.oauth.config.OAuthProperties
+import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
 import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
 import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
 import org.springframework.stereotype.Component
 
 @Component
-class GoogleAuthorizationCodeClient(
-    private val oAuthProperties: OAuthProperties,
+class CentralGoogleAuthorizationCodeClient(
+    private val properties: GoogleCentralCalendarProperties,
     private val tokenClient: GoogleOAuthTokenClient,
 ) {
-    private val clientId: String
-        get() =
-            oAuthProperties.providers["google"]?.clientId
-                ?: throw IllegalStateException("Google OAuth client-id가 설정되지 않았습니다")
-
-    private val clientSecret: String
-        get() =
-            oAuthProperties.providers["google"]?.clientSecret
-                ?: throw IllegalStateException("Google OAuth client-secret이 설정되지 않았습니다")
-
     fun exchangeCodeForTokens(
         code: String,
         redirectUri: String,
@@ -27,15 +17,15 @@ class GoogleAuthorizationCodeClient(
         tokenClient.exchangeCodeForTokens(
             code = code,
             redirectUri = redirectUri,
-            clientId = clientId,
-            clientSecret = clientSecret,
+            clientId = properties.requireClientId(),
+            clientSecret = properties.requireClientSecret(),
         )
 
     fun refreshAccessToken(refreshToken: String): String =
         tokenClient.refreshAccessToken(
             refreshToken = refreshToken,
-            clientId = clientId,
-            clientSecret = clientSecret,
+            clientId = properties.requireClientId(),
+            clientSecret = properties.requireClientSecret(),
         )
 
     fun revokeRefreshToken(refreshToken: String) {

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/GoogleOAuthTokenClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/oauth/client/GoogleOAuthTokenClient.kt
@@ -1,0 +1,149 @@
+package com.sclass.infrastructure.oauth.client
+
+import com.sclass.common.exception.GoogleOAuthProviderUnavailableException
+import com.sclass.common.exception.GoogleTokenExchangeFailedException
+import com.sclass.common.exception.GoogleTokenRefreshFailedException
+import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
+import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+@Component
+class GoogleOAuthTokenClient(
+    @param:Qualifier("oAuthWebClient") private val webClient: WebClient,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun exchangeCodeForTokens(
+        code: String,
+        redirectUri: String,
+        clientId: String,
+        clientSecret: String,
+    ): GoogleTokenExchangeResponse {
+        val params =
+            LinkedMultiValueMap<String, String>().apply {
+                add("code", code)
+                add("client_id", clientId)
+                add("client_secret", clientSecret)
+                add("redirect_uri", redirectUri)
+                add("grant_type", "authorization_code")
+            }
+
+        val response =
+            try {
+                webClient
+                    .post()
+                    .uri("https://oauth2.googleapis.com/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(params))
+                    .retrieve()
+                    .bodyToMono(GoogleTokenExchangeResponse::class.java)
+                    .block()
+            } catch (e: WebClientResponseException) {
+                log.warn("Google token exchange failed: ${e.responseBodyAsString}", e)
+                if (e.isRetryableUpstreamFailure()) {
+                    throw GoogleOAuthProviderUnavailableException()
+                }
+                throw GoogleTokenExchangeFailedException()
+            } catch (e: Exception) {
+                log.warn("Google token exchange failed", e)
+                throw GoogleOAuthProviderUnavailableException()
+            }
+
+        return response ?: throw GoogleOAuthProviderUnavailableException()
+    }
+
+    fun refreshAccessToken(
+        refreshToken: String,
+        clientId: String,
+        clientSecret: String,
+    ): String {
+        val params =
+            LinkedMultiValueMap<String, String>().apply {
+                add("client_id", clientId)
+                add("client_secret", clientSecret)
+                add("refresh_token", refreshToken)
+                add("grant_type", "refresh_token")
+            }
+
+        val response =
+            try {
+                webClient
+                    .post()
+                    .uri("https://oauth2.googleapis.com/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(params))
+                    .retrieve()
+                    .bodyToMono(GoogleTokenExchangeResponse::class.java)
+                    .block()
+            } catch (e: WebClientResponseException) {
+                log.warn("Google token refresh failed: ${e.responseBodyAsString}", e)
+                if (e.isRetryableUpstreamFailure()) {
+                    throw GoogleOAuthProviderUnavailableException()
+                }
+                throw GoogleTokenRefreshFailedException()
+            } catch (e: Exception) {
+                log.warn("Google token refresh failed", e)
+                throw GoogleOAuthProviderUnavailableException()
+            }
+
+        return response?.accessToken ?: throw GoogleOAuthProviderUnavailableException()
+    }
+
+    fun revokeRefreshToken(refreshToken: String) {
+        val params =
+            LinkedMultiValueMap<String, String>().apply {
+                add("token", refreshToken)
+            }
+
+        try {
+            webClient
+                .post()
+                .uri("https://oauth2.googleapis.com/revoke")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(params))
+                .retrieve()
+                .toBodilessEntity()
+                .block()
+        } catch (e: Exception) {
+            log.warn("Google token revoke failed (best effort, ignoring)", e)
+        }
+    }
+
+    fun fetchUserInfo(accessToken: String): GoogleUserInfoResponse {
+        val userInfo =
+            try {
+                webClient
+                    .get()
+                    .uri("https://www.googleapis.com/oauth2/v2/userinfo")
+                    .header("Authorization", "Bearer $accessToken")
+                    .retrieve()
+                    .bodyToMono(GoogleUserInfoResponse::class.java)
+                    .block()
+            } catch (e: WebClientResponseException) {
+                log.warn("Google fetch user info failed: ${e.responseBodyAsString}", e)
+                if (e.isRetryableUpstreamFailure()) {
+                    throw GoogleOAuthProviderUnavailableException()
+                }
+                throw GoogleTokenExchangeFailedException()
+            } catch (e: Exception) {
+                log.warn("Google fetch user info failed", e)
+                throw GoogleOAuthProviderUnavailableException()
+            }
+
+        return userInfo ?: throw GoogleOAuthProviderUnavailableException()
+    }
+
+    private fun WebClientResponseException.isRetryableUpstreamFailure(): Boolean =
+        statusCode.is5xxServerError || statusCode.value() == TOO_MANY_REQUESTS_STATUS
+
+    private companion object {
+        const val TOO_MANY_REQUESTS_STATUS = 429
+    }
+}

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClientTest.kt
@@ -2,7 +2,7 @@ package com.sclass.infrastructure.calendar
 
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
-import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -12,7 +12,7 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 
 class CentralGoogleCalendarClientTest {
-    private val authorizationCodeClient: GoogleAuthorizationCodeClient = mockk()
+    private val authorizationCodeClient: CentralGoogleAuthorizationCodeClient = mockk()
     private val googleCalendarClient: GoogleCalendarClient = mockk()
     private val properties =
         GoogleCentralCalendarProperties().apply {

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClientTest.kt
@@ -1,0 +1,64 @@
+package com.sclass.infrastructure.calendar
+
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
+import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class CentralGoogleCalendarClientTest {
+    private val authorizationCodeClient: GoogleAuthorizationCodeClient = mockk()
+    private val googleCalendarClient: GoogleCalendarClient = mockk()
+    private val properties =
+        GoogleCentralCalendarProperties().apply {
+            calendarId = "primary"
+        }
+    private val client =
+        CentralGoogleCalendarClient(
+            authorizationCodeClient = authorizationCodeClient,
+            googleCalendarClient = googleCalendarClient,
+            properties = properties,
+        )
+
+    @Test
+    fun `central refresh token으로 access token을 갱신해 중앙 캘린더에 Meet 이벤트를 생성한다`() {
+        val command =
+            GoogleCalendarEventCreateCommand(
+                summary = "수학 1회차",
+                startAt = ZonedDateTime.of(2026, 4, 26, 14, 0, 0, 0, ZoneId.of("Asia/Seoul")),
+                endAt = ZonedDateTime.of(2026, 4, 26, 15, 0, 0, 0, ZoneId.of("Asia/Seoul")),
+                attendeeEmails = listOf("teacher@example.com", "student@example.com"),
+            )
+        val expected = GoogleCalendarEventResult(eventId = "event-id", meetJoinUrl = "https://meet.google.com/abc-defg-hij")
+
+        every { authorizationCodeClient.refreshAccessToken("central-refresh-token") } returns "central-access-token"
+        every {
+            googleCalendarClient.createMeetEventWithAccessToken(
+                command = command,
+                accessToken = "central-access-token",
+                calendarId = "primary",
+            )
+        } returns expected
+
+        val result =
+            client.createMeetEventWithRefreshToken(
+                refreshToken = "central-refresh-token",
+                command = command,
+            )
+
+        assertEquals(expected, result)
+        verify { authorizationCodeClient.refreshAccessToken("central-refresh-token") }
+        verify {
+            googleCalendarClient.createMeetEventWithAccessToken(
+                command = command,
+                accessToken = "central-access-token",
+                calendarId = "primary",
+            )
+        }
+    }
+}

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClientTest.kt
@@ -1,5 +1,6 @@
 package com.sclass.infrastructure.calendar
 
+import com.sclass.common.exception.GoogleCalendarUnauthorizedException
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
 import com.sclass.infrastructure.oauth.client.CentralGoogleAuthorizationCodeClient
@@ -8,6 +9,10 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
@@ -27,13 +32,7 @@ class CentralGoogleCalendarClientTest {
 
     @Test
     fun `central refresh token으로 access token을 갱신해 중앙 캘린더에 Meet 이벤트를 생성한다`() {
-        val command =
-            GoogleCalendarEventCreateCommand(
-                summary = "수학 1회차",
-                startAt = ZonedDateTime.of(2026, 4, 26, 14, 0, 0, 0, ZoneId.of("Asia/Seoul")),
-                endAt = ZonedDateTime.of(2026, 4, 26, 15, 0, 0, 0, ZoneId.of("Asia/Seoul")),
-                attendeeEmails = listOf("teacher@example.com", "student@example.com"),
-            )
+        val command = command()
         val expected = GoogleCalendarEventResult(eventId = "event-id", meetJoinUrl = "https://meet.google.com/abc-defg-hij")
 
         every { authorizationCodeClient.refreshAccessToken("central-refresh-token") } returns "central-access-token"
@@ -61,4 +60,39 @@ class CentralGoogleCalendarClientTest {
             )
         }
     }
+
+    @Test
+    fun `중앙 캘린더 이벤트 생성에서 Google 인증 실패가 발생하면 도메인 예외로 변환한다`() {
+        val command = command()
+        every { authorizationCodeClient.refreshAccessToken("central-refresh-token") } returns "central-access-token"
+        every {
+            googleCalendarClient.createMeetEventWithAccessToken(
+                command = command,
+                accessToken = "central-access-token",
+                calendarId = "primary",
+            )
+        } throws
+            WebClientResponseException.create(
+                HttpStatus.UNAUTHORIZED.value(),
+                "Unauthorized",
+                HttpHeaders.EMPTY,
+                ByteArray(0),
+                null,
+            )
+
+        assertThrows<GoogleCalendarUnauthorizedException> {
+            client.createMeetEventWithRefreshToken(
+                refreshToken = "central-refresh-token",
+                command = command,
+            )
+        }
+    }
+
+    private fun command() =
+        GoogleCalendarEventCreateCommand(
+            summary = "수학 1회차",
+            startAt = ZonedDateTime.of(2026, 4, 26, 14, 0, 0, 0, ZoneId.of("Asia/Seoul")),
+            endAt = ZonedDateTime.of(2026, 4, 26, 15, 0, 0, 0, ZoneId.of("Asia/Seoul")),
+            attendeeEmails = listOf("teacher@example.com", "student@example.com"),
+        )
 }

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
@@ -6,6 +6,7 @@ import com.sclass.common.exception.GoogleOAuthProviderUnavailableException
 import com.sclass.infrastructure.calendar.dto.CreateGoogleCalendarEventCommand
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarConferenceResponse
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEntryPoint
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventRequest
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResponse
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
@@ -120,6 +121,27 @@ class GoogleCalendarClientTest {
 
         assertEquals("https://meet.google.com/abc-defg-hij", result.meetJoinUrl)
         assertEquals(listOf("teacher@example.com", "student@example.com"), requestSlot.single().attendees.map { it.email })
+    }
+
+    @Test
+    fun `calendarId가 이메일 형식이면 URL path에 안전하게 인코딩한다`() {
+        mockCreateEventCall(uri = CALENDAR_EVENTS_WITH_ENCODED_CALENDAR_ID_URI)
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.just(calendarResponse(meetUri = "https://meet.google.com/abc-defg-hij"))
+
+        val result =
+            client.createMeetEventWithAccessToken(
+                command =
+                    GoogleCalendarEventCreateCommand(
+                        summary = command.summary,
+                        startAt = command.startAt,
+                        endAt = command.endAt,
+                    ),
+                accessToken = "central-access-token",
+                calendarId = "central@example.com",
+            )
+
+        assertEquals("https://meet.google.com/abc-defg-hij", result.meetJoinUrl)
     }
 
     @Test
@@ -292,5 +314,7 @@ class GoogleCalendarClientTest {
             "https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1"
         const val CALENDAR_EVENTS_WITH_SEND_UPDATES_URI =
             "https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1&sendUpdates=all"
+        const val CALENDAR_EVENTS_WITH_ENCODED_CALENDAR_ID_URI =
+            "https://www.googleapis.com/calendar/v3/calendars/central%40example.com/events?conferenceDataVersion=1"
     }
 }

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
@@ -54,9 +54,12 @@ class GoogleCalendarClientTest {
         client = GoogleCalendarClient(webClient, authorizationCodeClient)
     }
 
-    private fun mockCreateEventCall(requestSlot: MutableList<GoogleCalendarEventRequest> = mutableListOf()) {
+    private fun mockCreateEventCall(
+        requestSlot: MutableList<GoogleCalendarEventRequest> = mutableListOf(),
+        uri: String = CALENDAR_EVENTS_URI,
+    ) {
         every { webClient.post() } returns requestBodyUriSpec
-        every { requestBodyUriSpec.uri(CALENDAR_EVENTS_URI) } returns requestBodySpec
+        every { requestBodyUriSpec.uri(uri) } returns requestBodySpec
         every { requestBodySpec.header(HttpHeaders.AUTHORIZATION, any()) } returns requestBodySpec
         every { requestBodySpec.bodyValue(capture(requestSlot)) } returns requestHeadersSpec
         every { requestHeadersSpec.retrieve() } returns responseSpec
@@ -100,6 +103,23 @@ class GoogleCalendarClientTest {
         val result = client.createMeetEvent(command)
 
         assertEquals("https://meet.google.com/hangout-link", result.meetJoinUrl)
+    }
+
+    @Test
+    fun `attendee가 있으면 이벤트 요청에 참석자를 포함하고 업데이트를 전송한다`() {
+        val requestSlot = mutableListOf<GoogleCalendarEventRequest>()
+        mockCreateEventCall(requestSlot, CALENDAR_EVENTS_WITH_SEND_UPDATES_URI)
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.just(calendarResponse(meetUri = "https://meet.google.com/abc-defg-hij"))
+        val commandWithAttendees =
+            command.copy(
+                attendeeEmails = listOf("teacher@example.com", "student@example.com"),
+            )
+
+        val result = client.createMeetEvent(commandWithAttendees)
+
+        assertEquals("https://meet.google.com/abc-defg-hij", result.meetJoinUrl)
+        assertEquals(listOf("teacher@example.com", "student@example.com"), requestSlot.single().attendees.map { it.email })
     }
 
     @Test
@@ -270,5 +290,7 @@ class GoogleCalendarClientTest {
     private companion object {
         const val CALENDAR_EVENTS_URI =
             "https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1"
+        const val CALENDAR_EVENTS_WITH_SEND_UPDATES_URI =
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1&sendUpdates=all"
     }
 }

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCentralCalendarPropertiesTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCentralCalendarPropertiesTest.kt
@@ -21,4 +21,28 @@ class GoogleCentralCalendarPropertiesTest {
             GoogleCentralCalendarProperties().requireAllowedEmail()
         }
     }
+
+    @Test
+    fun `central client id와 secret이 있으면 반환한다`() {
+        val properties =
+            GoogleCentralCalendarProperties().apply {
+                clientId = "central-client-id"
+                clientSecret = "central-client-secret"
+            }
+
+        assertEquals("central-client-id", properties.requireClientId())
+        assertEquals("central-client-secret", properties.requireClientSecret())
+    }
+
+    @Test
+    fun `central client id와 secret이 없으면 예외`() {
+        val properties = GoogleCentralCalendarProperties()
+
+        assertThrows<IllegalStateException> {
+            properties.requireClientId()
+        }
+        assertThrows<IllegalStateException> {
+            properties.requireClientSecret()
+        }
+    }
 }

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCentralCalendarPropertiesTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCentralCalendarPropertiesTest.kt
@@ -1,0 +1,24 @@
+package com.sclass.infrastructure.calendar
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class GoogleCentralCalendarPropertiesTest {
+    @Test
+    fun `allowed email이 있으면 반환한다`() {
+        val properties =
+            GoogleCentralCalendarProperties().apply {
+                allowedEmail = "central-google@example.com"
+            }
+
+        assertEquals("central-google@example.com", properties.requireAllowedEmail())
+    }
+
+    @Test
+    fun `allowed email이 없으면 예외`() {
+        assertThrows<IllegalStateException> {
+            GoogleCentralCalendarProperties().requireAllowedEmail()
+        }
+    }
+}

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/client/CentralGoogleAuthorizationCodeClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/client/CentralGoogleAuthorizationCodeClientTest.kt
@@ -1,0 +1,77 @@
+package com.sclass.infrastructure.oauth.client
+
+import com.sclass.infrastructure.calendar.GoogleCentralCalendarProperties
+import com.sclass.infrastructure.oauth.dto.GoogleTokenExchangeResponse
+import com.sclass.infrastructure.oauth.dto.GoogleUserInfoResponse
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CentralGoogleAuthorizationCodeClientTest {
+    private val properties =
+        GoogleCentralCalendarProperties().apply {
+            clientId = "central-client-id"
+            clientSecret = "central-client-secret"
+        }
+    private val tokenClient: GoogleOAuthTokenClient = mockk()
+    private val client = CentralGoogleAuthorizationCodeClient(properties, tokenClient)
+
+    @Test
+    fun `central credential로 authorization code를 token으로 교환한다`() {
+        val expected =
+            GoogleTokenExchangeResponse(
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                scope =
+                    "openid https://www.googleapis.com/auth/userinfo.email " +
+                        "https://www.googleapis.com/auth/calendar.events " +
+                        "https://www.googleapis.com/auth/drive.meet.readonly",
+            )
+        every {
+            tokenClient.exchangeCodeForTokens(
+                code = "auth-code",
+                redirectUri = "https://backoffice/callback",
+                clientId = "central-client-id",
+                clientSecret = "central-client-secret",
+            )
+        } returns expected
+
+        val result = client.exchangeCodeForTokens("auth-code", "https://backoffice/callback")
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `central credential로 refresh token을 access token으로 갱신한다`() {
+        every {
+            tokenClient.refreshAccessToken(
+                refreshToken = "refresh-token",
+                clientId = "central-client-id",
+                clientSecret = "central-client-secret",
+            )
+        } returns "access-token"
+
+        val result = client.refreshAccessToken("refresh-token")
+
+        assertEquals("access-token", result)
+    }
+
+    @Test
+    fun `revoke와 user info 조회는 token client로 위임한다`() {
+        every { tokenClient.revokeRefreshToken("refresh-token") } returns Unit
+        every { tokenClient.fetchUserInfo("access-token") } returns
+            GoogleUserInfoResponse(
+                id = "google-user-id",
+                email = "central-google@example.com",
+            )
+
+        client.revokeRefreshToken("refresh-token")
+        val userInfo = client.fetchUserInfo("access-token")
+
+        assertEquals("central-google@example.com", userInfo.email)
+        verify { tokenClient.revokeRefreshToken("refresh-token") }
+        verify { tokenClient.fetchUserInfo("access-token") }
+    }
+}

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/oauth/client/GoogleAuthorizationCodeClientTest.kt
@@ -50,7 +50,7 @@ class GoogleAuthorizationCodeClientTest {
         requestHeadersSpec = mockk()
         requestHeadersUriSpec = mockk()
         responseSpec = mockk()
-        client = GoogleAuthorizationCodeClient(properties, webClient)
+        client = GoogleAuthorizationCodeClient(properties, GoogleOAuthTokenClient(webClient))
     }
 
     private fun mockPostFormData() {

--- a/infra/env/ecs.tf
+++ b/infra/env/ecs.tf
@@ -315,6 +315,8 @@ locals {
       { name = "REPORT_SERVICE_ENABLED", value = contains(["backoffice-api", "supporters-api"], key) ? "true" : "false" },
       { name = "REPORT_SERVICE_BASE_URL", value = contains(["backoffice-api", "supporters-api"], key) ? var.report_service_base_url : "" },
       { name = "REPORT_SERVICE_CALLBACK_BASE_URL", value = key == "supporters-api" ? var.report_service_callback_base_url : "" },
+      { name = "GOOGLE_CALENDAR_CENTRAL_ENABLED", value = var.google_calendar_central_enabled },
+      { name = "GOOGLE_CALENDAR_CENTRAL_CALENDAR_ID", value = var.google_calendar_central_calendar_id },
     ]
   }
 
@@ -326,6 +328,7 @@ locals {
       { name = "TOKEN_ENCRYPTION_KEY", valueFrom = aws_ssm_parameter.token_encryption_key.arn },
       { name = "GOOGLE_CLIENT_ID", valueFrom = aws_ssm_parameter.google_client_id.arn },
       { name = "GOOGLE_CLIENT_SECRET", valueFrom = aws_ssm_parameter.google_client_secret.arn },
+      { name = "GOOGLE_CALENDAR_CENTRAL_ALLOWED_EMAIL", valueFrom = aws_ssm_parameter.google_calendar_central_allowed_email.arn },
       { name = "KAKAO_CLIENT_ID", valueFrom = aws_ssm_parameter.kakao_client_id.arn },
       { name = "KAKAO_APP_ID", valueFrom = aws_ssm_parameter.kakao_app_id.arn },
       { name = "SMTP_USERNAME", valueFrom = aws_ssm_parameter.smtp_username.arn },

--- a/infra/env/ecs.tf
+++ b/infra/env/ecs.tf
@@ -328,6 +328,8 @@ locals {
       { name = "TOKEN_ENCRYPTION_KEY", valueFrom = aws_ssm_parameter.token_encryption_key.arn },
       { name = "GOOGLE_CLIENT_ID", valueFrom = aws_ssm_parameter.google_client_id.arn },
       { name = "GOOGLE_CLIENT_SECRET", valueFrom = aws_ssm_parameter.google_client_secret.arn },
+      { name = "GOOGLE_CENTRAL_CLIENT_ID", valueFrom = aws_ssm_parameter.google_central_client_id.arn },
+      { name = "GOOGLE_CENTRAL_CLIENT_SECRET", valueFrom = aws_ssm_parameter.google_central_client_secret.arn },
       { name = "GOOGLE_CALENDAR_CENTRAL_ALLOWED_EMAIL", valueFrom = aws_ssm_parameter.google_calendar_central_allowed_email.arn },
       { name = "KAKAO_CLIENT_ID", valueFrom = aws_ssm_parameter.kakao_client_id.arn },
       { name = "KAKAO_APP_ID", valueFrom = aws_ssm_parameter.kakao_app_id.arn },

--- a/infra/env/envs/dev.tfvars
+++ b/infra/env/envs/dev.tfvars
@@ -8,7 +8,7 @@ db_name = "sclass_dev"
 # EC2 (dev: docker-compose + certbot SSL)
 dev_ec2_instance_type = "t4g.small"
 dev_ec2_domain        = "dev.sclass.click"
-dev_certbot_email     = ""  # TODO: Let's Encrypt 등록 이메일 설정
+dev_certbot_email     = "" # TODO: Let's Encrypt 등록 이메일 설정
 
 services = {
   supporters-api = {
@@ -23,11 +23,11 @@ services = {
   }
 }
 
-cors_allow_origins      = "http://localhost:3000,http://localhost:3100,http://localhost:3200,https://s-class.dev.aura.co.kr,https://s-class-backoffice.pages.dev,https://report-service-452628026107.asia-northeast3.run.app"
-report_service_base_url = "https://report-service-452628026107.asia-northeast3.run.app"
+cors_allow_origins               = "http://localhost:3000,http://localhost:3100,http://localhost:3200,https://s-class.dev.aura.co.kr,https://s-class-backoffice.pages.dev,https://report-service-452628026107.asia-northeast3.run.app"
+report_service_base_url          = "https://report-service-452628026107.asia-northeast3.run.app"
 report_service_callback_base_url = ""
-alimtalk_app_base_url = "https://sclass.aura.co.kr"
-frontend_url          = "https://sclass.aura.co.kr"
+alimtalk_app_base_url            = "https://sclass.aura.co.kr"
+frontend_url                     = "https://sclass.aura.co.kr"
 
 # SMTP
 smtp_host = "smtp.gmail.com"
@@ -36,3 +36,8 @@ smtp_port = "587"
 # JWT Expiry
 jwt_access_exp  = "3600"
 jwt_refresh_exp = "604800"
+
+# Google Calendar central account
+google_calendar_central_enabled       = "false"
+google_calendar_central_calendar_id   = "primary"
+google_calendar_central_allowed_email = ""

--- a/infra/env/envs/prod.tfvars
+++ b/infra/env/envs/prod.tfvars
@@ -3,7 +3,7 @@ aws_region  = "ap-northeast-2"
 domain      = "sclass.click"
 
 # Database
-db_name              = "sclass_prod"
+db_name = "sclass_prod"
 # ECS (prod)
 ecs_cpu    = "1024"
 ecs_memory = "2048"
@@ -21,9 +21,9 @@ services = {
   }
 }
 
-cors_allow_origins    = "https://aura.co.kr,https://app.aura.co.kr,https://lms.aura.co.kr,https://backoffice.aura.co.kr,https://sclass.aura.co.kr,https://academy.aura.co.kr"
-alimtalk_app_base_url = "https://sclass.aura.co.kr"
-frontend_url          = "https://sclass.aura.co.kr"
+cors_allow_origins               = "https://aura.co.kr,https://app.aura.co.kr,https://lms.aura.co.kr,https://backoffice.aura.co.kr,https://sclass.aura.co.kr,https://academy.aura.co.kr"
+alimtalk_app_base_url            = "https://sclass.aura.co.kr"
+frontend_url                     = "https://sclass.aura.co.kr"
 report_service_base_url          = "https://report-service-452628026107.asia-northeast3.run.app"
 report_service_callback_base_url = ""
 
@@ -34,3 +34,8 @@ smtp_port = "587"
 # JWT Expiry
 jwt_access_exp  = "3600"
 jwt_refresh_exp = "604800"
+
+# Google Calendar central account
+google_calendar_central_enabled       = "false"
+google_calendar_central_calendar_id   = "primary"
+google_calendar_central_allowed_email = ""

--- a/infra/env/ssm.tf
+++ b/infra/env/ssm.tf
@@ -49,6 +49,22 @@ resource "aws_ssm_parameter" "google_client_secret" {
   tags      = { Name = "${local.name_prefix}-ssm-google-client-secret" }
 }
 
+resource "aws_ssm_parameter" "google_central_client_id" {
+  name      = "/sclass/${var.environment}/GOOGLE_CENTRAL_CLIENT_ID"
+  type      = "SecureString"
+  value     = var.google_central_client_id
+  overwrite = true
+  tags      = { Name = "${local.name_prefix}-ssm-google-central-client" }
+}
+
+resource "aws_ssm_parameter" "google_central_client_secret" {
+  name      = "/sclass/${var.environment}/GOOGLE_CENTRAL_CLIENT_SECRET"
+  type      = "SecureString"
+  value     = var.google_central_client_secret
+  overwrite = true
+  tags      = { Name = "${local.name_prefix}-ssm-google-central-client-secret" }
+}
+
 resource "aws_ssm_parameter" "google_calendar_central_allowed_email" {
   name      = "/sclass/${var.environment}/GOOGLE_CALENDAR_CENTRAL_ALLOWED_EMAIL"
   type      = "String"

--- a/infra/env/ssm.tf
+++ b/infra/env/ssm.tf
@@ -49,6 +49,14 @@ resource "aws_ssm_parameter" "google_client_secret" {
   tags      = { Name = "${local.name_prefix}-ssm-google-client-secret" }
 }
 
+resource "aws_ssm_parameter" "google_calendar_central_allowed_email" {
+  name      = "/sclass/${var.environment}/GOOGLE_CALENDAR_CENTRAL_ALLOWED_EMAIL"
+  type      = "String"
+  value     = var.google_calendar_central_allowed_email
+  overwrite = true
+  tags      = { Name = "${local.name_prefix}-ssm-google-calendar-central-allowed-email" }
+}
+
 resource "aws_ssm_parameter" "kakao_client_id" {
   name      = "/sclass/${var.environment}/KAKAO_CLIENT_ID"
   type      = "SecureString"

--- a/infra/env/variables.tf
+++ b/infra/env/variables.tf
@@ -130,6 +130,17 @@ variable "google_client_secret" {
   sensitive = true
 }
 
+variable "google_central_client_id" {
+  type    = string
+  default = ""
+}
+
+variable "google_central_client_secret" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
 variable "google_calendar_central_enabled" {
   type    = string
   default = "false"

--- a/infra/env/variables.tf
+++ b/infra/env/variables.tf
@@ -130,6 +130,21 @@ variable "google_client_secret" {
   sensitive = true
 }
 
+variable "google_calendar_central_enabled" {
+  type    = string
+  default = "false"
+}
+
+variable "google_calendar_central_calendar_id" {
+  type    = string
+  default = "primary"
+}
+
+variable "google_calendar_central_allowed_email" {
+  type    = string
+  default = ""
+}
+
 variable "kakao_client_id" {
   type    = string
   default = ""

--- a/scripts/central-google-accounts-migration.sql
+++ b/scripts/central-google-accounts-migration.sql
@@ -1,0 +1,17 @@
+-- Central Google account connection schema.
+-- Run before deploying the central Google Calendar account feature because
+-- production services validate JPA mappings at startup.
+
+CREATE TABLE IF NOT EXISTS central_google_accounts (
+    provider VARCHAR(20) NOT NULL,
+    google_email VARCHAR(320) NOT NULL,
+    encrypted_refresh_token TEXT NOT NULL,
+    scope VARCHAR(500) NOT NULL,
+    connected_by_admin_user_id VARCHAR(26) NOT NULL,
+    connected_at DATETIME(6) NOT NULL,
+    last_used_at DATETIME(6) NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (provider),
+    KEY idx_central_google_email (google_email)
+);


### PR DESCRIPTION
## 요약
- 백오피스에서 중앙 Google 계정 연결 상태 조회, OAuth state 발급, 연결, 해제를 처리하는 API를 추가했습니다.
- 중앙 계정 refresh token은 DB에 암호화 저장하고, 허용 계정 이메일은 SSM/환경값으로 검증하도록 구성했습니다.
- 중앙 계정용 Calendar/Meet 이벤트 생성 client를 Infrastructure에 추가했습니다. DB 계정 조회/복호화는 usecase 책임으로 남기고, infra client는 refresh token 기반 Google API 호출만 담당합니다.
- Calendar event 생성 시 attendee 초대 및 sendUpdates 처리를 추가했습니다.
- Terraform/example application 설정에 중앙 Google Calendar 설정값을 추가했습니다.

## 제외
- lesson scheduling 연동 및 lesson table 변경은 이번 PR 범위에서 제외했습니다.
- Meet Media API 기반 STT/녹화 artifact 수집은 후속 POC로 분리합니다.

## 테스트
- pre-commit ktlintFormat/build
- ./gradlew :SClass-Infrastructure:test --tests "*CentralGoogleCalendarClientTest" --tests "*GoogleCalendarClientTest" --tests "*GoogleCentralCalendarPropertiesTest" :SClass-Api-Backoffice:test --tests "*ConnectCentralGoogleUseCaseTest" --tests "*GetCentralGoogleConnectionStatusUseCaseTest"
- terraform fmt -check infra/env/variables.tf infra/env/ssm.tf infra/env/ecs.tf infra/env/envs/dev.tfvars infra/env/envs/prod.tfvars
- git diff --check

Closes #299