### PR TITLE
feat: add lesson central meet scheduling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,6 @@ root = true
 
 [*.{kt,kts}]
 ktlint_standard_no-blank-line-in-list = disabled
+ij_kotlin_name_count_to_use_star_import = 999
+ij_kotlin_name_count_to_use_star_import_for_members = 999
+ij_kotlin_packages_to_use_import_on_demand =

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/EnrollmentLessonListResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/enrollment/dto/EnrollmentLessonListResponse.kt
@@ -19,6 +19,8 @@ data class EnrollmentLessonResponse(
     val startedAt: LocalDateTime?,
     val completedAt: LocalDateTime?,
     val createdAt: LocalDateTime,
+    val googleMeetJoinUrl: String?,
+    val googleMeetCode: String?,
 ) {
     companion object {
         fun from(lesson: Lesson) =
@@ -32,6 +34,8 @@ data class EnrollmentLessonResponse(
                 startedAt = lesson.startedAt,
                 completedAt = lesson.completedAt,
                 createdAt = lesson.createdAt,
+                googleMeetJoinUrl = lesson.googleMeet?.joinUrl,
+                googleMeetCode = lesson.googleMeet?.code,
             )
     }
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/dto/LessonResponse.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/dto/LessonResponse.kt
@@ -22,6 +22,8 @@ data class LessonResponse(
     val completedAt: LocalDateTime?,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
+    val googleMeetJoinUrl: String?,
+    val googleMeetCode: String?,
 ) {
     companion object {
         fun from(lesson: Lesson) =
@@ -42,6 +44,8 @@ data class LessonResponse(
                 completedAt = lesson.completedAt,
                 createdAt = lesson.createdAt,
                 updatedAt = lesson.updatedAt,
+                googleMeetJoinUrl = lesson.googleMeet?.joinUrl,
+                googleMeetCode = lesson.googleMeet?.code,
             )
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/controller/LessonController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/controller/LessonController.kt
@@ -10,12 +10,14 @@ import com.sclass.supporters.lesson.dto.LessonDetailResponse
 import com.sclass.supporters.lesson.dto.LessonReportResponse
 import com.sclass.supporters.lesson.dto.LessonResponse
 import com.sclass.supporters.lesson.dto.RecordLessonRequest
+import com.sclass.supporters.lesson.dto.ScheduleLessonRequest
 import com.sclass.supporters.lesson.dto.StartLessonRequest
 import com.sclass.supporters.lesson.dto.SubmitLessonReportRequest
 import com.sclass.supporters.lesson.dto.UpdateLessonReportRequest
 import com.sclass.supporters.lesson.dto.UpdateLessonRequest
 import com.sclass.supporters.lesson.usecase.CompleteLessonUseCase
 import com.sclass.supporters.lesson.usecase.CreateLessonInquiryPlanUseCase
+import com.sclass.supporters.lesson.usecase.CreateLessonScheduleUseCase
 import com.sclass.supporters.lesson.usecase.GetLessonDetailUseCase
 import com.sclass.supporters.lesson.usecase.GetLessonReportUseCase
 import com.sclass.supporters.lesson.usecase.GetMySubstituteLessonsUseCase
@@ -23,6 +25,7 @@ import com.sclass.supporters.lesson.usecase.RecordLessonUseCase
 import com.sclass.supporters.lesson.usecase.StartLessonUseCase
 import com.sclass.supporters.lesson.usecase.SubmitLessonReportUseCase
 import com.sclass.supporters.lesson.usecase.UpdateLessonReportUseCase
+import com.sclass.supporters.lesson.usecase.UpdateLessonScheduleUseCase
 import com.sclass.supporters.lesson.usecase.UpdateLessonUseCase
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
@@ -48,6 +51,8 @@ class LessonController(
     private val startLessonUseCase: StartLessonUseCase,
     private val completeLessonUseCase: CompleteLessonUseCase,
     private val recordLessonUseCase: RecordLessonUseCase,
+    private val createLessonScheduleUseCase: CreateLessonScheduleUseCase,
+    private val updateLessonScheduleUseCase: UpdateLessonScheduleUseCase,
 ) {
     @GetMapping("/my/substitutes")
     fun mySubstituteLessons(
@@ -61,6 +66,7 @@ class LessonController(
         @PathVariable lessonId: Long,
     ): ApiResponse<LessonDetailResponse> = ApiResponse.success(getLessonDetailUseCase.execute(userId, lessonId))
 
+    @Deprecated("Use POST/PUT /api/v1/lessons/{lessonId}/schedule")
     @PatchMapping("/{lessonId}")
     fun update(
         @CurrentUserId userId: String,
@@ -116,4 +122,32 @@ class LessonController(
         @PathVariable lessonId: Long,
         @Valid @RequestBody request: RecordLessonRequest,
     ): ApiResponse<LessonResponse> = ApiResponse.success(recordLessonUseCase.execute(userId, lessonId, request))
+
+    @PostMapping("/{lessonId}/schedule")
+    fun createSchedule(
+        @CurrentUserId userId: String,
+        @PathVariable lessonId: Long,
+        @Valid @RequestBody request: ScheduleLessonRequest,
+    ): ApiResponse<LessonResponse> =
+        ApiResponse.success(
+            createLessonScheduleUseCase.execute(
+                userId,
+                lessonId,
+                request,
+            ),
+        )
+
+    @PutMapping("/{lessonId}/schedule")
+    fun updateSchedule(
+        @CurrentUserId userId: String,
+        @PathVariable lessonId: Long,
+        @Valid @RequestBody request: ScheduleLessonRequest,
+    ): ApiResponse<LessonResponse> =
+        ApiResponse.success(
+            updateLessonScheduleUseCase.execute(
+                userId,
+                lessonId,
+                request,
+            ),
+        )
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/LessonDetailResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/LessonDetailResponse.kt
@@ -24,6 +24,8 @@ data class LessonDetailResponse(
     val completedAt: LocalDateTime?,
     val inquiryPlans: List<InquiryPlanResponse>,
     val createdAt: LocalDateTime,
+    val googleMeetJoinUrl: String?,
+    val googleMeetCode: String?,
 ) {
     companion object {
         fun from(
@@ -47,6 +49,8 @@ data class LessonDetailResponse(
             completedAt = lesson.completedAt,
             inquiryPlans = inquiryPlans,
             createdAt = lesson.createdAt,
+            googleMeetJoinUrl = lesson.googleMeet?.joinUrl,
+            googleMeetCode = lesson.googleMeet?.code,
         )
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/LessonResponse.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/LessonResponse.kt
@@ -16,6 +16,8 @@ data class LessonResponse(
     val scheduledAt: LocalDateTime?,
     val startedAt: LocalDateTime?,
     val completedAt: LocalDateTime?,
+    val googleMeetJoinUrl: String?,
+    val googleMeetCode: String?,
 ) {
     companion object {
         fun from(lesson: Lesson) =
@@ -30,6 +32,8 @@ data class LessonResponse(
                 scheduledAt = lesson.scheduledAt,
                 startedAt = lesson.startedAt,
                 completedAt = lesson.completedAt,
+                googleMeetJoinUrl = lesson.googleMeet?.joinUrl,
+                googleMeetCode = lesson.googleMeet?.code,
             )
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/ScheduleLessonRequest.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/dto/ScheduleLessonRequest.kt
@@ -1,0 +1,13 @@
+package com.sclass.supporters.lesson.dto
+
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
+
+data class ScheduleLessonRequest(
+    @field:Size(max = 200)
+    val name: String? = null,
+
+    @field:NotNull
+    val scheduledAt: LocalDateTime?,
+)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -82,7 +82,7 @@ class CreateLessonScheduleUseCase(
                 studentUserId = lesson.studentUserId,
                 teacherUserId = lesson.effectiveTeacherUserId,
                 scheduledAt = scheduledAt,
-                durationMinutes = Lesson.DEFAULT_DURATION_MINUTES,
+                requestedDurationMinutes = Lesson.DEFAULT_DURATION_MINUTES,
                 excludeLessonId = lesson.id,
             )
         ) {

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -1,0 +1,103 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.exception.LessonScheduleAlreadyExistsException
+import com.sclass.domain.domains.lesson.exception.LessonScheduleConflictException
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.user.adaptor.UserAdaptor
+import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
+import com.sclass.supporters.lesson.dto.LessonResponse
+import com.sclass.supporters.lesson.dto.ScheduleLessonRequest
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@UseCase
+class CreateLessonScheduleUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val userAdaptor: UserAdaptor,
+    private val aesTokenEncryptor: AesTokenEncryptor,
+    private val centralGoogleCalendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    @Transactional
+    fun execute(
+        userId: String,
+        lessonId: Long,
+        request: ScheduleLessonRequest,
+    ): LessonResponse {
+        val lesson = lessonAdaptor.findById(lessonId)
+        if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
+        if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
+
+        val scheduledAt = requireNotNull(request.scheduledAt)
+        validateNoScheduleConflict(lesson, scheduledAt)
+
+        lesson.updateSchedule(request.name, scheduledAt)
+        createGoogleMeet(lesson)
+
+        return LessonResponse.from(lesson)
+    }
+
+    private fun validateNoScheduleConflict(
+        lesson: Lesson,
+        scheduledAt: LocalDateTime,
+    ) {
+        if (
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = lesson.studentUserId,
+                teacherUserId = lesson.effectiveTeacherUserId,
+                scheduledAt = scheduledAt,
+                durationMinutes = DEFAULT_LESSON_DURATION_MINUTES,
+                excludeLessonId = lesson.id,
+            )
+        ) {
+            throw LessonScheduleConflictException()
+        }
+    }
+
+    private fun createGoogleMeet(lesson: Lesson) {
+        val calendarClient = centralGoogleCalendarClientProvider.getIfAvailable() ?: throw GoogleCalendarCentralDisabledException()
+
+        val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+        val refreshToken = aesTokenEncryptor.decrypt(centralAccount.encryptedRefreshToken)
+        val command = lesson.toGoogleCalendarCommand()
+
+        val result = calendarClient.createMeetEventWithRefreshToken(refreshToken, command)
+
+        lesson.attachGoogleMeet(
+            eventId = result.eventId,
+            meetJoinUrl = result.meetJoinUrl,
+            meetCode = result.meetCode,
+        )
+
+        centralAccount.markUsed(LocalDateTime.now(clock))
+    }
+
+    private fun Lesson.toGoogleCalendarCommand(): GoogleCalendarEventCreateCommand {
+        val scheduledAt = requireNotNull(scheduledAt)
+        val teacher = userAdaptor.findById(effectiveTeacherUserId)
+        val student = userAdaptor.findById(studentUserId)
+
+        return GoogleCalendarEventCreateCommand(
+            summary = name,
+            startAt = scheduledAt.atZone(SEOUL_ZONE_ID),
+            endAt = scheduledAt.plusMinutes(DEFAULT_LESSON_DURATION_MINUTES).atZone(SEOUL_ZONE_ID),
+            attendeeEmails = listOf(teacher.email, student.email).distinct(),
+        )
+    }
+
+    private companion object {
+        val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
+        const val DEFAULT_LESSON_DURATION_MINUTES = 60L
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -15,6 +15,7 @@ import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
 import com.sclass.supporters.lesson.dto.LessonResponse
 import com.sclass.supporters.lesson.dto.ScheduleLessonRequest
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.Clock
@@ -31,6 +32,8 @@ class CreateLessonScheduleUseCase(
     private val txTemplate: TransactionTemplate,
     private val clock: Clock = Clock.systemDefaultZone(),
 ) {
+    private val log = LoggerFactory.getLogger(CreateLessonScheduleUseCase::class.java)
+
     fun execute(
         userId: String,
         lessonId: Long,
@@ -43,7 +46,12 @@ class CreateLessonScheduleUseCase(
                 command = prepared.command,
             )
 
-        return saveSchedule(lessonId, request, prepared.scheduledAt, result)
+        return try {
+            saveSchedule(userId, lessonId, request, prepared.scheduledAt, result)
+        } catch (e: RuntimeException) {
+            deleteCreatedCalendarEvent(prepared, result.eventId)
+            throw e
+        }
     }
 
     private fun prepareSchedule(
@@ -91,6 +99,7 @@ class CreateLessonScheduleUseCase(
     }
 
     private fun saveSchedule(
+        userId: String,
         lessonId: Long,
         request: ScheduleLessonRequest,
         scheduledAt: LocalDateTime,
@@ -98,6 +107,10 @@ class CreateLessonScheduleUseCase(
     ): LessonResponse =
         txTemplate.execute {
             val lesson = lessonAdaptor.findById(lessonId)
+            if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
+            if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
+            validateNoScheduleConflict(lesson, scheduledAt)
+
             lesson.updateSchedule(request.name, scheduledAt)
             lesson.attachGoogleMeet(
                 eventId = result.eventId,
@@ -109,6 +122,20 @@ class CreateLessonScheduleUseCase(
             centralAccount.markUsed(LocalDateTime.now(clock))
             LessonResponse.from(lesson)
         }!!
+
+    private fun deleteCreatedCalendarEvent(
+        prepared: PreparedCreateSchedule,
+        eventId: String,
+    ) {
+        runCatching {
+            prepared.calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = prepared.refreshToken,
+                eventId = eventId,
+            )
+        }.onFailure {
+            log.warn("Failed to delete Google Calendar event after lesson schedule save failed: eventId={}", eventId, it)
+        }
+    }
 
     private fun Lesson.toGoogleCalendarCommand(
         name: String?,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -12,10 +12,11 @@ import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
 import com.sclass.domain.domains.user.adaptor.UserAdaptor
 import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
 import com.sclass.supporters.lesson.dto.LessonResponse
 import com.sclass.supporters.lesson.dto.ScheduleLessonRequest
 import org.springframework.beans.factory.ObjectProvider
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -27,26 +28,50 @@ class CreateLessonScheduleUseCase(
     private val userAdaptor: UserAdaptor,
     private val aesTokenEncryptor: AesTokenEncryptor,
     private val centralGoogleCalendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>,
+    private val txTemplate: TransactionTemplate,
     private val clock: Clock = Clock.systemDefaultZone(),
 ) {
-    @Transactional
     fun execute(
         userId: String,
         lessonId: Long,
         request: ScheduleLessonRequest,
     ): LessonResponse {
-        val lesson = lessonAdaptor.findById(lessonId)
-        if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
-        if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
+        val prepared = prepareSchedule(userId, lessonId, request)
+        val result =
+            prepared.calendarClient.createMeetEventWithRefreshToken(
+                refreshToken = prepared.refreshToken,
+                command = prepared.command,
+            )
 
-        val scheduledAt = requireNotNull(request.scheduledAt)
-        validateNoScheduleConflict(lesson, scheduledAt)
-
-        lesson.updateSchedule(request.name, scheduledAt)
-        createGoogleMeet(lesson)
-
-        return LessonResponse.from(lesson)
+        return saveSchedule(lessonId, request, prepared.scheduledAt, result)
     }
+
+    private fun prepareSchedule(
+        userId: String,
+        lessonId: Long,
+        request: ScheduleLessonRequest,
+    ): PreparedCreateSchedule =
+        txTemplate.execute {
+            val scheduledAt = requireNotNull(request.scheduledAt)
+            val lesson = lessonAdaptor.findById(lessonId)
+            if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
+            if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
+
+            validateNoScheduleConflict(lesson, scheduledAt)
+
+            val calendarClient =
+                centralGoogleCalendarClientProvider.getIfAvailable()
+                    ?: throw GoogleCalendarCentralDisabledException()
+            val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+            val refreshToken = aesTokenEncryptor.decrypt(centralAccount.encryptedRefreshToken)
+
+            PreparedCreateSchedule(
+                scheduledAt = scheduledAt,
+                command = lesson.toGoogleCalendarCommand(request.name, scheduledAt),
+                calendarClient = calendarClient,
+                refreshToken = refreshToken,
+            )
+        }!!
 
     private fun validateNoScheduleConflict(
         lesson: Lesson,
@@ -57,7 +82,7 @@ class CreateLessonScheduleUseCase(
                 studentUserId = lesson.studentUserId,
                 teacherUserId = lesson.effectiveTeacherUserId,
                 scheduledAt = scheduledAt,
-                durationMinutes = DEFAULT_LESSON_DURATION_MINUTES,
+                durationMinutes = Lesson.DEFAULT_DURATION_MINUTES,
                 excludeLessonId = lesson.id,
             )
         ) {
@@ -65,39 +90,49 @@ class CreateLessonScheduleUseCase(
         }
     }
 
-    private fun createGoogleMeet(lesson: Lesson) {
-        val calendarClient = centralGoogleCalendarClientProvider.getIfAvailable() ?: throw GoogleCalendarCentralDisabledException()
+    private fun saveSchedule(
+        lessonId: Long,
+        request: ScheduleLessonRequest,
+        scheduledAt: LocalDateTime,
+        result: GoogleCalendarEventResult,
+    ): LessonResponse =
+        txTemplate.execute {
+            val lesson = lessonAdaptor.findById(lessonId)
+            lesson.updateSchedule(request.name, scheduledAt)
+            lesson.attachGoogleMeet(
+                eventId = result.eventId,
+                meetJoinUrl = result.meetJoinUrl,
+                meetCode = result.meetCode,
+            )
 
-        val centralAccount = centralGoogleAccountAdaptor.findGoogle()
-        val refreshToken = aesTokenEncryptor.decrypt(centralAccount.encryptedRefreshToken)
-        val command = lesson.toGoogleCalendarCommand()
+            val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+            centralAccount.markUsed(LocalDateTime.now(clock))
+            LessonResponse.from(lesson)
+        }!!
 
-        val result = calendarClient.createMeetEventWithRefreshToken(refreshToken, command)
-
-        lesson.attachGoogleMeet(
-            eventId = result.eventId,
-            meetJoinUrl = result.meetJoinUrl,
-            meetCode = result.meetCode,
-        )
-
-        centralAccount.markUsed(LocalDateTime.now(clock))
-    }
-
-    private fun Lesson.toGoogleCalendarCommand(): GoogleCalendarEventCreateCommand {
-        val scheduledAt = requireNotNull(scheduledAt)
+    private fun Lesson.toGoogleCalendarCommand(
+        name: String?,
+        scheduledAt: LocalDateTime,
+    ): GoogleCalendarEventCreateCommand {
         val teacher = userAdaptor.findById(effectiveTeacherUserId)
         val student = userAdaptor.findById(studentUserId)
 
         return GoogleCalendarEventCreateCommand(
-            summary = name,
+            summary = name ?: this.name,
             startAt = scheduledAt.atZone(SEOUL_ZONE_ID),
-            endAt = scheduledAt.plusMinutes(DEFAULT_LESSON_DURATION_MINUTES).atZone(SEOUL_ZONE_ID),
+            endAt = scheduledAt.plusMinutes(Lesson.DEFAULT_DURATION_MINUTES).atZone(SEOUL_ZONE_ID),
             attendeeEmails = listOf(teacher.email, student.email).distinct(),
         )
     }
 
+    private data class PreparedCreateSchedule(
+        val scheduledAt: LocalDateTime,
+        val command: GoogleCalendarEventCreateCommand,
+        val calendarClient: CentralGoogleCalendarClient,
+        val refreshToken: String,
+    )
+
     private companion object {
         val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
-        const val DEFAULT_LESSON_DURATION_MINUTES = 60L
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -64,6 +64,7 @@ class CreateLessonScheduleUseCase(
             val lesson = lessonAdaptor.findById(lessonId)
             if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
             if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
+            lesson.validateScheduleUpdatable()
 
             validateNoScheduleConflict(lesson, scheduledAt)
 
@@ -109,6 +110,7 @@ class CreateLessonScheduleUseCase(
             val lesson = lessonAdaptor.findById(lessonId)
             if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
             if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
+            lesson.validateScheduleUpdatable()
             validateNoScheduleConflict(lesson, scheduledAt)
 
             lesson.updateSchedule(request.name, scheduledAt)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -94,7 +94,7 @@ class UpdateLessonScheduleUseCase(
                 studentUserId = lesson.studentUserId,
                 teacherUserId = lesson.effectiveTeacherUserId,
                 scheduledAt = scheduledAt,
-                durationMinutes = Lesson.DEFAULT_DURATION_MINUTES,
+                requestedDurationMinutes = Lesson.DEFAULT_DURATION_MINUTES,
                 excludeLessonId = lesson.id,
             )
         ) {

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -12,10 +12,11 @@ import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
 import com.sclass.domain.domains.user.adaptor.UserAdaptor
 import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
 import com.sclass.supporters.lesson.dto.LessonResponse
 import com.sclass.supporters.lesson.dto.ScheduleLessonRequest
 import org.springframework.beans.factory.ObjectProvider
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -27,29 +28,62 @@ class UpdateLessonScheduleUseCase(
     private val userAdaptor: UserAdaptor,
     private val aesTokenEncryptor: AesTokenEncryptor,
     private val centralGoogleCalendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>,
+    private val txTemplate: TransactionTemplate,
     private val clock: Clock = Clock.systemDefaultZone(),
 ) {
-    @Transactional
     fun execute(
         userId: String,
         lessonId: Long,
         request: ScheduleLessonRequest,
     ): LessonResponse {
-        val lesson = lessonAdaptor.findById(lessonId)
-        if (!lesson.isTeacher(userId)) {
-            throw LessonUnauthorizedAccessException()
-        }
+        val prepared = prepareSchedule(userId, lessonId, request)
+        val result =
+            if (prepared.eventId.isNullOrBlank()) {
+                prepared.calendarClient.createMeetEventWithRefreshToken(
+                    refreshToken = prepared.refreshToken,
+                    command = prepared.command,
+                )
+            } else {
+                prepared.calendarClient.updateMeetEventWithRefreshToken(
+                    refreshToken = prepared.refreshToken,
+                    eventId = prepared.eventId,
+                    command = prepared.command,
+                )
+            }
 
-        if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
-
-        val scheduledAt = requireNotNull(request.scheduledAt)
-        validateNoScheduleConflict(lesson, scheduledAt)
-
-        lesson.updateSchedule(request.name, scheduledAt)
-        syncGoogleMeet(lesson)
-
-        return LessonResponse.from(lesson)
+        return saveSchedule(lessonId, request, prepared.scheduledAt, result)
     }
+
+    private fun prepareSchedule(
+        userId: String,
+        lessonId: Long,
+        request: ScheduleLessonRequest,
+    ): PreparedUpdateSchedule =
+        txTemplate.execute {
+            val scheduledAt = requireNotNull(request.scheduledAt)
+            val lesson = lessonAdaptor.findById(lessonId)
+            if (!lesson.isTeacher(userId)) {
+                throw LessonUnauthorizedAccessException()
+            }
+
+            if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
+
+            validateNoScheduleConflict(lesson, scheduledAt)
+
+            val calendarClient =
+                centralGoogleCalendarClientProvider.getIfAvailable()
+                    ?: throw GoogleCalendarCentralDisabledException()
+            val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+            val refreshToken = aesTokenEncryptor.decrypt(centralAccount.encryptedRefreshToken)
+
+            PreparedUpdateSchedule(
+                scheduledAt = scheduledAt,
+                command = lesson.toGoogleCalendarCommand(request.name, scheduledAt),
+                calendarClient = calendarClient,
+                refreshToken = refreshToken,
+                eventId = lesson.googleMeet?.calendarEventId,
+            )
+        }!!
 
     private fun validateNoScheduleConflict(
         lesson: Lesson,
@@ -60,7 +94,7 @@ class UpdateLessonScheduleUseCase(
                 studentUserId = lesson.studentUserId,
                 teacherUserId = lesson.effectiveTeacherUserId,
                 scheduledAt = scheduledAt,
-                durationMinutes = DEFAULT_LESSON_DURATION_MINUTES,
+                durationMinutes = Lesson.DEFAULT_DURATION_MINUTES,
                 excludeLessonId = lesson.id,
             )
         ) {
@@ -68,46 +102,38 @@ class UpdateLessonScheduleUseCase(
         }
     }
 
-    private fun syncGoogleMeet(lesson: Lesson) {
-        val calendarClient =
-            centralGoogleCalendarClientProvider.getIfAvailable()
-                ?: throw GoogleCalendarCentralDisabledException()
+    private fun saveSchedule(
+        lessonId: Long,
+        request: ScheduleLessonRequest,
+        scheduledAt: LocalDateTime,
+        result: GoogleCalendarEventResult,
+    ): LessonResponse =
+        txTemplate.execute {
+            val lesson = lessonAdaptor.findById(lessonId)
+            lesson.updateSchedule(request.name, scheduledAt)
+            lesson.attachGoogleMeet(
+                eventId = result.eventId,
+                meetJoinUrl = result.meetJoinUrl,
+                meetCode = result.meetCode,
+            )
 
-        val centralAccount = centralGoogleAccountAdaptor.findGoogle()
-        val refreshToken =
-            aesTokenEncryptor.decrypt(centralAccount.encryptedRefreshToken)
-        val command = lesson.toGoogleCalendarCommand()
-        val eventId = lesson.googleMeet?.calendarEventId
+            val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+            centralAccount.markUsed(LocalDateTime.now(clock))
+            LessonResponse.from(lesson)
+        }!!
 
-        val result =
-            if (eventId.isNullOrBlank()) {
-                calendarClient.createMeetEventWithRefreshToken(refreshToken, command)
-            } else {
-                calendarClient.updateMeetEventWithRefreshToken(
-                    refreshToken = refreshToken,
-                    eventId = eventId,
-                    command = command,
-                )
-            }
-
-        lesson.attachGoogleMeet(
-            eventId = result.eventId,
-            meetJoinUrl = result.meetJoinUrl,
-            meetCode = result.meetCode,
-        )
-        centralAccount.markUsed(LocalDateTime.now(clock))
-    }
-
-    private fun Lesson.toGoogleCalendarCommand(): GoogleCalendarEventCreateCommand {
-        val scheduledAt = requireNotNull(scheduledAt)
+    private fun Lesson.toGoogleCalendarCommand(
+        name: String?,
+        scheduledAt: LocalDateTime,
+    ): GoogleCalendarEventCreateCommand {
         val teacher = userAdaptor.findById(effectiveTeacherUserId)
         val student = userAdaptor.findById(studentUserId)
 
         return GoogleCalendarEventCreateCommand(
-            summary = name,
+            summary = name ?: this.name,
             startAt = scheduledAt.atZone(SEOUL_ZONE_ID),
             endAt =
-                scheduledAt.plusMinutes(DEFAULT_LESSON_DURATION_MINUTES).atZone(SEOUL_ZONE_ID),
+                scheduledAt.plusMinutes(Lesson.DEFAULT_DURATION_MINUTES).atZone(SEOUL_ZONE_ID),
             attendeeEmails =
                 listOf(
                     teacher.email,
@@ -116,8 +142,15 @@ class UpdateLessonScheduleUseCase(
         )
     }
 
+    private data class PreparedUpdateSchedule(
+        val scheduledAt: LocalDateTime,
+        val command: GoogleCalendarEventCreateCommand,
+        val calendarClient: CentralGoogleCalendarClient,
+        val refreshToken: String,
+        val eventId: String?,
+    )
+
     private companion object {
         val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
-        const val DEFAULT_LESSON_DURATION_MINUTES = 60L
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -75,6 +75,7 @@ class UpdateLessonScheduleUseCase(
             }
 
             val currentScheduledAt = lesson.scheduledAt ?: throw LessonScheduleNotFoundException()
+            lesson.validateScheduleUpdatable()
 
             validateNoScheduleConflict(lesson, scheduledAt)
 
@@ -122,6 +123,7 @@ class UpdateLessonScheduleUseCase(
             val lesson = lessonAdaptor.findById(lessonId)
             if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
             if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
+            lesson.validateScheduleUpdatable()
             validateNoScheduleConflict(lesson, scheduledAt)
 
             lesson.updateSchedule(request.name, scheduledAt)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -1,0 +1,123 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.exception.LessonScheduleConflictException
+import com.sclass.domain.domains.lesson.exception.LessonScheduleNotFoundException
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.user.adaptor.UserAdaptor
+import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
+import com.sclass.supporters.lesson.dto.LessonResponse
+import com.sclass.supporters.lesson.dto.ScheduleLessonRequest
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@UseCase
+class UpdateLessonScheduleUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val userAdaptor: UserAdaptor,
+    private val aesTokenEncryptor: AesTokenEncryptor,
+    private val centralGoogleCalendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    @Transactional
+    fun execute(
+        userId: String,
+        lessonId: Long,
+        request: ScheduleLessonRequest,
+    ): LessonResponse {
+        val lesson = lessonAdaptor.findById(lessonId)
+        if (!lesson.isTeacher(userId)) {
+            throw LessonUnauthorizedAccessException()
+        }
+
+        if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
+
+        val scheduledAt = requireNotNull(request.scheduledAt)
+        validateNoScheduleConflict(lesson, scheduledAt)
+
+        lesson.updateSchedule(request.name, scheduledAt)
+        syncGoogleMeet(lesson)
+
+        return LessonResponse.from(lesson)
+    }
+
+    private fun validateNoScheduleConflict(
+        lesson: Lesson,
+        scheduledAt: LocalDateTime,
+    ) {
+        if (
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = lesson.studentUserId,
+                teacherUserId = lesson.effectiveTeacherUserId,
+                scheduledAt = scheduledAt,
+                durationMinutes = DEFAULT_LESSON_DURATION_MINUTES,
+                excludeLessonId = lesson.id,
+            )
+        ) {
+            throw LessonScheduleConflictException()
+        }
+    }
+
+    private fun syncGoogleMeet(lesson: Lesson) {
+        val calendarClient =
+            centralGoogleCalendarClientProvider.getIfAvailable()
+                ?: throw GoogleCalendarCentralDisabledException()
+
+        val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+        val refreshToken =
+            aesTokenEncryptor.decrypt(centralAccount.encryptedRefreshToken)
+        val command = lesson.toGoogleCalendarCommand()
+        val eventId = lesson.googleMeet?.calendarEventId
+
+        val result =
+            if (eventId.isNullOrBlank()) {
+                calendarClient.createMeetEventWithRefreshToken(refreshToken, command)
+            } else {
+                calendarClient.updateMeetEventWithRefreshToken(
+                    refreshToken = refreshToken,
+                    eventId = eventId,
+                    command = command,
+                )
+            }
+
+        lesson.attachGoogleMeet(
+            eventId = result.eventId,
+            meetJoinUrl = result.meetJoinUrl,
+            meetCode = result.meetCode,
+        )
+        centralAccount.markUsed(LocalDateTime.now(clock))
+    }
+
+    private fun Lesson.toGoogleCalendarCommand(): GoogleCalendarEventCreateCommand {
+        val scheduledAt = requireNotNull(scheduledAt)
+        val teacher = userAdaptor.findById(effectiveTeacherUserId)
+        val student = userAdaptor.findById(studentUserId)
+
+        return GoogleCalendarEventCreateCommand(
+            summary = name,
+            startAt = scheduledAt.atZone(SEOUL_ZONE_ID),
+            endAt =
+                scheduledAt.plusMinutes(DEFAULT_LESSON_DURATION_MINUTES).atZone(SEOUL_ZONE_ID),
+            attendeeEmails =
+                listOf(
+                    teacher.email,
+                    student.email,
+                ).distinct(),
+        )
+    }
+
+    private companion object {
+        val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
+        const val DEFAULT_LESSON_DURATION_MINUTES = 60L
+    }
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -15,6 +15,7 @@ import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
 import com.sclass.supporters.lesson.dto.LessonResponse
 import com.sclass.supporters.lesson.dto.ScheduleLessonRequest
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.Clock
@@ -31,6 +32,8 @@ class UpdateLessonScheduleUseCase(
     private val txTemplate: TransactionTemplate,
     private val clock: Clock = Clock.systemDefaultZone(),
 ) {
+    private val log = LoggerFactory.getLogger(UpdateLessonScheduleUseCase::class.java)
+
     fun execute(
         userId: String,
         lessonId: Long,
@@ -51,7 +54,12 @@ class UpdateLessonScheduleUseCase(
                 )
             }
 
-        return saveSchedule(lessonId, request, prepared.scheduledAt, result)
+        return try {
+            saveSchedule(userId, lessonId, request, prepared.scheduledAt, result)
+        } catch (e: RuntimeException) {
+            rollbackCalendarEvent(prepared, result)
+            throw e
+        }
     }
 
     private fun prepareSchedule(
@@ -66,7 +74,7 @@ class UpdateLessonScheduleUseCase(
                 throw LessonUnauthorizedAccessException()
             }
 
-            if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
+            val currentScheduledAt = lesson.scheduledAt ?: throw LessonScheduleNotFoundException()
 
             validateNoScheduleConflict(lesson, scheduledAt)
 
@@ -79,6 +87,7 @@ class UpdateLessonScheduleUseCase(
             PreparedUpdateSchedule(
                 scheduledAt = scheduledAt,
                 command = lesson.toGoogleCalendarCommand(request.name, scheduledAt),
+                previousCommand = lesson.toGoogleCalendarCommand(lesson.name, currentScheduledAt),
                 calendarClient = calendarClient,
                 refreshToken = refreshToken,
                 eventId = lesson.googleMeet?.calendarEventId,
@@ -103,6 +112,7 @@ class UpdateLessonScheduleUseCase(
     }
 
     private fun saveSchedule(
+        userId: String,
         lessonId: Long,
         request: ScheduleLessonRequest,
         scheduledAt: LocalDateTime,
@@ -110,6 +120,10 @@ class UpdateLessonScheduleUseCase(
     ): LessonResponse =
         txTemplate.execute {
             val lesson = lessonAdaptor.findById(lessonId)
+            if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
+            if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
+            validateNoScheduleConflict(lesson, scheduledAt)
+
             lesson.updateSchedule(request.name, scheduledAt)
             lesson.attachGoogleMeet(
                 eventId = result.eventId,
@@ -121,6 +135,47 @@ class UpdateLessonScheduleUseCase(
             centralAccount.markUsed(LocalDateTime.now(clock))
             LessonResponse.from(lesson)
         }!!
+
+    private fun rollbackCalendarEvent(
+        prepared: PreparedUpdateSchedule,
+        result: GoogleCalendarEventResult,
+    ) {
+        if (prepared.eventId.isNullOrBlank()) {
+            deleteCreatedCalendarEvent(prepared, result.eventId)
+        } else {
+            restoreUpdatedCalendarEvent(prepared)
+        }
+    }
+
+    private fun deleteCreatedCalendarEvent(
+        prepared: PreparedUpdateSchedule,
+        eventId: String,
+    ) {
+        runCatching {
+            prepared.calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = prepared.refreshToken,
+                eventId = eventId,
+            )
+        }.onFailure {
+            log.warn("Failed to delete Google Calendar event after lesson schedule save failed: eventId={}", eventId, it)
+        }
+    }
+
+    private fun restoreUpdatedCalendarEvent(prepared: PreparedUpdateSchedule) {
+        runCatching {
+            prepared.calendarClient.updateMeetEventWithRefreshToken(
+                refreshToken = prepared.refreshToken,
+                eventId = prepared.eventId!!,
+                command = prepared.previousCommand,
+            )
+        }.onFailure {
+            log.warn(
+                "Failed to restore Google Calendar event after lesson schedule save failed: eventId={}",
+                prepared.eventId,
+                it,
+            )
+        }
+    }
 
     private fun Lesson.toGoogleCalendarCommand(
         name: String?,
@@ -145,6 +200,7 @@ class UpdateLessonScheduleUseCase(
     private data class PreparedUpdateSchedule(
         val scheduledAt: LocalDateTime,
         val command: GoogleCalendarEventCreateCommand,
+        val previousCommand: GoogleCalendarEventCreateCommand,
         val calendarClient: CentralGoogleCalendarClient,
         val refreshToken: String,
         val eventId: String?,

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonUseCase.kt
@@ -2,6 +2,7 @@ package com.sclass.supporters.lesson.usecase
 
 import com.sclass.common.annotation.UseCase
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.exception.LessonScheduleSyncRequiredException
 import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
 import com.sclass.supporters.lesson.dto.LessonResponse
 import com.sclass.supporters.lesson.dto.UpdateLessonRequest
@@ -21,7 +22,10 @@ class UpdateLessonUseCase(
         if (!lesson.isTeacher(userId)) {
             throw LessonUnauthorizedAccessException()
         }
-        lesson.updateSchedule(request.name, request.scheduledAt)
+        if (request.scheduledAt != null) {
+            throw LessonScheduleSyncRequiredException()
+        }
+        lesson.updateSchedule(request.name, null)
         return LessonResponse.from(lesson)
     }
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonUseCase.kt
@@ -25,6 +25,9 @@ class UpdateLessonUseCase(
         if (request.scheduledAt != null) {
             throw LessonScheduleSyncRequiredException()
         }
+        if (request.name != null && lesson.hasGoogleCalendarEvent()) {
+            throw LessonScheduleSyncRequiredException()
+        }
         lesson.updateSchedule(request.name, null)
         return LessonResponse.from(lesson)
     }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
@@ -29,18 +29,20 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneId
 
-class
-CreateLessonScheduleUseCaseTest {
+class CreateLessonScheduleUseCaseTest {
     private lateinit var lessonAdaptor: LessonAdaptor
     private lateinit var centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor
     private lateinit var userAdaptor: UserAdaptor
     private lateinit var aesTokenEncryptor: AesTokenEncryptor
     private lateinit var calendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>
     private lateinit var calendarClient: CentralGoogleCalendarClient
+    private lateinit var txTemplate: TransactionTemplate
     private lateinit var useCase: CreateLessonScheduleUseCase
 
     private val studentUserId = "student-user-id-0000000001"
@@ -57,6 +59,10 @@ CreateLessonScheduleUseCaseTest {
         aesTokenEncryptor = mockk()
         calendarClientProvider = mockk()
         calendarClient = mockk()
+        txTemplate = mockk()
+        every { txTemplate.execute(any<TransactionCallback<Any?>>()) } answers {
+            firstArg<TransactionCallback<Any?>>().doInTransaction(mockk())
+        }
         useCase =
             CreateLessonScheduleUseCase(
                 lessonAdaptor = lessonAdaptor,
@@ -64,6 +70,7 @@ CreateLessonScheduleUseCaseTest {
                 userAdaptor = userAdaptor,
                 aesTokenEncryptor = aesTokenEncryptor,
                 centralGoogleCalendarClientProvider = calendarClientProvider,
+                txTemplate = txTemplate,
                 clock = clock,
             )
     }
@@ -118,6 +125,7 @@ CreateLessonScheduleUseCaseTest {
             { assertEquals(scheduledAt.plusMinutes(60).atZone(zoneId), commandSlot.captured.endAt) },
             { assertEquals(listOf("teacher@example.com", "student@example.com"), commandSlot.captured.attendeeEmails) },
         )
+        verify(exactly = 2) { txTemplate.execute(any<TransactionCallback<Any?>>()) }
     }
 
     @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
@@ -18,7 +18,9 @@ import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
 import com.sclass.supporters.lesson.dto.ScheduleLessonRequest
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -169,6 +171,60 @@ class CreateLessonScheduleUseCaseTest {
 
         assertNull(lesson.scheduledAt)
         verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
+    fun `Calendar event 생성 후 저장 직전 충돌이 감지되면 생성한 이벤트를 삭제한다`() {
+        val lesson = lesson()
+        val account = centralGoogleAccount()
+        val scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every {
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = studentUserId,
+                teacherUserId = teacherUserId,
+                scheduledAt = scheduledAt,
+                requestedDurationMinutes = 60L,
+                excludeLessonId = 1L,
+            )
+        } returnsMany listOf(false, true)
+        every { calendarClientProvider.getIfAvailable() } returns calendarClient
+        every { centralGoogleAccountAdaptor.findGoogle() } returns account
+        every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every { userAdaptor.findById(teacherUserId) } returns user(teacherUserId, "teacher@example.com")
+        every { userAdaptor.findById(studentUserId) } returns user(studentUserId, "student@example.com")
+        every {
+            calendarClient.createMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                command = any(),
+            )
+        } returns GoogleCalendarEventResult("event-id", "https://meet.google.com/abc-defg-hij", "abc-defg-hij")
+        every {
+            calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "event-id",
+            )
+        } just Runs
+
+        assertThrows<LessonScheduleConflictException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = ScheduleLessonRequest(scheduledAt = scheduledAt),
+            )
+        }
+
+        assertAll(
+            { assertNull(lesson.scheduledAt) },
+            { assertNull(lesson.googleMeet) },
+        )
+        verify {
+            calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "event-id",
+            )
+        }
     }
 
     @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.lesson.domain.LessonStatus
 import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonInvalidStatusTransitionException
 import com.sclass.domain.domains.lesson.exception.LessonScheduleAlreadyExistsException
 import com.sclass.domain.domains.lesson.exception.LessonScheduleConflictException
 import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
@@ -243,6 +244,21 @@ class CreateLessonScheduleUseCaseTest {
     }
 
     @Test
+    fun `예정 상태가 아닌 수업은 Calendar 호출 전에 스케줄 생성 불가`() {
+        every { lessonAdaptor.findById(1L) } returns lesson(status = LessonStatus.IN_PROGRESS)
+
+        assertThrows<LessonInvalidStatusTransitionException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = ScheduleLessonRequest(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)),
+            )
+        }
+
+        verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
     fun `중앙 Google Calendar client가 없으면 예외`() {
         val lesson = lesson()
         val scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
@@ -269,18 +285,20 @@ class CreateLessonScheduleUseCaseTest {
         assertNull(lesson.googleMeet)
     }
 
-    private fun lesson(scheduledAt: LocalDateTime? = null) =
-        Lesson(
-            id = 1L,
-            lessonType = LessonType.COURSE,
-            enrollmentId = 1L,
-            studentUserId = studentUserId,
-            assignedTeacherUserId = teacherUserId,
-            lessonNumber = 1,
-            name = "수학 1회차",
-            scheduledAt = scheduledAt,
-            status = LessonStatus.SCHEDULED,
-        )
+    private fun lesson(
+        scheduledAt: LocalDateTime? = null,
+        status: LessonStatus = LessonStatus.SCHEDULED,
+    ) = Lesson(
+        id = 1L,
+        lessonType = LessonType.COURSE,
+        enrollmentId = 1L,
+        studentUserId = studentUserId,
+        assignedTeacherUserId = teacherUserId,
+        lessonNumber = 1,
+        name = "수학 1회차",
+        scheduledAt = scheduledAt,
+        status = status,
+    )
 
     private fun user(
         id: String,

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
@@ -88,7 +88,7 @@ class CreateLessonScheduleUseCaseTest {
                 studentUserId = studentUserId,
                 teacherUserId = teacherUserId,
                 scheduledAt = scheduledAt,
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = 1L,
             )
         } returns false
@@ -154,7 +154,7 @@ class CreateLessonScheduleUseCaseTest {
                 studentUserId = studentUserId,
                 teacherUserId = teacherUserId,
                 scheduledAt = scheduledAt,
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = 1L,
             )
         } returns true
@@ -196,7 +196,7 @@ class CreateLessonScheduleUseCaseTest {
                 studentUserId = studentUserId,
                 teacherUserId = teacherUserId,
                 scheduledAt = scheduledAt,
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = 1L,
             )
         } returns false

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
@@ -1,0 +1,239 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonScheduleAlreadyExistsException
+import com.sclass.domain.domains.lesson.exception.LessonScheduleConflictException
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.domain.domains.user.adaptor.UserAdaptor
+import com.sclass.domain.domains.user.domain.AuthProvider
+import com.sclass.domain.domains.user.domain.User
+import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
+import com.sclass.supporters.lesson.dto.ScheduleLessonRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.ObjectProvider
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class
+CreateLessonScheduleUseCaseTest {
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor
+    private lateinit var userAdaptor: UserAdaptor
+    private lateinit var aesTokenEncryptor: AesTokenEncryptor
+    private lateinit var calendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>
+    private lateinit var calendarClient: CentralGoogleCalendarClient
+    private lateinit var useCase: CreateLessonScheduleUseCase
+
+    private val studentUserId = "student-user-id-0000000001"
+    private val teacherUserId = "teacher-user-id-0000000001"
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 12, 30)
+    private val zoneId = ZoneId.of("Asia/Seoul")
+    private val clock = Clock.fixed(fixedNow.atZone(zoneId).toInstant(), zoneId)
+
+    @BeforeEach
+    fun setUp() {
+        lessonAdaptor = mockk()
+        centralGoogleAccountAdaptor = mockk()
+        userAdaptor = mockk()
+        aesTokenEncryptor = mockk()
+        calendarClientProvider = mockk()
+        calendarClient = mockk()
+        useCase =
+            CreateLessonScheduleUseCase(
+                lessonAdaptor = lessonAdaptor,
+                centralGoogleAccountAdaptor = centralGoogleAccountAdaptor,
+                userAdaptor = userAdaptor,
+                aesTokenEncryptor = aesTokenEncryptor,
+                centralGoogleCalendarClientProvider = calendarClientProvider,
+                clock = clock,
+            )
+    }
+
+    @Test
+    fun `일정이 없는 수업에 스케줄을 생성하면 중앙 Google Meet을 생성하고 lesson에 저장한다`() {
+        val lesson = lesson()
+        val account = centralGoogleAccount()
+        val commandSlot = slot<GoogleCalendarEventCreateCommand>()
+        val scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every {
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = studentUserId,
+                teacherUserId = teacherUserId,
+                scheduledAt = scheduledAt,
+                durationMinutes = 60L,
+                excludeLessonId = 1L,
+            )
+        } returns false
+        every { calendarClientProvider.getIfAvailable() } returns calendarClient
+        every { centralGoogleAccountAdaptor.findGoogle() } returns account
+        every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every { userAdaptor.findById(teacherUserId) } returns user(teacherUserId, "teacher@example.com")
+        every { userAdaptor.findById(studentUserId) } returns user(studentUserId, "student@example.com")
+        every {
+            calendarClient.createMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                command = capture(commandSlot),
+            )
+        } returns GoogleCalendarEventResult("event-id", "https://meet.google.com/abc-defg-hij", "abc-defg-hij")
+
+        val response =
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = ScheduleLessonRequest(name = "변경된 수업명", scheduledAt = scheduledAt),
+            )
+
+        assertAll(
+            { assertEquals("변경된 수업명", lesson.name) },
+            { assertEquals(scheduledAt, lesson.scheduledAt) },
+            { assertEquals("event-id", lesson.googleMeet?.calendarEventId) },
+            { assertEquals("https://meet.google.com/abc-defg-hij", lesson.googleMeet?.joinUrl) },
+            { assertEquals("abc-defg-hij", lesson.googleMeet?.code) },
+            { assertEquals("https://meet.google.com/abc-defg-hij", response.googleMeetJoinUrl) },
+            { assertEquals("abc-defg-hij", response.googleMeetCode) },
+            { assertEquals(fixedNow, account.lastUsedAt) },
+            { assertEquals("변경된 수업명", commandSlot.captured.summary) },
+            { assertEquals(scheduledAt.atZone(zoneId), commandSlot.captured.startAt) },
+            { assertEquals(scheduledAt.plusMinutes(60).atZone(zoneId), commandSlot.captured.endAt) },
+            { assertEquals(listOf("teacher@example.com", "student@example.com"), commandSlot.captured.attendeeEmails) },
+        )
+    }
+
+    @Test
+    fun `담당 선생님이 아니면 스케줄 생성 불가`() {
+        every { lessonAdaptor.findById(1L) } returns lesson()
+
+        assertThrows<LessonUnauthorizedAccessException> {
+            useCase.execute(
+                userId = "other-teacher-id-000000001",
+                lessonId = 1L,
+                request = ScheduleLessonRequest(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)),
+            )
+        }
+
+        verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
+    fun `학생이나 선생님의 기존 수업과 시간이 겹치면 스케줄 생성 불가`() {
+        val lesson = lesson()
+        val scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every {
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = studentUserId,
+                teacherUserId = teacherUserId,
+                scheduledAt = scheduledAt,
+                durationMinutes = 60L,
+                excludeLessonId = 1L,
+            )
+        } returns true
+
+        assertThrows<LessonScheduleConflictException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = ScheduleLessonRequest(scheduledAt = scheduledAt),
+            )
+        }
+
+        assertNull(lesson.scheduledAt)
+        verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
+    fun `이미 일정이 있으면 스케줄 생성 불가`() {
+        every { lessonAdaptor.findById(1L) } returns lesson(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0))
+
+        assertThrows<LessonScheduleAlreadyExistsException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = ScheduleLessonRequest(scheduledAt = LocalDateTime.of(2026, 5, 2, 20, 0)),
+            )
+        }
+
+        verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
+    fun `중앙 Google Calendar client가 없으면 예외`() {
+        val lesson = lesson()
+        val scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every {
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = studentUserId,
+                teacherUserId = teacherUserId,
+                scheduledAt = scheduledAt,
+                durationMinutes = 60L,
+                excludeLessonId = 1L,
+            )
+        } returns false
+        every { calendarClientProvider.getIfAvailable() } returns null
+
+        assertThrows<GoogleCalendarCentralDisabledException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = ScheduleLessonRequest(scheduledAt = scheduledAt),
+            )
+        }
+
+        assertNull(lesson.googleMeet)
+    }
+
+    private fun lesson(scheduledAt: LocalDateTime? = null) =
+        Lesson(
+            id = 1L,
+            lessonType = LessonType.COURSE,
+            enrollmentId = 1L,
+            studentUserId = studentUserId,
+            assignedTeacherUserId = teacherUserId,
+            lessonNumber = 1,
+            name = "수학 1회차",
+            scheduledAt = scheduledAt,
+            status = LessonStatus.SCHEDULED,
+        )
+
+    private fun user(
+        id: String,
+        email: String,
+    ) = User(
+        id = id,
+        email = email,
+        name = "user",
+        authProvider = AuthProvider.EMAIL,
+    )
+
+    private fun centralGoogleAccount() =
+        CentralGoogleAccount(
+            googleEmail = "central@example.com",
+            encryptedRefreshToken = "encrypted-refresh-token",
+            scope = "openid https://www.googleapis.com/auth/calendar.events",
+            connectedByAdminUserId = "admin-user-id-000000000001",
+            connectedAt = fixedNow.minusDays(1),
+        )
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.lesson.domain.LessonGoogleMeet
 import com.sclass.domain.domains.lesson.domain.LessonStatus
 import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonInvalidStatusTransitionException
 import com.sclass.domain.domains.lesson.exception.LessonScheduleConflictException
 import com.sclass.domain.domains.lesson.exception.LessonScheduleNotFoundException
 import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
@@ -341,6 +342,23 @@ class UpdateLessonScheduleUseCaseTest {
     }
 
     @Test
+    fun `예정 상태가 아닌 수업은 Calendar 호출 전에 스케줄 수정 불가`() {
+        every {
+            lessonAdaptor.findById(1L)
+        } returns lesson(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0), status = LessonStatus.IN_PROGRESS)
+
+        assertThrows<LessonInvalidStatusTransitionException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = ScheduleLessonRequest(scheduledAt = LocalDateTime.of(2026, 5, 2, 21, 0)),
+            )
+        }
+
+        verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
     fun `담당 선생님이 아니면 스케줄 수정 불가`() {
         every { lessonAdaptor.findById(1L) } returns lesson(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0))
 
@@ -358,6 +376,7 @@ class UpdateLessonScheduleUseCaseTest {
     private fun lesson(
         scheduledAt: LocalDateTime?,
         googleMeet: LessonGoogleMeet? = null,
+        status: LessonStatus = LessonStatus.SCHEDULED,
     ) = Lesson(
         id = 1L,
         lessonType = LessonType.COURSE,
@@ -367,7 +386,7 @@ class UpdateLessonScheduleUseCaseTest {
         lessonNumber = 1,
         name = "수학 1회차",
         scheduledAt = scheduledAt,
-        status = LessonStatus.SCHEDULED,
+        status = status,
         googleMeet = googleMeet,
     )
 

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
@@ -91,7 +91,7 @@ class UpdateLessonScheduleUseCaseTest {
                 studentUserId = studentUserId,
                 teacherUserId = teacherUserId,
                 scheduledAt = newScheduledAt,
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = 1L,
             )
         } returns false
@@ -143,7 +143,7 @@ class UpdateLessonScheduleUseCaseTest {
                 studentUserId = studentUserId,
                 teacherUserId = teacherUserId,
                 scheduledAt = newScheduledAt,
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = 1L,
             )
         } returns false
@@ -186,7 +186,7 @@ class UpdateLessonScheduleUseCaseTest {
                 studentUserId = studentUserId,
                 teacherUserId = teacherUserId,
                 scheduledAt = newScheduledAt,
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = 1L,
             )
         } returns true

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
@@ -18,7 +18,9 @@ import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
 import com.sclass.supporters.lesson.dto.ScheduleLessonRequest
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -204,6 +206,123 @@ class UpdateLessonScheduleUseCaseTest {
             { assertEquals(originalScheduledAt, lesson.scheduledAt) },
         )
         verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
+    fun `Calendar event 수정 후 저장 직전 충돌이 감지되면 기존 이벤트 일정으로 되돌린다`() {
+        val originalScheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
+        val newScheduledAt = LocalDateTime.of(2026, 5, 2, 21, 0)
+        val lesson =
+            lesson(
+                scheduledAt = originalScheduledAt,
+                googleMeet = LessonGoogleMeet("old-event-id", "https://meet.google.com/old-code", "old-code"),
+            )
+        val account = centralGoogleAccount()
+        val commandSlots = mutableListOf<GoogleCalendarEventCreateCommand>()
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every {
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = studentUserId,
+                teacherUserId = teacherUserId,
+                scheduledAt = newScheduledAt,
+                requestedDurationMinutes = 60L,
+                excludeLessonId = 1L,
+            )
+        } returnsMany listOf(false, true)
+        every { calendarClientProvider.getIfAvailable() } returns calendarClient
+        every { centralGoogleAccountAdaptor.findGoogle() } returns account
+        every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every { userAdaptor.findById(teacherUserId) } returns user(teacherUserId, "teacher@example.com")
+        every { userAdaptor.findById(studentUserId) } returns user(studentUserId, "student@example.com")
+        every {
+            calendarClient.updateMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "old-event-id",
+                command = capture(commandSlots),
+            )
+        } returnsMany
+            listOf(
+                GoogleCalendarEventResult("old-event-id", "https://meet.google.com/new-code", "new-code"),
+                GoogleCalendarEventResult("old-event-id", "https://meet.google.com/old-code", "old-code"),
+            )
+
+        assertThrows<LessonScheduleConflictException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = ScheduleLessonRequest(name = "수학 보강", scheduledAt = newScheduledAt),
+            )
+        }
+
+        assertAll(
+            { assertEquals("수학 1회차", lesson.name) },
+            { assertEquals(originalScheduledAt, lesson.scheduledAt) },
+            { assertEquals(newScheduledAt.atZone(zoneId), commandSlots[0].startAt) },
+            { assertEquals(originalScheduledAt.atZone(zoneId), commandSlots[1].startAt) },
+        )
+        verify(exactly = 2) {
+            calendarClient.updateMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "old-event-id",
+                command = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `Google Meet이 없어 create로 보정한 후 저장 직전 충돌이 감지되면 생성한 이벤트를 삭제한다`() {
+        val originalScheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
+        val newScheduledAt = LocalDateTime.of(2026, 5, 2, 21, 0)
+        val lesson = lesson(scheduledAt = originalScheduledAt)
+        val account = centralGoogleAccount()
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every {
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = studentUserId,
+                teacherUserId = teacherUserId,
+                scheduledAt = newScheduledAt,
+                requestedDurationMinutes = 60L,
+                excludeLessonId = 1L,
+            )
+        } returnsMany listOf(false, true)
+        every { calendarClientProvider.getIfAvailable() } returns calendarClient
+        every { centralGoogleAccountAdaptor.findGoogle() } returns account
+        every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every { userAdaptor.findById(teacherUserId) } returns user(teacherUserId, "teacher@example.com")
+        every { userAdaptor.findById(studentUserId) } returns user(studentUserId, "student@example.com")
+        every {
+            calendarClient.createMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                command = any(),
+            )
+        } returns GoogleCalendarEventResult("new-event-id", "https://meet.google.com/new-code", "new-code")
+        every {
+            calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "new-event-id",
+            )
+        } just Runs
+
+        assertThrows<LessonScheduleConflictException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = ScheduleLessonRequest(scheduledAt = newScheduledAt),
+            )
+        }
+
+        assertAll(
+            { assertEquals(originalScheduledAt, lesson.scheduledAt) },
+            { assertEquals(null, lesson.googleMeet) },
+        )
+        verify {
+            calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "new-event-id",
+            )
+        }
     }
 
     @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -39,6 +41,7 @@ class UpdateLessonScheduleUseCaseTest {
     private lateinit var aesTokenEncryptor: AesTokenEncryptor
     private lateinit var calendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>
     private lateinit var calendarClient: CentralGoogleCalendarClient
+    private lateinit var txTemplate: TransactionTemplate
     private lateinit var useCase: UpdateLessonScheduleUseCase
 
     private val studentUserId = "student-user-id-0000000001"
@@ -55,6 +58,10 @@ class UpdateLessonScheduleUseCaseTest {
         aesTokenEncryptor = mockk()
         calendarClientProvider = mockk()
         calendarClient = mockk()
+        txTemplate = mockk()
+        every { txTemplate.execute(any<TransactionCallback<Any?>>()) } answers {
+            firstArg<TransactionCallback<Any?>>().doInTransaction(mockk())
+        }
         useCase =
             UpdateLessonScheduleUseCase(
                 lessonAdaptor = lessonAdaptor,
@@ -62,6 +69,7 @@ class UpdateLessonScheduleUseCaseTest {
                 userAdaptor = userAdaptor,
                 aesTokenEncryptor = aesTokenEncryptor,
                 centralGoogleCalendarClientProvider = calendarClientProvider,
+                txTemplate = txTemplate,
                 clock = clock,
             )
     }
@@ -120,6 +128,7 @@ class UpdateLessonScheduleUseCaseTest {
             { assertEquals(newScheduledAt.plusMinutes(60).atZone(zoneId), commandSlot.captured.endAt) },
         )
         verify(exactly = 0) { calendarClient.createMeetEventWithRefreshToken(any(), any()) }
+        verify(exactly = 2) { txTemplate.execute(any<TransactionCallback<Any?>>()) }
     }
 
     @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
@@ -1,0 +1,264 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonGoogleMeet
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonScheduleConflictException
+import com.sclass.domain.domains.lesson.exception.LessonScheduleNotFoundException
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.domain.domains.user.adaptor.UserAdaptor
+import com.sclass.domain.domains.user.domain.AuthProvider
+import com.sclass.domain.domains.user.domain.User
+import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
+import com.sclass.supporters.lesson.dto.ScheduleLessonRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.ObjectProvider
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class UpdateLessonScheduleUseCaseTest {
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor
+    private lateinit var userAdaptor: UserAdaptor
+    private lateinit var aesTokenEncryptor: AesTokenEncryptor
+    private lateinit var calendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>
+    private lateinit var calendarClient: CentralGoogleCalendarClient
+    private lateinit var useCase: UpdateLessonScheduleUseCase
+
+    private val studentUserId = "student-user-id-0000000001"
+    private val teacherUserId = "teacher-user-id-0000000001"
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 12, 30)
+    private val zoneId = ZoneId.of("Asia/Seoul")
+    private val clock = Clock.fixed(fixedNow.atZone(zoneId).toInstant(), zoneId)
+
+    @BeforeEach
+    fun setUp() {
+        lessonAdaptor = mockk()
+        centralGoogleAccountAdaptor = mockk()
+        userAdaptor = mockk()
+        aesTokenEncryptor = mockk()
+        calendarClientProvider = mockk()
+        calendarClient = mockk()
+        useCase =
+            UpdateLessonScheduleUseCase(
+                lessonAdaptor = lessonAdaptor,
+                centralGoogleAccountAdaptor = centralGoogleAccountAdaptor,
+                userAdaptor = userAdaptor,
+                aesTokenEncryptor = aesTokenEncryptor,
+                centralGoogleCalendarClientProvider = calendarClientProvider,
+                clock = clock,
+            )
+    }
+
+    @Test
+    fun `기존 Google Meet이 있으면 중앙 Calendar event를 수정한다`() {
+        val lesson =
+            lesson(
+                scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
+                googleMeet = LessonGoogleMeet("old-event-id", "https://meet.google.com/old-code", "old-code"),
+            )
+        val account = centralGoogleAccount()
+        val commandSlot = slot<GoogleCalendarEventCreateCommand>()
+        val newScheduledAt = LocalDateTime.of(2026, 5, 2, 21, 0)
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every {
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = studentUserId,
+                teacherUserId = teacherUserId,
+                scheduledAt = newScheduledAt,
+                durationMinutes = 60L,
+                excludeLessonId = 1L,
+            )
+        } returns false
+        every { calendarClientProvider.getIfAvailable() } returns calendarClient
+        every { centralGoogleAccountAdaptor.findGoogle() } returns account
+        every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every { userAdaptor.findById(teacherUserId) } returns user(teacherUserId, "teacher@example.com")
+        every { userAdaptor.findById(studentUserId) } returns user(studentUserId, "student@example.com")
+        every {
+            calendarClient.updateMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "old-event-id",
+                command = capture(commandSlot),
+            )
+        } returns GoogleCalendarEventResult("old-event-id", "https://meet.google.com/new-code", "new-code")
+
+        val response =
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = ScheduleLessonRequest(name = "수학 보강", scheduledAt = newScheduledAt),
+            )
+
+        assertAll(
+            { assertEquals("수학 보강", lesson.name) },
+            { assertEquals(newScheduledAt, lesson.scheduledAt) },
+            { assertEquals("old-event-id", lesson.googleMeet?.calendarEventId) },
+            { assertEquals("https://meet.google.com/new-code", lesson.googleMeet?.joinUrl) },
+            { assertEquals("new-code", lesson.googleMeet?.code) },
+            { assertEquals("https://meet.google.com/new-code", response.googleMeetJoinUrl) },
+            { assertEquals(fixedNow, account.lastUsedAt) },
+            { assertEquals("수학 보강", commandSlot.captured.summary) },
+            { assertEquals(newScheduledAt.atZone(zoneId), commandSlot.captured.startAt) },
+            { assertEquals(newScheduledAt.plusMinutes(60).atZone(zoneId), commandSlot.captured.endAt) },
+        )
+        verify(exactly = 0) { calendarClient.createMeetEventWithRefreshToken(any(), any()) }
+    }
+
+    @Test
+    fun `기존 일정은 있지만 Google Meet이 없으면 create로 보정한다`() {
+        val lesson = lesson(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0))
+        val account = centralGoogleAccount()
+        val newScheduledAt = LocalDateTime.of(2026, 5, 2, 21, 0)
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every {
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = studentUserId,
+                teacherUserId = teacherUserId,
+                scheduledAt = newScheduledAt,
+                durationMinutes = 60L,
+                excludeLessonId = 1L,
+            )
+        } returns false
+        every { calendarClientProvider.getIfAvailable() } returns calendarClient
+        every { centralGoogleAccountAdaptor.findGoogle() } returns account
+        every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every { userAdaptor.findById(teacherUserId) } returns user(teacherUserId, "teacher@example.com")
+        every { userAdaptor.findById(studentUserId) } returns user(studentUserId, "student@example.com")
+        every {
+            calendarClient.createMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                command = any(),
+            )
+        } returns GoogleCalendarEventResult("new-event-id", "https://meet.google.com/new-code", "new-code")
+
+        useCase.execute(
+            userId = teacherUserId,
+            lessonId = 1L,
+            request = ScheduleLessonRequest(scheduledAt = newScheduledAt),
+        )
+
+        assertAll(
+            { assertEquals("new-event-id", lesson.googleMeet?.calendarEventId) },
+            { assertEquals("https://meet.google.com/new-code", lesson.googleMeet?.joinUrl) },
+            { assertEquals("new-code", lesson.googleMeet?.code) },
+            { assertEquals(fixedNow, account.lastUsedAt) },
+        )
+        verify(exactly = 0) { calendarClient.updateMeetEventWithRefreshToken(any(), any(), any()) }
+    }
+
+    @Test
+    fun `학생이나 선생님의 기존 수업과 시간이 겹치면 스케줄 수정 불가`() {
+        val originalScheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
+        val newScheduledAt = LocalDateTime.of(2026, 5, 2, 21, 0)
+        val lesson = lesson(scheduledAt = originalScheduledAt)
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every {
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = studentUserId,
+                teacherUserId = teacherUserId,
+                scheduledAt = newScheduledAt,
+                durationMinutes = 60L,
+                excludeLessonId = 1L,
+            )
+        } returns true
+
+        assertThrows<LessonScheduleConflictException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = ScheduleLessonRequest(name = "변경 불가", scheduledAt = newScheduledAt),
+            )
+        }
+
+        assertAll(
+            { assertEquals("수학 1회차", lesson.name) },
+            { assertEquals(originalScheduledAt, lesson.scheduledAt) },
+        )
+        verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
+    fun `일정이 없는 수업은 수정할 수 없다`() {
+        every { lessonAdaptor.findById(1L) } returns lesson(scheduledAt = null)
+
+        assertThrows<LessonScheduleNotFoundException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = ScheduleLessonRequest(scheduledAt = LocalDateTime.of(2026, 5, 2, 21, 0)),
+            )
+        }
+
+        verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
+    fun `담당 선생님이 아니면 스케줄 수정 불가`() {
+        every { lessonAdaptor.findById(1L) } returns lesson(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0))
+
+        assertThrows<LessonUnauthorizedAccessException> {
+            useCase.execute(
+                userId = "other-teacher-id-000000001",
+                lessonId = 1L,
+                request = ScheduleLessonRequest(scheduledAt = LocalDateTime.of(2026, 5, 2, 21, 0)),
+            )
+        }
+
+        verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    private fun lesson(
+        scheduledAt: LocalDateTime?,
+        googleMeet: LessonGoogleMeet? = null,
+    ) = Lesson(
+        id = 1L,
+        lessonType = LessonType.COURSE,
+        enrollmentId = 1L,
+        studentUserId = studentUserId,
+        assignedTeacherUserId = teacherUserId,
+        lessonNumber = 1,
+        name = "수학 1회차",
+        scheduledAt = scheduledAt,
+        status = LessonStatus.SCHEDULED,
+        googleMeet = googleMeet,
+    )
+
+    private fun user(
+        id: String,
+        email: String,
+    ) = User(
+        id = id,
+        email = email,
+        name = "user",
+        authProvider = AuthProvider.EMAIL,
+    )
+
+    private fun centralGoogleAccount() =
+        CentralGoogleAccount(
+            googleEmail = "central@example.com",
+            encryptedRefreshToken = "encrypted-refresh-token",
+            scope = "openid https://www.googleapis.com/auth/calendar.events",
+            connectedByAdminUserId = "admin-user-id-000000000001",
+            connectedAt = fixedNow.minusDays(1),
+        )
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.sclass.supporters.lesson.usecase
 
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
 import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonGoogleMeet
 import com.sclass.domain.domains.lesson.domain.LessonStatus
 import com.sclass.domain.domains.lesson.domain.LessonType
 import com.sclass.domain.domains.lesson.exception.LessonScheduleSyncRequiredException
@@ -65,6 +66,26 @@ class UpdateLessonUseCaseTest {
     }
 
     @Test
+    fun `Google Meet이 연결된 수업은 deprecated PATCH로 이름을 직접 수정할 수 없다`() {
+        val lesson =
+            lesson(
+                name = "수학 1회차",
+                googleMeet = LessonGoogleMeet("event-id", "https://meet.google.com/abc-defg-hij", "abc-defg-hij"),
+            )
+        every { lessonAdaptor.findById(1L) } returns lesson
+
+        assertThrows<LessonScheduleSyncRequiredException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = UpdateLessonRequest(name = "수학 보강"),
+            )
+        }
+
+        assertEquals("수학 1회차", lesson.name)
+    }
+
+    @Test
     fun `담당 선생님이 아니면 deprecated PATCH 수정 불가`() {
         every { lessonAdaptor.findById(1L) } returns lesson()
 
@@ -80,6 +101,7 @@ class UpdateLessonUseCaseTest {
     private fun lesson(
         name: String = "수학 1회차",
         scheduledAt: LocalDateTime? = null,
+        googleMeet: LessonGoogleMeet? = null,
     ) = Lesson(
         id = 1L,
         lessonType = LessonType.COURSE,
@@ -90,5 +112,6 @@ class UpdateLessonUseCaseTest {
         name = name,
         scheduledAt = scheduledAt,
         status = LessonStatus.SCHEDULED,
+        googleMeet = googleMeet,
     )
 }

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonUseCaseTest.kt
@@ -1,0 +1,94 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonScheduleSyncRequiredException
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.supporters.lesson.dto.UpdateLessonRequest
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class UpdateLessonUseCaseTest {
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var useCase: UpdateLessonUseCase
+
+    private val studentUserId = "student-user-id-0000000001"
+    private val teacherUserId = "teacher-user-id-0000000001"
+
+    @BeforeEach
+    fun setUp() {
+        lessonAdaptor = mockk()
+        useCase = UpdateLessonUseCase(lessonAdaptor)
+    }
+
+    @Test
+    fun `deprecated PATCH는 수업 이름만 수정한다`() {
+        val lesson = lesson(name = "수학 1회차")
+        every { lessonAdaptor.findById(1L) } returns lesson
+
+        val response =
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = UpdateLessonRequest(name = "수학 보강"),
+            )
+
+        assertAll(
+            { assertEquals("수학 보강", lesson.name) },
+            { assertEquals("수학 보강", response.name) },
+        )
+    }
+
+    @Test
+    fun `deprecated PATCH는 scheduledAt을 직접 수정할 수 없다`() {
+        val originalScheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
+        val lesson = lesson(scheduledAt = originalScheduledAt)
+        every { lessonAdaptor.findById(1L) } returns lesson
+
+        assertThrows<LessonScheduleSyncRequiredException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+                request = UpdateLessonRequest(scheduledAt = LocalDateTime.of(2026, 5, 2, 21, 0)),
+            )
+        }
+
+        assertEquals(originalScheduledAt, lesson.scheduledAt)
+    }
+
+    @Test
+    fun `담당 선생님이 아니면 deprecated PATCH 수정 불가`() {
+        every { lessonAdaptor.findById(1L) } returns lesson()
+
+        assertThrows<LessonUnauthorizedAccessException> {
+            useCase.execute(
+                userId = "other-teacher-id-000000001",
+                lessonId = 1L,
+                request = UpdateLessonRequest(name = "변경 불가"),
+            )
+        }
+    }
+
+    private fun lesson(
+        name: String = "수학 1회차",
+        scheduledAt: LocalDateTime? = null,
+    ) = Lesson(
+        id = 1L,
+        lessonType = LessonType.COURSE,
+        enrollmentId = 1L,
+        studentUserId = studentUserId,
+        assignedTeacherUserId = teacherUserId,
+        lessonNumber = 1,
+        name = name,
+        scheduledAt = scheduledAt,
+        status = LessonStatus.SCHEDULED,
+    )
+}

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/adaptor/LessonAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/adaptor/LessonAdaptor.kt
@@ -6,6 +6,7 @@ import com.sclass.domain.domains.lesson.domain.LessonStatus
 import com.sclass.domain.domains.lesson.exception.LessonNotFoundException
 import com.sclass.domain.domains.lesson.repository.LessonRepository
 import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDateTime
 
 @Adaptor
 class LessonAdaptor(
@@ -34,4 +35,19 @@ class LessonAdaptor(
 
     fun findCompletedByActualTeacher(teacherUserId: String): List<Lesson> =
         lessonRepository.findAllByActualTeacherUserIdAndStatus(teacherUserId, LessonStatus.COMPLETED)
+
+    fun existsScheduleConflict(
+        studentUserId: String,
+        teacherUserId: String,
+        scheduledAt: LocalDateTime,
+        durationMinutes: Long,
+        excludeLessonId: Long,
+    ): Boolean =
+        lessonRepository.existsScheduleConflict(
+            studentUserId = studentUserId,
+            teacherUserId = teacherUserId,
+            scheduledAt = scheduledAt,
+            durationMinutes = durationMinutes,
+            excludeLessonId = excludeLessonId,
+        )
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/adaptor/LessonAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/adaptor/LessonAdaptor.kt
@@ -40,14 +40,14 @@ class LessonAdaptor(
         studentUserId: String,
         teacherUserId: String,
         scheduledAt: LocalDateTime,
-        durationMinutes: Long,
+        requestedDurationMinutes: Long,
         excludeLessonId: Long,
     ): Boolean =
         lessonRepository.existsScheduleConflict(
             studentUserId = studentUserId,
             teacherUserId = teacherUserId,
             scheduledAt = scheduledAt,
-            durationMinutes = durationMinutes,
+            requestedDurationMinutes = requestedDurationMinutes,
             excludeLessonId = excludeLessonId,
         )
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
@@ -146,14 +146,18 @@ class Lesson(
         name: String?,
         scheduledAt: LocalDateTime?,
     ) {
-        if (status != LessonStatus.SCHEDULED) {
-            throw LessonInvalidStatusTransitionException()
-        }
+        validateScheduleUpdatable()
         name?.let { this.name = it }
         scheduledAt?.let { this.scheduledAt = it }
     }
 
     fun hasGoogleCalendarEvent(): Boolean = googleMeet?.calendarEventId?.isNotBlank() == true
+
+    fun validateScheduleUpdatable() {
+        if (status != LessonStatus.SCHEDULED) {
+            throw LessonInvalidStatusTransitionException()
+        }
+    }
 
     fun attachGoogleMeet(
         eventId: String,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
@@ -8,6 +8,7 @@ import com.sclass.domain.domains.lesson.exception.LessonInvalidTimeException
 import com.sclass.domain.domains.lesson.exception.LessonSubstituteAssignNotAllowedException
 import com.sclass.domain.domains.lesson.exception.LessonSubstituteSameAsAssignedException
 import jakarta.persistence.Column
+import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -65,6 +66,8 @@ class Lesson(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     var status: LessonStatus = LessonStatus.SCHEDULED,
+    @Embedded
+    var googleMeet: LessonGoogleMeet? = null,
 ) : BaseTimeEntity() {
     val effectiveTeacherUserId: String
         get() = substituteTeacherUserId ?: assignedTeacherUserId
@@ -148,6 +151,16 @@ class Lesson(
         }
         name?.let { this.name = it }
         scheduledAt?.let { this.scheduledAt = it }
+    }
+
+    fun hasGoogleCalendarEvent(): Boolean = googleMeet?.calendarEventId?.isNotBlank() == true
+
+    fun attachGoogleMeet(
+        eventId: String,
+        meetJoinUrl: String,
+        meetCode: String?,
+    ) {
+        this.googleMeet = LessonGoogleMeet(eventId, meetJoinUrl, meetCode)
     }
 
     private fun validateTransition(target: LessonStatus) {

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
@@ -173,4 +173,8 @@ class Lesson(
             }
         if (status !in allowed) throw LessonInvalidStatusTransitionException()
     }
+
+    companion object {
+        const val DEFAULT_DURATION_MINUTES = 60L
+    }
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/LessonGoogleMeet.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/LessonGoogleMeet.kt
@@ -1,0 +1,16 @@
+package com.sclass.domain.domains.lesson.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class LessonGoogleMeet(
+    @Column(name = "google_calendar_event_id", length = 256)
+    val calendarEventId: String,
+
+    @Column(name = "google_meet_join_url", length = 512)
+    val joinUrl: String,
+
+    @Column(name = "google_meet_code", length = 64)
+    val code: String? = null,
+)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonErrorCode.kt
@@ -16,4 +16,7 @@ enum class LessonErrorCode(
     LESSON_ALREADY_COMPLETED("LESSON_007", "이미 완료 처리된 수업입니다", 400),
     LESSON_INVALID_TIME("LESSON_008", "유효하지 않은 시간입니다", 400),
     LESSON_ALREADY_STARTED("LESSON_009", "이미 시작된 수업입니다", 400),
+    LESSON_SCHEDULE_ALREADY_EXISTS("LESSON_010", "이미 수업 일정이 등록되어 있습니다", 409),
+    LESSON_SCHEDULE_NOT_FOUND("LESSON_011", "수업 일정이 등록되어 있지 않습니다", 404),
+    LESSON_SCHEDULE_CONFLICT("LESSON_012", "해당 시간에 이미 예정된 수업이 있습니다", 409),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonErrorCode.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonErrorCode.kt
@@ -19,4 +19,5 @@ enum class LessonErrorCode(
     LESSON_SCHEDULE_ALREADY_EXISTS("LESSON_010", "이미 수업 일정이 등록되어 있습니다", 409),
     LESSON_SCHEDULE_NOT_FOUND("LESSON_011", "수업 일정이 등록되어 있지 않습니다", 404),
     LESSON_SCHEDULE_CONFLICT("LESSON_012", "해당 시간에 이미 예정된 수업이 있습니다", 409),
+    LESSON_SCHEDULE_SYNC_REQUIRED("LESSON_013", "수업 일정은 schedule API로 변경해야 합니다", 400),
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonExceptions.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonExceptions.kt
@@ -13,3 +13,9 @@ class LessonAlreadyCompletedException : BusinessException(LessonErrorCode.LESSON
 class LessonInvalidTimeException : BusinessException(LessonErrorCode.LESSON_INVALID_TIME)
 
 class LessonAlreadyStartedException : BusinessException(LessonErrorCode.LESSON_ALREADY_STARTED)
+
+class LessonScheduleAlreadyExistsException : BusinessException(LessonErrorCode.LESSON_SCHEDULE_ALREADY_EXISTS)
+
+class LessonScheduleNotFoundException : BusinessException(LessonErrorCode.LESSON_SCHEDULE_NOT_FOUND)
+
+class LessonScheduleConflictException : BusinessException(LessonErrorCode.LESSON_SCHEDULE_CONFLICT)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonExceptions.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/exception/LessonExceptions.kt
@@ -19,3 +19,5 @@ class LessonScheduleAlreadyExistsException : BusinessException(LessonErrorCode.L
 class LessonScheduleNotFoundException : BusinessException(LessonErrorCode.LESSON_SCHEDULE_NOT_FOUND)
 
 class LessonScheduleConflictException : BusinessException(LessonErrorCode.LESSON_SCHEDULE_CONFLICT)
+
+class LessonScheduleSyncRequiredException : BusinessException(LessonErrorCode.LESSON_SCHEDULE_SYNC_REQUIRED)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepository.kt
@@ -1,7 +1,16 @@
 package com.sclass.domain.domains.lesson.repository
 
 import com.sclass.domain.domains.lesson.domain.Lesson
+import java.time.LocalDateTime
 
 interface LessonCustomRepository {
     fun findAllByEffectiveTeacher(teacherUserId: String): List<Lesson>
+
+    fun existsScheduleConflict(
+        studentUserId: String,
+        teacherUserId: String,
+        scheduledAt: LocalDateTime,
+        durationMinutes: Long,
+        excludeLessonId: Long,
+    ): Boolean
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepository.kt
@@ -10,7 +10,7 @@ interface LessonCustomRepository {
         studentUserId: String,
         teacherUserId: String,
         scheduledAt: LocalDateTime,
-        durationMinutes: Long,
+        requestedDurationMinutes: Long,
         excludeLessonId: Long,
     ): Boolean
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepositoryImpl.kt
@@ -29,12 +29,13 @@ class LessonCustomRepositoryImpl(
         studentUserId: String,
         teacherUserId: String,
         scheduledAt: LocalDateTime,
-        durationMinutes: Long,
+        requestedDurationMinutes: Long,
         excludeLessonId: Long,
     ): Boolean {
         val lesson = QLesson.lesson
-        val conflictStartAt = scheduledAt.minusMinutes(durationMinutes)
-        val conflictEndAt = scheduledAt.plusMinutes(durationMinutes)
+        val existingLessonDurationMinutes = Lesson.DEFAULT_DURATION_MINUTES
+        val conflictStartAt = scheduledAt.minusMinutes(existingLessonDurationMinutes)
+        val conflictEndAt = scheduledAt.plusMinutes(requestedDurationMinutes)
 
         return queryFactory
             .selectOne()

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepositoryImpl.kt
@@ -1,8 +1,11 @@
 package com.sclass.domain.domains.lesson.repository
 
+import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
 import com.sclass.domain.domains.lesson.domain.QLesson
+import java.time.LocalDateTime
 
 class LessonCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
@@ -21,4 +24,42 @@ class LessonCustomRepositoryImpl(
                         ),
                     ),
             ).fetch()
+
+    override fun existsScheduleConflict(
+        studentUserId: String,
+        teacherUserId: String,
+        scheduledAt: LocalDateTime,
+        durationMinutes: Long,
+        excludeLessonId: Long,
+    ): Boolean {
+        val lesson = QLesson.lesson
+        val conflictStartAt = scheduledAt.minusMinutes(durationMinutes)
+        val conflictEndAt = scheduledAt.plusMinutes(durationMinutes)
+
+        return queryFactory
+            .selectOne()
+            .from(lesson)
+            .where(
+                lesson.id.ne(excludeLessonId),
+                lesson.status.`in`(SCHEDULE_CONFLICT_TARGET_STATUSES),
+                lesson.scheduledAt.gt(conflictStartAt),
+                lesson.scheduledAt.lt(conflictEndAt),
+                lesson.studentUserId
+                    .eq(studentUserId)
+                    .or(lesson.effectiveTeacherEq(teacherUserId)),
+            ).fetchFirst() != null
+    }
+
+    private fun QLesson.effectiveTeacherEq(teacherUserId: String): BooleanExpression =
+        substituteTeacherUserId
+            .eq(teacherUserId)
+            .or(
+                substituteTeacherUserId.isNull.and(
+                    assignedTeacherUserId.eq(teacherUserId),
+                ),
+            )
+
+    private companion object {
+        val SCHEDULE_CONFLICT_TARGET_STATUSES = listOf(LessonStatus.SCHEDULED, LessonStatus.IN_PROGRESS)
+    }
 }

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/domain/LessonTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/domain/LessonTest.kt
@@ -317,4 +317,20 @@ class LessonTest {
             { assertEquals("abc-defg-hij", lesson.googleMeet?.code) },
         )
     }
+
+    @Test
+    fun `SCHEDULED 상태의 lesson은 일정 변경 가능 검증을 통과한다`() {
+        val lesson = newLesson(status = LessonStatus.SCHEDULED)
+
+        lesson.validateScheduleUpdatable()
+    }
+
+    @Test
+    fun `SCHEDULED가 아니면 일정 변경 가능 검증 시 예외`() {
+        val lesson = newLesson(status = LessonStatus.IN_PROGRESS)
+
+        assertThrows<LessonInvalidStatusTransitionException> {
+            lesson.validateScheduleUpdatable()
+        }
+    }
 }

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/domain/LessonTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/domain/LessonTest.kt
@@ -299,4 +299,22 @@ class LessonTest {
             lesson.record(assignedTeacher, started, started.minusSeconds(1), clock)
         }
     }
+
+    @Test
+    fun `Google Meet 정보를 lesson에 연결한다`() {
+        val lesson = newLesson()
+
+        lesson.attachGoogleMeet(
+            eventId = "event-id",
+            meetJoinUrl = "https://meet.google.com/abc-defg-hij",
+            meetCode = "abc-defg-hij",
+        )
+
+        assertAll(
+            { assertTrue(lesson.hasGoogleCalendarEvent()) },
+            { assertEquals("event-id", lesson.googleMeet?.calendarEventId) },
+            { assertEquals("https://meet.google.com/abc-defg-hij", lesson.googleMeet?.joinUrl) },
+            { assertEquals("abc-defg-hij", lesson.googleMeet?.code) },
+        )
+    }
 }

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepositoryImplTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepositoryImplTest.kt
@@ -43,7 +43,7 @@ class LessonCustomRepositoryImplTest {
                 studentUserId = STUDENT_USER_ID,
                 teacherUserId = "other-teacher-id",
                 scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 30),
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = 0L,
             ),
         )
@@ -52,7 +52,7 @@ class LessonCustomRepositoryImplTest {
                 studentUserId = "other-student-id",
                 teacherUserId = TEACHER_USER_ID,
                 scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 30),
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = 0L,
             ),
         )
@@ -78,7 +78,7 @@ class LessonCustomRepositoryImplTest {
                 studentUserId = STUDENT_USER_ID,
                 teacherUserId = TEACHER_USER_ID,
                 scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = 0L,
             ),
         )
@@ -100,7 +100,7 @@ class LessonCustomRepositoryImplTest {
                 studentUserId = STUDENT_USER_ID,
                 teacherUserId = TEACHER_USER_ID,
                 scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = lesson.id,
             ),
         )
@@ -122,7 +122,7 @@ class LessonCustomRepositoryImplTest {
                 studentUserId = STUDENT_USER_ID,
                 teacherUserId = TEACHER_USER_ID,
                 scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 30),
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = 0L,
             ),
         )
@@ -131,7 +131,7 @@ class LessonCustomRepositoryImplTest {
                 studentUserId = STUDENT_USER_ID,
                 teacherUserId = SUBSTITUTE_TEACHER_USER_ID,
                 scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 30),
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = 0L,
             ),
         )
@@ -159,7 +159,7 @@ class LessonCustomRepositoryImplTest {
                 studentUserId = STUDENT_USER_ID,
                 teacherUserId = TEACHER_USER_ID,
                 scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
-                durationMinutes = 60L,
+                requestedDurationMinutes = 60L,
                 excludeLessonId = 0L,
             ),
         )

--- a/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepositoryImplTest.kt
+++ b/SClass-Domain/src/test/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepositoryImplTest.kt
@@ -1,0 +1,196 @@
+package com.sclass.domain.domains.lesson.repository
+
+import com.sclass.domain.config.DomainTestConfig
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import jakarta.persistence.EntityManager
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import java.time.LocalDateTime
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(DomainTestConfig::class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ComponentScan(basePackages = ["com.sclass.domain"])
+class LessonCustomRepositoryImplTest {
+    @Autowired
+    private lateinit var lessonRepository: LessonRepository
+
+    @Autowired
+    private lateinit var em: EntityManager
+
+    @Test
+    fun `학생이나 선생님의 기존 수업과 시간이 겹치면 충돌이다`() {
+        persistLesson(
+            studentUserId = STUDENT_USER_ID,
+            assignedTeacherUserId = TEACHER_USER_ID,
+            scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
+        )
+        em.flush()
+        em.clear()
+
+        assertTrue(
+            lessonRepository.existsScheduleConflict(
+                studentUserId = STUDENT_USER_ID,
+                teacherUserId = "other-teacher-id",
+                scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 30),
+                durationMinutes = 60L,
+                excludeLessonId = 0L,
+            ),
+        )
+        assertTrue(
+            lessonRepository.existsScheduleConflict(
+                studentUserId = "other-student-id",
+                teacherUserId = TEACHER_USER_ID,
+                scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 30),
+                durationMinutes = 60L,
+                excludeLessonId = 0L,
+            ),
+        )
+    }
+
+    @Test
+    fun `기존 수업과 시간이 딱 붙으면 충돌이 아니다`() {
+        persistLesson(
+            studentUserId = STUDENT_USER_ID,
+            assignedTeacherUserId = TEACHER_USER_ID,
+            scheduledAt = LocalDateTime.of(2026, 5, 1, 19, 0),
+        )
+        persistLesson(
+            studentUserId = STUDENT_USER_ID,
+            assignedTeacherUserId = TEACHER_USER_ID,
+            scheduledAt = LocalDateTime.of(2026, 5, 1, 21, 0),
+        )
+        em.flush()
+        em.clear()
+
+        assertFalse(
+            lessonRepository.existsScheduleConflict(
+                studentUserId = STUDENT_USER_ID,
+                teacherUserId = TEACHER_USER_ID,
+                scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
+                durationMinutes = 60L,
+                excludeLessonId = 0L,
+            ),
+        )
+    }
+
+    @Test
+    fun `수정 대상 수업은 충돌 검사에서 제외한다`() {
+        val lesson =
+            persistLesson(
+                studentUserId = STUDENT_USER_ID,
+                assignedTeacherUserId = TEACHER_USER_ID,
+                scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
+            )
+        em.flush()
+        em.clear()
+
+        assertFalse(
+            lessonRepository.existsScheduleConflict(
+                studentUserId = STUDENT_USER_ID,
+                teacherUserId = TEACHER_USER_ID,
+                scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
+                durationMinutes = 60L,
+                excludeLessonId = lesson.id,
+            ),
+        )
+    }
+
+    @Test
+    fun `대타가 있으면 대타 선생님 기준으로 충돌을 검사한다`() {
+        persistLesson(
+            studentUserId = "other-student-id",
+            assignedTeacherUserId = TEACHER_USER_ID,
+            substituteTeacherUserId = SUBSTITUTE_TEACHER_USER_ID,
+            scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
+        )
+        em.flush()
+        em.clear()
+
+        assertFalse(
+            lessonRepository.existsScheduleConflict(
+                studentUserId = STUDENT_USER_ID,
+                teacherUserId = TEACHER_USER_ID,
+                scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 30),
+                durationMinutes = 60L,
+                excludeLessonId = 0L,
+            ),
+        )
+        assertTrue(
+            lessonRepository.existsScheduleConflict(
+                studentUserId = STUDENT_USER_ID,
+                teacherUserId = SUBSTITUTE_TEACHER_USER_ID,
+                scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 30),
+                durationMinutes = 60L,
+                excludeLessonId = 0L,
+            ),
+        )
+    }
+
+    @Test
+    fun `완료되거나 취소된 수업은 충돌 대상이 아니다`() {
+        persistLesson(
+            studentUserId = STUDENT_USER_ID,
+            assignedTeacherUserId = TEACHER_USER_ID,
+            scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
+            status = LessonStatus.COMPLETED,
+        )
+        persistLesson(
+            studentUserId = STUDENT_USER_ID,
+            assignedTeacherUserId = TEACHER_USER_ID,
+            scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 30),
+            status = LessonStatus.CANCELLED,
+        )
+        em.flush()
+        em.clear()
+
+        assertFalse(
+            lessonRepository.existsScheduleConflict(
+                studentUserId = STUDENT_USER_ID,
+                teacherUserId = TEACHER_USER_ID,
+                scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
+                durationMinutes = 60L,
+                excludeLessonId = 0L,
+            ),
+        )
+    }
+
+    private fun persistLesson(
+        studentUserId: String,
+        assignedTeacherUserId: String,
+        scheduledAt: LocalDateTime,
+        substituteTeacherUserId: String? = null,
+        status: LessonStatus = LessonStatus.SCHEDULED,
+    ): Lesson {
+        val lesson =
+            Lesson(
+                lessonType = LessonType.COURSE,
+                enrollmentId = 1L,
+                studentUserId = studentUserId,
+                assignedTeacherUserId = assignedTeacherUserId,
+                substituteTeacherUserId = substituteTeacherUserId,
+                lessonNumber = 1,
+                name = "수학 수업",
+                scheduledAt = scheduledAt,
+                status = status,
+            )
+        em.persist(lesson)
+        return lesson
+    }
+
+    private companion object {
+        const val STUDENT_USER_ID = "student-user-id"
+        const val TEACHER_USER_ID = "teacher-user-id"
+        const val SUBSTITUTE_TEACHER_USER_ID = "substitute-teacher-id"
+    }
+}

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClient.kt
@@ -51,6 +51,23 @@ class CentralGoogleCalendarClient(
         }
     }
 
+    fun deleteMeetEventWithRefreshToken(
+        refreshToken: String,
+        eventId: String,
+    ) {
+        val accessToken = authorizationCodeClient.refreshAccessToken(refreshToken)
+        try {
+            googleCalendarClient.deleteMeetEventWithAccessToken(
+                eventId = eventId,
+                accessToken = accessToken,
+                calendarId = properties.calendarId,
+            )
+        } catch (e: WebClientResponseException) {
+            if (e.isAuthorizationFailure()) throw GoogleCalendarUnauthorizedException()
+            throw e
+        }
+    }
+
     private fun WebClientResponseException.isAuthorizationFailure(): Boolean =
         statusCode.value() == UNAUTHORIZED_STATUS || statusCode.value() == FORBIDDEN_STATUS
 

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClient.kt
@@ -32,6 +32,25 @@ class CentralGoogleCalendarClient(
         }
     }
 
+    fun updateMeetEventWithRefreshToken(
+        refreshToken: String,
+        eventId: String,
+        command: GoogleCalendarEventCreateCommand,
+    ): GoogleCalendarEventResult {
+        val accessToken = authorizationCodeClient.refreshAccessToken(refreshToken)
+        return try {
+            googleCalendarClient.updateMeetEventWithAccessToken(
+                eventId = eventId,
+                command = command,
+                accessToken = accessToken,
+                calendarId = properties.calendarId,
+            )
+        } catch (e: WebClientResponseException) {
+            if (e.isAuthorizationFailure()) throw GoogleCalendarUnauthorizedException()
+            throw e
+        }
+    }
+
     private fun WebClientResponseException.isAuthorizationFailure(): Boolean =
         statusCode.value() == UNAUTHORIZED_STATUS || statusCode.value() == FORBIDDEN_STATUS
 

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
@@ -117,6 +117,32 @@ class GoogleCalendarClient(
         return response.toResult()
     }
 
+    fun deleteMeetEventWithAccessToken(
+        eventId: String,
+        accessToken: String,
+        calendarId: String = PRIMARY_CALENDAR_ID,
+    ) {
+        try {
+            webClient
+                .delete()
+                .uri(calendarEventUri(calendarId, eventId, sendUpdates = false))
+                .header("Authorization", "Bearer $accessToken")
+                .retrieve()
+                .toBodilessEntity()
+                .block()
+        } catch (e: WebClientResponseException) {
+            log.warn("Google Calendar event delete failed: ${e.responseBodyAsString}", e)
+            if (e.isRetryableProviderFailure()) {
+                throw GoogleOAuthProviderUnavailableException()
+            }
+            if (e.isAuthorizationFailure()) throw e
+            throw GoogleCalendarRequestFailedException()
+        } catch (e: Exception) {
+            log.warn("Google Calendar event delete failed", e)
+            throw GoogleOAuthProviderUnavailableException()
+        }
+    }
+
     private fun GoogleCalendarEventCreateCommand.toCreateRequest(): GoogleCalendarEventRequest =
         GoogleCalendarEventRequest(
             summary = summary,

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
@@ -22,6 +22,8 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 @Component
@@ -148,12 +150,12 @@ class GoogleCalendarClient(
             summary = summary,
             start =
                 GoogleCalendarEventDateTime(
-                    dateTime = startAt.toOffsetDateTime().toString(),
+                    dateTime = startAt.toGoogleCalendarDateTime(),
                     timeZone = startAt.zone.id,
                 ),
             end =
                 GoogleCalendarEventDateTime(
-                    dateTime = endAt.toOffsetDateTime().toString(),
+                    dateTime = endAt.toGoogleCalendarDateTime(),
                     timeZone = endAt.zone.id,
                 ),
             conferenceData =
@@ -171,12 +173,12 @@ class GoogleCalendarClient(
             summary = summary,
             start =
                 GoogleCalendarEventDateTime(
-                    dateTime = startAt.toOffsetDateTime().toString(),
+                    dateTime = startAt.toGoogleCalendarDateTime(),
                     timeZone = startAt.zone.id,
                 ),
             end =
                 GoogleCalendarEventDateTime(
-                    dateTime = endAt.toOffsetDateTime().toString(),
+                    dateTime = endAt.toGoogleCalendarDateTime(),
                     timeZone = endAt.zone.id,
                 ),
             attendees = attendeeEmails.map { GoogleCalendarAttendee(email = it) },
@@ -260,12 +262,15 @@ class GoogleCalendarClient(
             .substringBefore("?")
             .takeIf { it.isNotBlank() }
 
+    private fun ZonedDateTime.toGoogleCalendarDateTime(): String = toOffsetDateTime().format(GOOGLE_CALENDAR_DATE_TIME_FORMATTER)
+
     private companion object {
         const val PRIMARY_CALENDAR_ID = "primary"
         const val UNAUTHORIZED_STATUS = 401
         const val FORBIDDEN_STATUS = 403
         const val TOO_MANY_REQUESTS_STATUS = 429
         const val GOOGLE_RESOURCE_EXHAUSTED_STATUS = "RESOURCE_EXHAUSTED"
+        val GOOGLE_CALENDAR_DATE_TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX")
         val GOOGLE_CALENDAR_RETRYABLE_FORBIDDEN_REASONS =
             setOf(
                 "dailyLimitExceeded",

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
@@ -13,6 +13,7 @@ import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventDateTime
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventRequest
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResponse
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventUpdateRequest
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -139,8 +140,8 @@ class GoogleCalendarClient(
             attendees = attendeeEmails.map { GoogleCalendarAttendee(email = it) },
         )
 
-    private fun GoogleCalendarEventCreateCommand.toUpdateRequest(): GoogleCalendarEventRequest =
-        GoogleCalendarEventRequest(
+    private fun GoogleCalendarEventCreateCommand.toUpdateRequest(): GoogleCalendarEventUpdateRequest =
+        GoogleCalendarEventUpdateRequest(
             summary = summary,
             start =
                 GoogleCalendarEventDateTime(

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
@@ -58,7 +58,7 @@ class GoogleCalendarClient(
         accessToken: String,
         calendarId: String = PRIMARY_CALENDAR_ID,
     ): GoogleCalendarEventResult {
-        val request = command.toRequest()
+        val request = command.toCreateRequest()
         val response =
             try {
                 webClient
@@ -84,7 +84,39 @@ class GoogleCalendarClient(
         return response.toResult()
     }
 
-    private fun GoogleCalendarEventCreateCommand.toRequest(): GoogleCalendarEventRequest =
+    fun updateMeetEventWithAccessToken(
+        eventId: String,
+        command: GoogleCalendarEventCreateCommand,
+        accessToken: String,
+        calendarId: String = PRIMARY_CALENDAR_ID,
+    ): GoogleCalendarEventResult {
+        val request = command.toUpdateRequest()
+        val response =
+            try {
+                webClient
+                    .patch()
+                    .uri(calendarEventUri(calendarId, eventId, sendUpdates = command.attendeeEmails.isNotEmpty()))
+                    .header("Authorization", "Bearer $accessToken")
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(GoogleCalendarEventResponse::class.java)
+                    .block()
+            } catch (e: WebClientResponseException) {
+                log.warn("Google Calendar event update failed:${e.responseBodyAsString}", e)
+                if (e.isRetryableProviderFailure()) {
+                    throw GoogleOAuthProviderUnavailableException()
+                }
+                if (e.isAuthorizationFailure()) throw e
+                throw GoogleCalendarRequestFailedException()
+            } catch (e: Exception) {
+                log.warn("Google Calendar event update failed", e)
+                throw GoogleOAuthProviderUnavailableException()
+            }
+
+        return response.toResult()
+    }
+
+    private fun GoogleCalendarEventCreateCommand.toCreateRequest(): GoogleCalendarEventRequest =
         GoogleCalendarEventRequest(
             summary = summary,
             start =
@@ -107,6 +139,22 @@ class GoogleCalendarClient(
             attendees = attendeeEmails.map { GoogleCalendarAttendee(email = it) },
         )
 
+    private fun GoogleCalendarEventCreateCommand.toUpdateRequest(): GoogleCalendarEventRequest =
+        GoogleCalendarEventRequest(
+            summary = summary,
+            start =
+                GoogleCalendarEventDateTime(
+                    dateTime = startAt.toOffsetDateTime().toString(),
+                    timeZone = startAt.zone.id,
+                ),
+            end =
+                GoogleCalendarEventDateTime(
+                    dateTime = endAt.toOffsetDateTime().toString(),
+                    timeZone = endAt.zone.id,
+                ),
+            attendees = attendeeEmails.map { GoogleCalendarAttendee(email = it) },
+        )
+
     private fun GoogleCalendarEventResponse?.toResult(): GoogleCalendarEventResult {
         val eventId = this?.id ?: throw GoogleCalendarRequestFailedException()
         val meetJoinUrl =
@@ -121,6 +169,9 @@ class GoogleCalendarClient(
         return GoogleCalendarEventResult(
             eventId = eventId,
             meetJoinUrl = meetJoinUrl,
+            meetCode =
+                conferenceData?.conferenceId
+                    ?: meetJoinUrl.extractMeetCode(),
         )
     }
 
@@ -156,6 +207,31 @@ class GoogleCalendarClient(
                 reasons.any { it in GOOGLE_CALENDAR_RETRYABLE_FORBIDDEN_REASONS }
         }.getOrDefault(false)
     }
+
+    private fun calendarEventUri(
+        calendarId: String,
+        eventId: String,
+        sendUpdates: Boolean,
+    ): String {
+        val sendUpdatesQuery = if (sendUpdates) "&sendUpdates=all" else ""
+        val encodedCalendarId =
+            URLEncoder.encode(
+                calendarId,
+                StandardCharsets.UTF_8,
+            )
+        val encodedEventId =
+            URLEncoder.encode(
+                eventId,
+                StandardCharsets.UTF_8,
+            )
+        return "https://www.googleapis.com/calendar/v3/calendars/$encodedCalendarId/events/$encodedEventId" +
+            "?conferenceDataVersion=1$sendUpdatesQuery"
+    }
+
+    private fun String.extractMeetCode(): String? =
+        substringAfterLast("/")
+            .substringBefore("?")
+            .takeIf { it.isNotBlank() }
 
     private companion object {
         const val PRIMARY_CALENDAR_ID = "primary"

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventRequest.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventRequest.kt
@@ -11,6 +11,13 @@ data class GoogleCalendarEventRequest(
     val attendees: List<GoogleCalendarAttendee> = emptyList(),
 )
 
+data class GoogleCalendarEventUpdateRequest(
+    val summary: String,
+    val start: GoogleCalendarEventDateTime,
+    val end: GoogleCalendarEventDateTime,
+    val attendees: List<GoogleCalendarAttendee> = emptyList(),
+)
+
 data class GoogleCalendarEventDateTime(
     val dateTime: String,
     val timeZone: String,

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventRequest.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventRequest.kt
@@ -4,7 +4,7 @@ data class GoogleCalendarEventRequest(
     val summary: String,
     val start: GoogleCalendarEventDateTime,
     val end: GoogleCalendarEventDateTime,
-    val conferenceData: GoogleCalendarConferenceData,
+    val conferenceData: GoogleCalendarConferenceData? = null,
     val attendees: List<GoogleCalendarAttendee> = emptyList(),
 )
 

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventRequest.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventRequest.kt
@@ -1,5 +1,8 @@
 package com.sclass.infrastructure.calendar.dto
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class GoogleCalendarEventRequest(
     val summary: String,
     val start: GoogleCalendarEventDateTime,

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventResponse.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventResponse.kt
@@ -7,6 +7,7 @@ data class GoogleCalendarEventResponse(
 )
 
 data class GoogleCalendarConferenceResponse(
+    val conferenceId: String? = null,
     val entryPoints: List<GoogleCalendarEntryPoint> = emptyList(),
 )
 

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventResult.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/dto/GoogleCalendarEventResult.kt
@@ -3,4 +3,5 @@ package com.sclass.infrastructure.calendar.dto
 data class GoogleCalendarEventResult(
     val eventId: String,
     val meetJoinUrl: String,
+    val meetCode: String? = null,
 )

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClientTest.kt
@@ -88,6 +88,69 @@ class CentralGoogleCalendarClientTest {
         }
     }
 
+    @Test
+    fun `central refresh token으로 access token을 갱신해 중앙 캘린더 Meet 이벤트를 수정한다`() {
+        val command = command()
+        val expected = GoogleCalendarEventResult(eventId = "event-id", meetJoinUrl = "https://meet.google.com/abc-defg-hij")
+
+        every { authorizationCodeClient.refreshAccessToken("central-refresh-token") } returns "central-access-token"
+        every {
+            googleCalendarClient.updateMeetEventWithAccessToken(
+                eventId = "event-id",
+                command = command,
+                accessToken = "central-access-token",
+                calendarId = "primary",
+            )
+        } returns expected
+
+        val result =
+            client.updateMeetEventWithRefreshToken(
+                refreshToken = "central-refresh-token",
+                eventId = "event-id",
+                command = command,
+            )
+
+        assertEquals(expected, result)
+        verify { authorizationCodeClient.refreshAccessToken("central-refresh-token") }
+        verify {
+            googleCalendarClient.updateMeetEventWithAccessToken(
+                eventId = "event-id",
+                command = command,
+                accessToken = "central-access-token",
+                calendarId = "primary",
+            )
+        }
+    }
+
+    @Test
+    fun `중앙 캘린더 이벤트 수정에서 Google 인증 실패가 발생하면 도메인 예외로 변환한다`() {
+        val command = command()
+        every { authorizationCodeClient.refreshAccessToken("central-refresh-token") } returns "central-access-token"
+        every {
+            googleCalendarClient.updateMeetEventWithAccessToken(
+                eventId = "event-id",
+                command = command,
+                accessToken = "central-access-token",
+                calendarId = "primary",
+            )
+        } throws
+            WebClientResponseException.create(
+                HttpStatus.FORBIDDEN.value(),
+                "Forbidden",
+                HttpHeaders.EMPTY,
+                ByteArray(0),
+                null,
+            )
+
+        assertThrows<GoogleCalendarUnauthorizedException> {
+            client.updateMeetEventWithRefreshToken(
+                refreshToken = "central-refresh-token",
+                eventId = "event-id",
+                command = command,
+            )
+        }
+    }
+
     private fun command() =
         GoogleCalendarEventCreateCommand(
             summary = "수학 1회차",

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClientTest.kt
@@ -151,6 +151,58 @@ class CentralGoogleCalendarClientTest {
         }
     }
 
+    @Test
+    fun `central refresh token으로 access token을 갱신해 중앙 캘린더 Meet 이벤트를 삭제한다`() {
+        every { authorizationCodeClient.refreshAccessToken("central-refresh-token") } returns "central-access-token"
+        every {
+            googleCalendarClient.deleteMeetEventWithAccessToken(
+                eventId = "event-id",
+                accessToken = "central-access-token",
+                calendarId = "primary",
+            )
+        } returns Unit
+
+        client.deleteMeetEventWithRefreshToken(
+            refreshToken = "central-refresh-token",
+            eventId = "event-id",
+        )
+
+        verify { authorizationCodeClient.refreshAccessToken("central-refresh-token") }
+        verify {
+            googleCalendarClient.deleteMeetEventWithAccessToken(
+                eventId = "event-id",
+                accessToken = "central-access-token",
+                calendarId = "primary",
+            )
+        }
+    }
+
+    @Test
+    fun `중앙 캘린더 이벤트 삭제에서 Google 인증 실패가 발생하면 도메인 예외로 변환한다`() {
+        every { authorizationCodeClient.refreshAccessToken("central-refresh-token") } returns "central-access-token"
+        every {
+            googleCalendarClient.deleteMeetEventWithAccessToken(
+                eventId = "event-id",
+                accessToken = "central-access-token",
+                calendarId = "primary",
+            )
+        } throws
+            WebClientResponseException.create(
+                HttpStatus.FORBIDDEN.value(),
+                "Forbidden",
+                HttpHeaders.EMPTY,
+                ByteArray(0),
+                null,
+            )
+
+        assertThrows<GoogleCalendarUnauthorizedException> {
+            client.deleteMeetEventWithRefreshToken(
+                refreshToken = "central-refresh-token",
+                eventId = "event-id",
+            )
+        }
+    }
+
     private fun command() =
         GoogleCalendarEventCreateCommand(
             summary = "수학 1회차",

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
@@ -1,5 +1,6 @@
 package com.sclass.infrastructure.calendar
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.sclass.common.exception.GoogleCalendarRequestFailedException
 import com.sclass.common.exception.GoogleCalendarUnauthorizedException
 import com.sclass.common.exception.GoogleOAuthProviderUnavailableException
@@ -15,6 +16,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -196,6 +198,7 @@ class GoogleCalendarClientTest {
             { assertEquals(null, requestSlot.single().conferenceData) },
             { assertEquals(listOf("teacher@example.com"), requestSlot.single().attendees.map { it.email }) },
         )
+        assertFalse(ObjectMapper().writeValueAsString(requestSlot.single()).contains("conferenceData"))
         verify { requestBodySpec.header(HttpHeaders.AUTHORIZATION, "Bearer access-token") }
     }
 

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
@@ -66,6 +66,17 @@ class GoogleCalendarClientTest {
         every { requestHeadersSpec.retrieve() } returns responseSpec
     }
 
+    private fun mockUpdateEventCall(
+        requestSlot: MutableList<GoogleCalendarEventRequest> = mutableListOf(),
+        uri: String = CALENDAR_EVENT_URI,
+    ) {
+        every { webClient.patch() } returns requestBodyUriSpec
+        every { requestBodyUriSpec.uri(uri) } returns requestBodySpec
+        every { requestBodySpec.header(HttpHeaders.AUTHORIZATION, any()) } returns requestBodySpec
+        every { requestBodySpec.bodyValue(capture(requestSlot)) } returns requestHeadersSpec
+        every { requestHeadersSpec.retrieve() } returns responseSpec
+    }
+
     @Test
     fun `Calendar event 생성 응답에서 video entryPoint를 Meet 링크로 반환한다`() {
         val requestSlot = mutableListOf<GoogleCalendarEventRequest>()
@@ -86,12 +97,13 @@ class GoogleCalendarClientTest {
                     "hangoutsMeet",
                     requestSlot
                         .single()
-                        .conferenceData
+                        .conferenceData!!
                         .createRequest
                         .conferenceSolutionKey
                         .type,
                 )
             },
+            { assertEquals("abc-defg-hij", result.meetCode) },
         )
     }
 
@@ -99,11 +111,20 @@ class GoogleCalendarClientTest {
     fun `video entryPoint가 없으면 hangoutLink를 Meet 링크로 반환한다`() {
         mockCreateEventCall()
         every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
-            Mono.just(calendarResponse(meetUri = null, hangoutLink = "https://meet.google.com/hangout-link"))
+            Mono.just(
+                calendarResponse(
+                    meetUri = null,
+                    hangoutLink = "https://meet.google.com/hangout-link",
+                    conferenceId = null,
+                ),
+            )
 
         val result = client.createMeetEvent(command)
 
-        assertEquals("https://meet.google.com/hangout-link", result.meetJoinUrl)
+        assertAll(
+            { assertEquals("https://meet.google.com/hangout-link", result.meetJoinUrl) },
+            { assertEquals("hangout-link", result.meetCode) },
+        )
     }
 
     @Test
@@ -142,6 +163,61 @@ class GoogleCalendarClientTest {
             )
 
         assertEquals("https://meet.google.com/abc-defg-hij", result.meetJoinUrl)
+    }
+
+    @Test
+    fun `Calendar event 수정은 기존 Meet 생성을 요청하지 않고 일정과 참석자만 전송한다`() {
+        val requestSlot = mutableListOf<GoogleCalendarEventRequest>()
+        mockUpdateEventCall(requestSlot, CALENDAR_EVENT_WITH_SEND_UPDATES_URI)
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.just(calendarResponse(meetUri = "https://meet.google.com/updated-code", conferenceId = "updated-code"))
+        val updateCommand =
+            GoogleCalendarEventCreateCommand(
+                summary = "변경된 수학 1회차",
+                startAt = command.startAt.plusDays(1),
+                endAt = command.endAt.plusDays(1),
+                attendeeEmails = listOf("teacher@example.com"),
+            )
+
+        val result =
+            client.updateMeetEventWithAccessToken(
+                eventId = "event-id-1",
+                command = updateCommand,
+                accessToken = "access-token",
+            )
+
+        assertAll(
+            { assertEquals("event-id-1", result.eventId) },
+            { assertEquals("https://meet.google.com/updated-code", result.meetJoinUrl) },
+            { assertEquals("updated-code", result.meetCode) },
+            { assertEquals("변경된 수학 1회차", requestSlot.single().summary) },
+            { assertEquals("2026-04-27T14:00+09:00", requestSlot.single().start.dateTime) },
+            { assertEquals("Asia/Seoul", requestSlot.single().start.timeZone) },
+            { assertEquals(null, requestSlot.single().conferenceData) },
+            { assertEquals(listOf("teacher@example.com"), requestSlot.single().attendees.map { it.email }) },
+        )
+        verify { requestBodySpec.header(HttpHeaders.AUTHORIZATION, "Bearer access-token") }
+    }
+
+    @Test
+    fun `event id와 calendar id는 update URL path에 안전하게 인코딩한다`() {
+        mockUpdateEventCall(uri = CALENDAR_EVENT_WITH_ENCODED_IDS_URI)
+        every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
+            Mono.just(calendarResponse(meetUri = "https://meet.google.com/updated-code"))
+
+        client.updateMeetEventWithAccessToken(
+            eventId = "event/id with space",
+            command =
+                GoogleCalendarEventCreateCommand(
+                    summary = command.summary,
+                    startAt = command.startAt,
+                    endAt = command.endAt,
+                ),
+            accessToken = "access-token",
+            calendarId = "central@example.com",
+        )
+
+        verify { requestBodyUriSpec.uri(CALENDAR_EVENT_WITH_ENCODED_IDS_URI) }
     }
 
     @Test
@@ -279,12 +355,14 @@ class GoogleCalendarClientTest {
         id: String? = "event-id-1",
         meetUri: String?,
         hangoutLink: String? = null,
+        conferenceId: String? = "abc-defg-hij",
     ): GoogleCalendarEventResponse =
         GoogleCalendarEventResponse(
             id = id,
             hangoutLink = hangoutLink,
             conferenceData =
                 GoogleCalendarConferenceResponse(
+                    conferenceId = conferenceId,
                     entryPoints =
                         listOfNotNull(
                             meetUri?.let {
@@ -316,5 +394,11 @@ class GoogleCalendarClientTest {
             "https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1&sendUpdates=all"
         const val CALENDAR_EVENTS_WITH_ENCODED_CALENDAR_ID_URI =
             "https://www.googleapis.com/calendar/v3/calendars/central%40example.com/events?conferenceDataVersion=1"
+        const val CALENDAR_EVENT_URI =
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events/event-id-1?conferenceDataVersion=1"
+        const val CALENDAR_EVENT_WITH_SEND_UPDATES_URI =
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events/event-id-1?conferenceDataVersion=1&sendUpdates=all"
+        const val CALENDAR_EVENT_WITH_ENCODED_IDS_URI =
+            "https://www.googleapis.com/calendar/v3/calendars/central%40example.com/events/event%2Fid+with+space?conferenceDataVersion=1"
     }
 }

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
@@ -10,6 +10,7 @@ import com.sclass.infrastructure.calendar.dto.GoogleCalendarEntryPoint
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventRequest
 import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResponse
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventUpdateRequest
 import com.sclass.infrastructure.oauth.client.GoogleAuthorizationCodeClient
 import io.mockk.every
 import io.mockk.mockk
@@ -69,7 +70,7 @@ class GoogleCalendarClientTest {
     }
 
     private fun mockUpdateEventCall(
-        requestSlot: MutableList<GoogleCalendarEventRequest> = mutableListOf(),
+        requestSlot: MutableList<GoogleCalendarEventUpdateRequest> = mutableListOf(),
         uri: String = CALENDAR_EVENT_URI,
     ) {
         every { webClient.patch() } returns requestBodyUriSpec
@@ -169,7 +170,7 @@ class GoogleCalendarClientTest {
 
     @Test
     fun `Calendar event 수정은 기존 Meet 생성을 요청하지 않고 일정과 참석자만 전송한다`() {
-        val requestSlot = mutableListOf<GoogleCalendarEventRequest>()
+        val requestSlot = mutableListOf<GoogleCalendarEventUpdateRequest>()
         mockUpdateEventCall(requestSlot, CALENDAR_EVENT_WITH_SEND_UPDATES_URI)
         every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
             Mono.just(calendarResponse(meetUri = "https://meet.google.com/updated-code", conferenceId = "updated-code"))
@@ -195,7 +196,6 @@ class GoogleCalendarClientTest {
             { assertEquals("변경된 수학 1회차", requestSlot.single().summary) },
             { assertEquals("2026-04-27T14:00+09:00", requestSlot.single().start.dateTime) },
             { assertEquals("Asia/Seoul", requestSlot.single().start.timeZone) },
-            { assertEquals(null, requestSlot.single().conferenceData) },
             { assertEquals(listOf("teacher@example.com"), requestSlot.single().attendees.map { it.email }) },
         )
         assertFalse(ObjectMapper().writeValueAsString(requestSlot.single()).contains("conferenceData"))

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
@@ -34,6 +35,8 @@ class GoogleCalendarClientTest {
     private lateinit var requestBodyUriSpec: WebClient.RequestBodyUriSpec
     private lateinit var requestBodySpec: WebClient.RequestBodySpec
     private lateinit var requestHeadersSpec: WebClient.RequestHeadersSpec<*>
+    private lateinit var requestHeadersUriSpec: WebClient.RequestHeadersUriSpec<*>
+    private lateinit var deleteRequestHeadersSpec: WebClient.RequestHeadersSpec<*>
     private lateinit var responseSpec: WebClient.ResponseSpec
     private lateinit var authorizationCodeClient: GoogleAuthorizationCodeClient
     private lateinit var client: GoogleCalendarClient
@@ -53,6 +56,8 @@ class GoogleCalendarClientTest {
         requestBodyUriSpec = mockk()
         requestBodySpec = mockk()
         requestHeadersSpec = mockk()
+        requestHeadersUriSpec = mockk()
+        deleteRequestHeadersSpec = mockk()
         responseSpec = mockk()
         authorizationCodeClient = mockk()
         client = GoogleCalendarClient(webClient, authorizationCodeClient)
@@ -67,6 +72,13 @@ class GoogleCalendarClientTest {
         every { requestBodySpec.header(HttpHeaders.AUTHORIZATION, any()) } returns requestBodySpec
         every { requestBodySpec.bodyValue(capture(requestSlot)) } returns requestHeadersSpec
         every { requestHeadersSpec.retrieve() } returns responseSpec
+    }
+
+    private fun mockDeleteEventCall(uri: String = CALENDAR_EVENT_URI) {
+        every { webClient.delete() } returns requestHeadersUriSpec
+        every { requestHeadersUriSpec.uri(uri) } returns deleteRequestHeadersSpec
+        every { deleteRequestHeadersSpec.header(HttpHeaders.AUTHORIZATION, any()) } returns deleteRequestHeadersSpec
+        every { deleteRequestHeadersSpec.retrieve() } returns responseSpec
     }
 
     private fun mockUpdateEventCall(
@@ -221,6 +233,34 @@ class GoogleCalendarClientTest {
         )
 
         verify { requestBodyUriSpec.uri(CALENDAR_EVENT_WITH_ENCODED_IDS_URI) }
+    }
+
+    @Test
+    fun `Calendar event 삭제는 event delete endpoint를 호출한다`() {
+        mockDeleteEventCall()
+        every { responseSpec.toBodilessEntity() } returns Mono.just(ResponseEntity.noContent().build())
+
+        client.deleteMeetEventWithAccessToken(
+            eventId = "event-id-1",
+            accessToken = "access-token",
+        )
+
+        verify { requestHeadersUriSpec.uri(CALENDAR_EVENT_URI) }
+        verify { deleteRequestHeadersSpec.header(HttpHeaders.AUTHORIZATION, "Bearer access-token") }
+    }
+
+    @Test
+    fun `event id와 calendar id는 delete URL path에 안전하게 인코딩한다`() {
+        mockDeleteEventCall(uri = CALENDAR_EVENT_WITH_ENCODED_IDS_URI)
+        every { responseSpec.toBodilessEntity() } returns Mono.just(ResponseEntity.noContent().build())
+
+        client.deleteMeetEventWithAccessToken(
+            eventId = "event/id with space",
+            accessToken = "access-token",
+            calendarId = "central@example.com",
+        )
+
+        verify { requestHeadersUriSpec.uri(CALENDAR_EVENT_WITH_ENCODED_IDS_URI) }
     }
 
     @Test

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
@@ -105,7 +105,8 @@ class GoogleCalendarClientTest {
             { assertEquals("event-id-1", result.eventId) },
             { assertEquals("https://meet.google.com/abc-defg-hij", result.meetJoinUrl) },
             { assertEquals("수학 1회차", requestSlot.single().summary) },
-            { assertEquals("2026-04-26T14:00+09:00", requestSlot.single().start.dateTime) },
+            { assertEquals("2026-04-26T14:00:00+09:00", requestSlot.single().start.dateTime) },
+            { assertEquals("2026-04-26T15:00:00+09:00", requestSlot.single().end.dateTime) },
             { assertEquals("Asia/Seoul", requestSlot.single().start.timeZone) },
             {
                 assertEquals(
@@ -206,7 +207,8 @@ class GoogleCalendarClientTest {
             { assertEquals("https://meet.google.com/updated-code", result.meetJoinUrl) },
             { assertEquals("updated-code", result.meetCode) },
             { assertEquals("변경된 수학 1회차", requestSlot.single().summary) },
-            { assertEquals("2026-04-27T14:00+09:00", requestSlot.single().start.dateTime) },
+            { assertEquals("2026-04-27T14:00:00+09:00", requestSlot.single().start.dateTime) },
+            { assertEquals("2026-04-27T15:00:00+09:00", requestSlot.single().end.dateTime) },
             { assertEquals("Asia/Seoul", requestSlot.single().start.timeZone) },
             { assertEquals(listOf("teacher@example.com"), requestSlot.single().attendees.map { it.email }) },
         )

--- a/scripts/lesson-google-meet-migration.sql
+++ b/scripts/lesson-google-meet-migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE lessons
+    ADD COLUMN google_calendar_event_id VARCHAR(256) NULL,
+    ADD COLUMN google_meet_join_url VARCHAR(512) NULL,
+    ADD COLUMN google_meet_code VARCHAR(64) NULL;


### PR DESCRIPTION
## 요약
- lesson에 중앙 Google Calendar/Meet 정보를 저장하는 embedded 필드를 추가했습니다.
- 선생님용 `POST/PUT /api/v1/lessons/{lessonId}/schedule` API를 추가하고 기존 PATCH schedule 수정은 deprecated 처리했습니다.
- 중앙 Google 계정으로 Meet 이벤트를 생성/수정하고, 수업 응답에 Meet URL/code를 노출합니다.
- 선생님/학생의 기존 수업과 시간이 겹치면 Google Calendar 호출 전에 `LessonScheduleConflictException`으로 차단합니다.

## API 변경
- `POST /api/v1/lessons/{lessonId}/schedule`
- `PUT /api/v1/lessons/{lessonId}/schedule`
- supporters/backoffice lesson 응답에 `googleMeetJoinUrl`, `googleMeetCode` 추가

## DB 변경
- `lessons.google_calendar_event_id` 추가
- `lessons.google_meet_join_url` 추가
- `lessons.google_meet_code` 추가
- 마이그레이션 스크립트: `scripts/lesson-google-meet-migration.sql`

## 관련 이슈
- Closes #293
- Related #287

## 검증
- pre-commit hook: ktlintFormat + build 통과
- `:SClass-Domain:compileKotlin :SClass-Api-Supporters:compileKotlin`
- `:SClass-Api-Supporters:test --tests com.sclass.supporters.lesson.usecase.CreateLessonScheduleUseCaseTest --tests com.sclass.supporters.lesson.usecase.UpdateLessonScheduleUseCaseTest`
- `:SClass-Domain:test --tests com.sclass.domain.domains.lesson.domain.LessonTest`
- `:SClass-Domain:test --tests com.sclass.domain.domains.lesson.repository.LessonCustomRepositoryImplTest`
- `:SClass-Infrastructure:test --tests com.sclass.infrastructure.calendar.GoogleCalendarClientTest --tests com.sclass.infrastructure.calendar.CentralGoogleCalendarClientTest`
- ktlint format task
- `git diff --check`