### PR TITLE
feat: add lesson schedule management APIs

### DIFF
--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/controller/LessonController.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/controller/LessonController.kt
@@ -1,16 +1,23 @@
 package com.sclass.backoffice.lesson.controller
 
 import com.sclass.backoffice.lesson.dto.LessonResponse
+import com.sclass.backoffice.lesson.dto.ScheduleLessonRequest
 import com.sclass.backoffice.lesson.dto.UpdateSubstituteTeacherRequest
+import com.sclass.backoffice.lesson.usecase.CreateLessonScheduleUseCase
+import com.sclass.backoffice.lesson.usecase.DeleteLessonScheduleUseCase
 import com.sclass.backoffice.lesson.usecase.GetLessonDetailUseCase
+import com.sclass.backoffice.lesson.usecase.UpdateLessonScheduleUseCase
 import com.sclass.backoffice.lesson.usecase.UpdateSubstituteTeacherUseCase
 import com.sclass.backoffice.lessonReport.dto.LessonReportResponse
 import com.sclass.backoffice.lessonReport.usecase.GetLessonReportUseCase
 import com.sclass.common.dto.ApiResponse
 import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -21,6 +28,9 @@ class LessonController(
     private val updateSubstituteTeacherUseCase: UpdateSubstituteTeacherUseCase,
     private val getLessonDetailUseCase: GetLessonDetailUseCase,
     private val getLessonReportUseCase: GetLessonReportUseCase,
+    private val createLessonScheduleUseCase: CreateLessonScheduleUseCase,
+    private val updateLessonScheduleUseCase: UpdateLessonScheduleUseCase,
+    private val deleteLessonScheduleUseCase: DeleteLessonScheduleUseCase,
 ) {
     @GetMapping("/{lessonId}")
     fun getDetail(
@@ -37,4 +47,38 @@ class LessonController(
     fun getReport(
         @PathVariable lessonId: Long,
     ): ApiResponse<LessonReportResponse> = ApiResponse.success(getLessonReportUseCase.execute(lessonId))
+
+    @PostMapping("/{lessonId}/schedule")
+    fun createSchedule(
+        @PathVariable lessonId: Long,
+        @Valid @RequestBody request: ScheduleLessonRequest,
+    ): ApiResponse<LessonResponse> =
+        ApiResponse.success(
+            createLessonScheduleUseCase.execute(
+                lessonId,
+                request,
+            ),
+        )
+
+    @PutMapping("/{lessonId}/schedule")
+    fun updateSchedule(
+        @PathVariable lessonId: Long,
+        @Valid @RequestBody request: ScheduleLessonRequest,
+    ): ApiResponse<LessonResponse> =
+        ApiResponse.success(
+            updateLessonScheduleUseCase.execute(
+                lessonId,
+                request,
+            ),
+        )
+
+    @DeleteMapping("/{lessonId}/schedule")
+    fun deleteSchedule(
+        @PathVariable lessonId: Long,
+    ): ApiResponse<LessonResponse> =
+        ApiResponse.success(
+            deleteLessonScheduleUseCase.execute(
+                lessonId,
+            ),
+        )
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/dto/ScheduleLessonRequest.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/dto/ScheduleLessonRequest.kt
@@ -1,0 +1,13 @@
+package com.sclass.backoffice.lesson.dto
+
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
+
+data class ScheduleLessonRequest(
+    @field:Size(max = 200)
+    val name: String? = null,
+
+    @field:NotNull
+    val scheduledAt: LocalDateTime?,
+)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -95,6 +95,15 @@ class CreateLessonScheduleUseCase(
         }
     }
 
+    private fun lockScheduleParticipants(lesson: Lesson) {
+        userAdaptor.lockByIdsForUpdate(
+            listOf(
+                lesson.studentUserId,
+                lesson.effectiveTeacherUserId,
+            ),
+        )
+    }
+
     private fun saveSchedule(
         lessonId: Long,
         request: ScheduleLessonRequest,
@@ -105,6 +114,7 @@ class CreateLessonScheduleUseCase(
             val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
             if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
             lesson.validateScheduleUpdatable()
+            lockScheduleParticipants(lesson)
             validateNoScheduleConflict(lesson, scheduledAt)
 
             lesson.updateSchedule(request.name, scheduledAt)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -102,7 +102,7 @@ class CreateLessonScheduleUseCase(
         result: GoogleCalendarEventResult,
     ): LessonResponse =
         txTemplate.execute {
-            val lesson = lessonAdaptor.findById(lessonId)
+            val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
             if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
             lesson.validateScheduleUpdatable()
             validateNoScheduleConflict(lesson, scheduledAt)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -45,7 +45,7 @@ class CreateLessonScheduleUseCase(
             )
 
         return try {
-            saveSchedule(lessonId, request, prepared.scheduledAt, result)
+            saveSchedule(lessonId, request, prepared, result)
         } catch (e: RuntimeException) {
             deleteCreatedCalendarEvent(prepared, result.eventId)
             throw e
@@ -75,6 +75,8 @@ class CreateLessonScheduleUseCase(
                 command = lesson.toGoogleCalendarCommand(request.name, scheduledAt),
                 calendarClient = calendarClient,
                 refreshToken = refreshToken,
+                studentUserId = lesson.studentUserId,
+                teacherUserId = lesson.effectiveTeacherUserId,
             )
         }!!
 
@@ -107,17 +109,18 @@ class CreateLessonScheduleUseCase(
     private fun saveSchedule(
         lessonId: Long,
         request: ScheduleLessonRequest,
-        scheduledAt: LocalDateTime,
+        prepared: PreparedCreateSchedule,
         result: GoogleCalendarEventResult,
     ): LessonResponse =
         txTemplate.execute {
             val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
             if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
             lesson.validateScheduleUpdatable()
+            lesson.validateParticipantSnapshot(prepared.studentUserId, prepared.teacherUserId)
             lockScheduleParticipants(lesson)
-            validateNoScheduleConflict(lesson, scheduledAt)
+            validateNoScheduleConflict(lesson, prepared.scheduledAt)
 
-            lesson.updateSchedule(request.name, scheduledAt)
+            lesson.updateSchedule(request.name, prepared.scheduledAt)
             lesson.attachGoogleMeet(
                 eventId = result.eventId,
                 meetJoinUrl = result.meetJoinUrl,
@@ -130,6 +133,15 @@ class CreateLessonScheduleUseCase(
             centralGoogleAccountAdaptor.save(centralAccount)
             LessonResponse.from(lesson)
         }!!
+
+    private fun Lesson.validateParticipantSnapshot(
+        studentUserId: String,
+        teacherUserId: String,
+    ) {
+        if (this.studentUserId != studentUserId || effectiveTeacherUserId != teacherUserId) {
+            throw LessonScheduleConflictException()
+        }
+    }
 
     private fun deleteCreatedCalendarEvent(
         prepared: PreparedCreateSchedule,
@@ -165,6 +177,8 @@ class CreateLessonScheduleUseCase(
         val command: GoogleCalendarEventCreateCommand,
         val calendarClient: CentralGoogleCalendarClient,
         val refreshToken: String,
+        val studentUserId: String,
+        val teacherUserId: String,
     )
 
     private companion object {

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -1,0 +1,161 @@
+package com.sclass.backoffice.lesson.usecase
+
+import com.sclass.backoffice.lesson.dto.LessonResponse
+import com.sclass.backoffice.lesson.dto.ScheduleLessonRequest
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.exception.LessonScheduleAlreadyExistsException
+import com.sclass.domain.domains.lesson.exception.LessonScheduleConflictException
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.user.adaptor.UserAdaptor
+import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@UseCase
+class CreateLessonScheduleUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val userAdaptor: UserAdaptor,
+    private val aesTokenEncryptor: AesTokenEncryptor,
+    private val centralGoogleCalendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>,
+    private val txTemplate: TransactionTemplate,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    private val log = LoggerFactory.getLogger(CreateLessonScheduleUseCase::class.java)
+
+    fun execute(
+        lessonId: Long,
+        request: ScheduleLessonRequest,
+    ): LessonResponse {
+        val prepared = prepareSchedule(lessonId, request)
+        val result =
+            prepared.calendarClient.createMeetEventWithRefreshToken(
+                refreshToken = prepared.refreshToken,
+                command = prepared.command,
+            )
+
+        return try {
+            saveSchedule(lessonId, request, prepared.scheduledAt, result)
+        } catch (e: RuntimeException) {
+            deleteCreatedCalendarEvent(prepared, result.eventId)
+            throw e
+        }
+    }
+
+    private fun prepareSchedule(
+        lessonId: Long,
+        request: ScheduleLessonRequest,
+    ): PreparedCreateSchedule =
+        txTemplate.execute {
+            val scheduledAt = requireNotNull(request.scheduledAt)
+            val lesson = lessonAdaptor.findById(lessonId)
+            if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
+            lesson.validateScheduleUpdatable()
+
+            validateNoScheduleConflict(lesson, scheduledAt)
+
+            val calendarClient =
+                centralGoogleCalendarClientProvider.getIfAvailable()
+                    ?: throw GoogleCalendarCentralDisabledException()
+            val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+            val refreshToken = aesTokenEncryptor.decrypt(centralAccount.encryptedRefreshToken)
+
+            PreparedCreateSchedule(
+                scheduledAt = scheduledAt,
+                command = lesson.toGoogleCalendarCommand(request.name, scheduledAt),
+                calendarClient = calendarClient,
+                refreshToken = refreshToken,
+            )
+        }!!
+
+    private fun validateNoScheduleConflict(
+        lesson: Lesson,
+        scheduledAt: LocalDateTime,
+    ) {
+        if (
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = lesson.studentUserId,
+                teacherUserId = lesson.effectiveTeacherUserId,
+                scheduledAt = scheduledAt,
+                requestedDurationMinutes = Lesson.DEFAULT_DURATION_MINUTES,
+                excludeLessonId = lesson.id,
+            )
+        ) {
+            throw LessonScheduleConflictException()
+        }
+    }
+
+    private fun saveSchedule(
+        lessonId: Long,
+        request: ScheduleLessonRequest,
+        scheduledAt: LocalDateTime,
+        result: GoogleCalendarEventResult,
+    ): LessonResponse =
+        txTemplate.execute {
+            val lesson = lessonAdaptor.findById(lessonId)
+            if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
+            lesson.validateScheduleUpdatable()
+            validateNoScheduleConflict(lesson, scheduledAt)
+
+            lesson.updateSchedule(request.name, scheduledAt)
+            lesson.attachGoogleMeet(
+                eventId = result.eventId,
+                meetJoinUrl = result.meetJoinUrl,
+                meetCode = result.meetCode,
+            )
+
+            val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+            centralAccount.markUsed(LocalDateTime.now(clock))
+            LessonResponse.from(lesson)
+        }!!
+
+    private fun deleteCreatedCalendarEvent(
+        prepared: PreparedCreateSchedule,
+        eventId: String,
+    ) {
+        runCatching {
+            prepared.calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = prepared.refreshToken,
+                eventId = eventId,
+            )
+        }.onFailure {
+            log.warn("Failed to delete Google Calendar event after lesson schedule save failed: eventId={}", eventId, it)
+        }
+    }
+
+    private fun Lesson.toGoogleCalendarCommand(
+        name: String?,
+        scheduledAt: LocalDateTime,
+    ): GoogleCalendarEventCreateCommand {
+        val teacher = userAdaptor.findById(effectiveTeacherUserId)
+        val student = userAdaptor.findById(studentUserId)
+
+        return GoogleCalendarEventCreateCommand(
+            summary = name ?: this.name,
+            startAt = scheduledAt.atZone(SEOUL_ZONE_ID),
+            endAt = scheduledAt.plusMinutes(Lesson.DEFAULT_DURATION_MINUTES).atZone(SEOUL_ZONE_ID),
+            attendeeEmails = listOf(teacher.email, student.email).distinct(),
+        )
+    }
+
+    private data class PreparedCreateSchedule(
+        val scheduledAt: LocalDateTime,
+        val command: GoogleCalendarEventCreateCommand,
+        val calendarClient: CentralGoogleCalendarClient,
+        val refreshToken: String,
+    )
+
+    private companion object {
+        val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -113,9 +113,11 @@ class CreateLessonScheduleUseCase(
                 meetJoinUrl = result.meetJoinUrl,
                 meetCode = result.meetCode,
             )
+            lessonAdaptor.save(lesson)
 
             val centralAccount = centralGoogleAccountAdaptor.findGoogle()
             centralAccount.markUsed(LocalDateTime.now(clock))
+            centralGoogleAccountAdaptor.save(centralAccount)
             LessonResponse.from(lesson)
         }!!
 

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/DeleteLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/DeleteLessonScheduleUseCase.kt
@@ -22,66 +22,37 @@ class DeleteLessonScheduleUseCase(
     private val txTemplate: TransactionTemplate,
     private val clock: Clock = Clock.systemDefaultZone(),
 ) {
-    fun execute(lessonId: Long): LessonResponse {
-        val prepared = prepareScheduleDelete(lessonId)
-
-        prepared.calendarEvent?.let {
-            it.calendarClient.deleteMeetEventWithRefreshToken(
-                refreshToken = it.refreshToken,
-                eventId = it.eventId,
-                sendUpdates = true,
-            )
-        }
-
-        return deleteSchedule(lessonId, prepared.calendarEvent != null)
-    }
-
-    private fun prepareScheduleDelete(lessonId: Long): PreparedDeleteSchedule =
+    fun execute(lessonId: Long): LessonResponse =
         txTemplate.execute {
-            val lesson = lessonAdaptor.findById(lessonId)
+            val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
             if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
             lesson.validateScheduleUpdatable()
 
             val eventId = lesson.googleMeet?.calendarEventId?.takeIf { it.isNotBlank() }
-            if (eventId == null) {
-                PreparedDeleteSchedule()
-            } else {
-                val calendarClient =
-                    centralGoogleCalendarClientProvider.getIfAvailable()
-                        ?: throw GoogleCalendarCentralDisabledException()
-                val centralAccount = centralGoogleAccountAdaptor.findGoogle()
-                val refreshToken = aesTokenEncryptor.decrypt(centralAccount.encryptedRefreshToken)
+            val centralAccount =
+                eventId?.let {
+                    val calendarClient =
+                        centralGoogleCalendarClientProvider.getIfAvailable()
+                            ?: throw GoogleCalendarCentralDisabledException()
+                    val account = centralGoogleAccountAdaptor.findGoogle()
+                    val refreshToken = aesTokenEncryptor.decrypt(account.encryptedRefreshToken)
 
-                PreparedDeleteSchedule(CalendarEventDelete(eventId, calendarClient, refreshToken))
-            }
-        }!!
-
-    private fun deleteSchedule(
-        lessonId: Long,
-        calendarEventDeleted: Boolean,
-    ): LessonResponse =
-        txTemplate.execute {
-            val lesson = lessonAdaptor.findById(lessonId)
-            if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
-            lesson.validateScheduleUpdatable()
+                    calendarClient.deleteMeetEventWithRefreshToken(
+                        refreshToken = refreshToken,
+                        eventId = it,
+                        sendUpdates = true,
+                    )
+                    account
+                }
 
             lesson.deleteSchedule()
+            lessonAdaptor.save(lesson)
 
-            if (calendarEventDeleted) {
-                val centralAccount = centralGoogleAccountAdaptor.findGoogle()
-                centralAccount.markUsed(LocalDateTime.now(clock))
+            centralAccount?.let {
+                it.markUsed(LocalDateTime.now(clock))
+                centralGoogleAccountAdaptor.save(it)
             }
 
             LessonResponse.from(lesson)
         }!!
-
-    private data class PreparedDeleteSchedule(
-        val calendarEvent: CalendarEventDelete? = null,
-    )
-
-    private data class CalendarEventDelete(
-        val eventId: String,
-        val calendarClient: CentralGoogleCalendarClient,
-        val refreshToken: String,
-    )
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/DeleteLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/DeleteLessonScheduleUseCase.kt
@@ -5,9 +5,11 @@ import com.sclass.common.annotation.UseCase
 import com.sclass.common.exception.GoogleCalendarCentralDisabledException
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.LessonGoogleMeet
 import com.sclass.domain.domains.lesson.exception.LessonScheduleNotFoundException
 import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
 import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.Clock
@@ -22,14 +24,22 @@ class DeleteLessonScheduleUseCase(
     private val txTemplate: TransactionTemplate,
     private val clock: Clock = Clock.systemDefaultZone(),
 ) {
-    fun execute(lessonId: Long): LessonResponse =
+    private val log = LoggerFactory.getLogger(DeleteLessonScheduleUseCase::class.java)
+
+    fun execute(lessonId: Long): LessonResponse {
+        val deleted = deleteSchedule(lessonId)
+        deleted.calendarEvent?.let { deleteCalendarEvent(lessonId, it) }
+        return deleted.response
+    }
+
+    private fun deleteSchedule(lessonId: Long): DeletedSchedule =
         txTemplate.execute {
             val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
             if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
             lesson.validateScheduleUpdatable()
 
             val eventId = lesson.googleMeet?.calendarEventId?.takeIf { it.isNotBlank() }
-            val centralAccount =
+            val calendarEvent =
                 eventId?.let {
                     val calendarClient =
                         centralGoogleCalendarClientProvider.getIfAvailable()
@@ -37,22 +47,85 @@ class DeleteLessonScheduleUseCase(
                     val account = centralGoogleAccountAdaptor.findGoogle()
                     val refreshToken = aesTokenEncryptor.decrypt(account.encryptedRefreshToken)
 
-                    calendarClient.deleteMeetEventWithRefreshToken(
-                        refreshToken = refreshToken,
+                    CalendarEventDelete(
                         eventId = it,
-                        sendUpdates = true,
+                        calendarClient = calendarClient,
+                        refreshToken = refreshToken,
+                        scheduledAt = lesson.scheduledAt!!,
+                        googleMeet = lesson.googleMeet!!,
                     )
-                    account
                 }
 
             lesson.deleteSchedule()
             lessonAdaptor.save(lesson)
 
-            centralAccount?.let {
-                it.markUsed(LocalDateTime.now(clock))
-                centralGoogleAccountAdaptor.save(it)
-            }
-
-            LessonResponse.from(lesson)
+            DeletedSchedule(
+                response = LessonResponse.from(lesson),
+                calendarEvent = calendarEvent,
+            )
         }!!
+
+    private fun deleteCalendarEvent(
+        lessonId: Long,
+        calendarEvent: CalendarEventDelete,
+    ) {
+        try {
+            calendarEvent.calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = calendarEvent.refreshToken,
+                eventId = calendarEvent.eventId,
+                sendUpdates = true,
+            )
+            markCalendarUsed()
+        } catch (e: RuntimeException) {
+            restoreSchedule(lessonId, calendarEvent)
+            throw e
+        }
+    }
+
+    private fun markCalendarUsed() {
+        runCatching {
+            txTemplate.execute {
+                val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+                centralAccount.markUsed(LocalDateTime.now(clock))
+                centralGoogleAccountAdaptor.save(centralAccount)
+            }
+        }.onFailure {
+            log.warn("Failed to mark central Google account as used after lesson schedule delete", it)
+        }
+    }
+
+    private fun restoreSchedule(
+        lessonId: Long,
+        calendarEvent: CalendarEventDelete,
+    ) {
+        runCatching {
+            txTemplate.execute {
+                val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
+                if (lesson.scheduledAt == null && lesson.googleMeet == null) {
+                    lesson.updateSchedule(null, calendarEvent.scheduledAt)
+                    lesson.attachGoogleMeet(
+                        eventId = calendarEvent.googleMeet.calendarEventId,
+                        meetJoinUrl = calendarEvent.googleMeet.joinUrl,
+                        meetCode = calendarEvent.googleMeet.code,
+                    )
+                    lessonAdaptor.save(lesson)
+                }
+            }
+        }.onFailure {
+            log.warn("Failed to restore lesson schedule after Google Calendar event delete failed: lessonId={}", lessonId, it)
+        }
+    }
+
+    private data class DeletedSchedule(
+        val response: LessonResponse,
+        val calendarEvent: CalendarEventDelete? = null,
+    )
+
+    private data class CalendarEventDelete(
+        val eventId: String,
+        val calendarClient: CentralGoogleCalendarClient,
+        val refreshToken: String,
+        val scheduledAt: LocalDateTime,
+        val googleMeet: LessonGoogleMeet,
+    )
 }

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/DeleteLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/DeleteLessonScheduleUseCase.kt
@@ -5,9 +5,12 @@ import com.sclass.common.annotation.UseCase
 import com.sclass.common.exception.GoogleCalendarCentralDisabledException
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.lesson.domain.LessonGoogleMeet
+import com.sclass.domain.domains.lesson.exception.LessonScheduleConflictException
 import com.sclass.domain.domains.lesson.exception.LessonScheduleNotFoundException
 import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.user.adaptor.UserAdaptor
 import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
@@ -19,6 +22,7 @@ import java.time.LocalDateTime
 class DeleteLessonScheduleUseCase(
     private val lessonAdaptor: LessonAdaptor,
     private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val userAdaptor: UserAdaptor,
     private val aesTokenEncryptor: AesTokenEncryptor,
     private val centralGoogleCalendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>,
     private val txTemplate: TransactionTemplate,
@@ -102,6 +106,9 @@ class DeleteLessonScheduleUseCase(
             txTemplate.execute {
                 val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
                 if (lesson.scheduledAt == null && lesson.googleMeet == null) {
+                    lockScheduleParticipants(lesson)
+                    validateNoScheduleConflict(lesson, calendarEvent.scheduledAt)
+
                     lesson.updateSchedule(null, calendarEvent.scheduledAt)
                     lesson.attachGoogleMeet(
                         eventId = calendarEvent.googleMeet.calendarEventId,
@@ -113,6 +120,32 @@ class DeleteLessonScheduleUseCase(
             }
         }.onFailure {
             log.warn("Failed to restore lesson schedule after Google Calendar event delete failed: lessonId={}", lessonId, it)
+        }
+    }
+
+    private fun lockScheduleParticipants(lesson: Lesson) {
+        userAdaptor.lockByIdsForUpdate(
+            listOf(
+                lesson.studentUserId,
+                lesson.effectiveTeacherUserId,
+            ),
+        )
+    }
+
+    private fun validateNoScheduleConflict(
+        lesson: Lesson,
+        scheduledAt: LocalDateTime,
+    ) {
+        if (
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = lesson.studentUserId,
+                teacherUserId = lesson.effectiveTeacherUserId,
+                scheduledAt = scheduledAt,
+                requestedDurationMinutes = Lesson.DEFAULT_DURATION_MINUTES,
+                excludeLessonId = lesson.id,
+            )
+        ) {
+            throw LessonScheduleConflictException()
         }
     }
 

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/DeleteLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/DeleteLessonScheduleUseCase.kt
@@ -1,0 +1,87 @@
+package com.sclass.backoffice.lesson.usecase
+
+import com.sclass.backoffice.lesson.dto.LessonResponse
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.exception.LessonScheduleNotFoundException
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
+import java.time.LocalDateTime
+
+@UseCase
+class DeleteLessonScheduleUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val aesTokenEncryptor: AesTokenEncryptor,
+    private val centralGoogleCalendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>,
+    private val txTemplate: TransactionTemplate,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    fun execute(lessonId: Long): LessonResponse {
+        val prepared = prepareScheduleDelete(lessonId)
+
+        prepared.calendarEvent?.let {
+            it.calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = it.refreshToken,
+                eventId = it.eventId,
+                sendUpdates = true,
+            )
+        }
+
+        return deleteSchedule(lessonId, prepared.calendarEvent != null)
+    }
+
+    private fun prepareScheduleDelete(lessonId: Long): PreparedDeleteSchedule =
+        txTemplate.execute {
+            val lesson = lessonAdaptor.findById(lessonId)
+            if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
+            lesson.validateScheduleUpdatable()
+
+            val eventId = lesson.googleMeet?.calendarEventId?.takeIf { it.isNotBlank() }
+            if (eventId == null) {
+                PreparedDeleteSchedule()
+            } else {
+                val calendarClient =
+                    centralGoogleCalendarClientProvider.getIfAvailable()
+                        ?: throw GoogleCalendarCentralDisabledException()
+                val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+                val refreshToken = aesTokenEncryptor.decrypt(centralAccount.encryptedRefreshToken)
+
+                PreparedDeleteSchedule(CalendarEventDelete(eventId, calendarClient, refreshToken))
+            }
+        }!!
+
+    private fun deleteSchedule(
+        lessonId: Long,
+        calendarEventDeleted: Boolean,
+    ): LessonResponse =
+        txTemplate.execute {
+            val lesson = lessonAdaptor.findById(lessonId)
+            if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
+            lesson.validateScheduleUpdatable()
+
+            lesson.deleteSchedule()
+
+            if (calendarEventDeleted) {
+                val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+                centralAccount.markUsed(LocalDateTime.now(clock))
+            }
+
+            LessonResponse.from(lesson)
+        }!!
+
+    private data class PreparedDeleteSchedule(
+        val calendarEvent: CalendarEventDelete? = null,
+    )
+
+    private data class CalendarEventDelete(
+        val eventId: String,
+        val calendarClient: CentralGoogleCalendarClient,
+        val refreshToken: String,
+    )
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -1,0 +1,205 @@
+package com.sclass.backoffice.lesson.usecase
+
+import com.sclass.backoffice.lesson.dto.LessonResponse
+import com.sclass.backoffice.lesson.dto.ScheduleLessonRequest
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.exception.LessonScheduleConflictException
+import com.sclass.domain.domains.lesson.exception.LessonScheduleNotFoundException
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.user.adaptor.UserAdaptor
+import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@UseCase
+class UpdateLessonScheduleUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val userAdaptor: UserAdaptor,
+    private val aesTokenEncryptor: AesTokenEncryptor,
+    private val centralGoogleCalendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>,
+    private val txTemplate: TransactionTemplate,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    private val log = LoggerFactory.getLogger(UpdateLessonScheduleUseCase::class.java)
+
+    fun execute(
+        lessonId: Long,
+        request: ScheduleLessonRequest,
+    ): LessonResponse {
+        val prepared = prepareSchedule(lessonId, request)
+        val result =
+            if (prepared.eventId.isNullOrBlank()) {
+                prepared.calendarClient.createMeetEventWithRefreshToken(
+                    refreshToken = prepared.refreshToken,
+                    command = prepared.command,
+                )
+            } else {
+                prepared.calendarClient.updateMeetEventWithRefreshToken(
+                    refreshToken = prepared.refreshToken,
+                    eventId = prepared.eventId,
+                    command = prepared.command,
+                )
+            }
+
+        return try {
+            saveSchedule(lessonId, request, prepared.scheduledAt, result)
+        } catch (e: RuntimeException) {
+            rollbackCalendarEvent(prepared, result)
+            throw e
+        }
+    }
+
+    private fun prepareSchedule(
+        lessonId: Long,
+        request: ScheduleLessonRequest,
+    ): PreparedUpdateSchedule =
+        txTemplate.execute {
+            val scheduledAt = requireNotNull(request.scheduledAt)
+            val lesson = lessonAdaptor.findById(lessonId)
+            val currentScheduledAt = lesson.scheduledAt ?: throw LessonScheduleNotFoundException()
+            lesson.validateScheduleUpdatable()
+
+            validateNoScheduleConflict(lesson, scheduledAt)
+
+            val calendarClient =
+                centralGoogleCalendarClientProvider.getIfAvailable()
+                    ?: throw GoogleCalendarCentralDisabledException()
+            val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+            val refreshToken = aesTokenEncryptor.decrypt(centralAccount.encryptedRefreshToken)
+
+            PreparedUpdateSchedule(
+                scheduledAt = scheduledAt,
+                command = lesson.toGoogleCalendarCommand(request.name, scheduledAt),
+                previousCommand = lesson.toGoogleCalendarCommand(lesson.name, currentScheduledAt),
+                calendarClient = calendarClient,
+                refreshToken = refreshToken,
+                eventId = lesson.googleMeet?.calendarEventId,
+            )
+        }!!
+
+    private fun validateNoScheduleConflict(
+        lesson: Lesson,
+        scheduledAt: LocalDateTime,
+    ) {
+        if (
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = lesson.studentUserId,
+                teacherUserId = lesson.effectiveTeacherUserId,
+                scheduledAt = scheduledAt,
+                requestedDurationMinutes = Lesson.DEFAULT_DURATION_MINUTES,
+                excludeLessonId = lesson.id,
+            )
+        ) {
+            throw LessonScheduleConflictException()
+        }
+    }
+
+    private fun saveSchedule(
+        lessonId: Long,
+        request: ScheduleLessonRequest,
+        scheduledAt: LocalDateTime,
+        result: GoogleCalendarEventResult,
+    ): LessonResponse =
+        txTemplate.execute {
+            val lesson = lessonAdaptor.findById(lessonId)
+            if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
+            lesson.validateScheduleUpdatable()
+            validateNoScheduleConflict(lesson, scheduledAt)
+
+            lesson.updateSchedule(request.name, scheduledAt)
+            lesson.attachGoogleMeet(
+                eventId = result.eventId,
+                meetJoinUrl = result.meetJoinUrl,
+                meetCode = result.meetCode,
+            )
+
+            val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+            centralAccount.markUsed(LocalDateTime.now(clock))
+            LessonResponse.from(lesson)
+        }!!
+
+    private fun rollbackCalendarEvent(
+        prepared: PreparedUpdateSchedule,
+        result: GoogleCalendarEventResult,
+    ) {
+        if (prepared.eventId.isNullOrBlank()) {
+            deleteCreatedCalendarEvent(prepared, result.eventId)
+        } else {
+            restoreUpdatedCalendarEvent(prepared)
+        }
+    }
+
+    private fun deleteCreatedCalendarEvent(
+        prepared: PreparedUpdateSchedule,
+        eventId: String,
+    ) {
+        runCatching {
+            prepared.calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = prepared.refreshToken,
+                eventId = eventId,
+            )
+        }.onFailure {
+            log.warn("Failed to delete Google Calendar event after lesson schedule save failed: eventId={}", eventId, it)
+        }
+    }
+
+    private fun restoreUpdatedCalendarEvent(prepared: PreparedUpdateSchedule) {
+        runCatching {
+            prepared.calendarClient.updateMeetEventWithRefreshToken(
+                refreshToken = prepared.refreshToken,
+                eventId = prepared.eventId!!,
+                command = prepared.previousCommand,
+            )
+        }.onFailure {
+            log.warn(
+                "Failed to restore Google Calendar event after lesson schedule save failed: eventId={}",
+                prepared.eventId,
+                it,
+            )
+        }
+    }
+
+    private fun Lesson.toGoogleCalendarCommand(
+        name: String?,
+        scheduledAt: LocalDateTime,
+    ): GoogleCalendarEventCreateCommand {
+        val teacher = userAdaptor.findById(effectiveTeacherUserId)
+        val student = userAdaptor.findById(studentUserId)
+
+        return GoogleCalendarEventCreateCommand(
+            summary = name ?: this.name,
+            startAt = scheduledAt.atZone(SEOUL_ZONE_ID),
+            endAt =
+                scheduledAt.plusMinutes(Lesson.DEFAULT_DURATION_MINUTES).atZone(SEOUL_ZONE_ID),
+            attendeeEmails =
+                listOf(
+                    teacher.email,
+                    student.email,
+                ).distinct(),
+        )
+    }
+
+    private data class PreparedUpdateSchedule(
+        val scheduledAt: LocalDateTime,
+        val command: GoogleCalendarEventCreateCommand,
+        val previousCommand: GoogleCalendarEventCreateCommand,
+        val calendarClient: CentralGoogleCalendarClient,
+        val refreshToken: String,
+        val eventId: String?,
+    )
+
+    private companion object {
+        val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
+    }
+}

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -112,7 +112,7 @@ class UpdateLessonScheduleUseCase(
         result: GoogleCalendarEventResult,
     ): LessonResponse =
         txTemplate.execute {
-            val lesson = lessonAdaptor.findById(lessonId)
+            val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
             if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
             lesson.validateScheduleUpdatable()
             validateNoScheduleConflict(lesson, scheduledAt)

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -123,9 +123,11 @@ class UpdateLessonScheduleUseCase(
                 meetJoinUrl = result.meetJoinUrl,
                 meetCode = result.meetCode,
             )
+            lessonAdaptor.save(lesson)
 
             val centralAccount = centralGoogleAccountAdaptor.findGoogle()
             centralAccount.markUsed(LocalDateTime.now(clock))
+            centralGoogleAccountAdaptor.save(centralAccount)
             LessonResponse.from(lesson)
         }!!
 

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -53,7 +53,7 @@ class UpdateLessonScheduleUseCase(
             }
 
         return try {
-            saveSchedule(lessonId, request, prepared.scheduledAt, result)
+            saveSchedule(lessonId, request, prepared, result)
         } catch (e: RuntimeException) {
             rollbackCalendarEvent(prepared, result)
             throw e
@@ -85,6 +85,8 @@ class UpdateLessonScheduleUseCase(
                 calendarClient = calendarClient,
                 refreshToken = refreshToken,
                 eventId = lesson.googleMeet?.calendarEventId,
+                studentUserId = lesson.studentUserId,
+                teacherUserId = lesson.effectiveTeacherUserId,
             )
         }!!
 
@@ -117,17 +119,18 @@ class UpdateLessonScheduleUseCase(
     private fun saveSchedule(
         lessonId: Long,
         request: ScheduleLessonRequest,
-        scheduledAt: LocalDateTime,
+        prepared: PreparedUpdateSchedule,
         result: GoogleCalendarEventResult,
     ): LessonResponse =
         txTemplate.execute {
             val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
             if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
             lesson.validateScheduleUpdatable()
+            lesson.validateParticipantSnapshot(prepared.studentUserId, prepared.teacherUserId)
             lockScheduleParticipants(lesson)
-            validateNoScheduleConflict(lesson, scheduledAt)
+            validateNoScheduleConflict(lesson, prepared.scheduledAt)
 
-            lesson.updateSchedule(request.name, scheduledAt)
+            lesson.updateSchedule(request.name, prepared.scheduledAt)
             lesson.attachGoogleMeet(
                 eventId = result.eventId,
                 meetJoinUrl = result.meetJoinUrl,
@@ -140,6 +143,15 @@ class UpdateLessonScheduleUseCase(
             centralGoogleAccountAdaptor.save(centralAccount)
             LessonResponse.from(lesson)
         }!!
+
+    private fun Lesson.validateParticipantSnapshot(
+        studentUserId: String,
+        teacherUserId: String,
+    ) {
+        if (this.studentUserId != studentUserId || effectiveTeacherUserId != teacherUserId) {
+            throw LessonScheduleConflictException()
+        }
+    }
 
     private fun rollbackCalendarEvent(
         prepared: PreparedUpdateSchedule,
@@ -209,6 +221,8 @@ class UpdateLessonScheduleUseCase(
         val calendarClient: CentralGoogleCalendarClient,
         val refreshToken: String,
         val eventId: String?,
+        val studentUserId: String,
+        val teacherUserId: String,
     )
 
     private companion object {

--- a/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Backoffice/src/main/kotlin/com/sclass/backoffice/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -105,6 +105,15 @@ class UpdateLessonScheduleUseCase(
         }
     }
 
+    private fun lockScheduleParticipants(lesson: Lesson) {
+        userAdaptor.lockByIdsForUpdate(
+            listOf(
+                lesson.studentUserId,
+                lesson.effectiveTeacherUserId,
+            ),
+        )
+    }
+
     private fun saveSchedule(
         lessonId: Long,
         request: ScheduleLessonRequest,
@@ -115,6 +124,7 @@ class UpdateLessonScheduleUseCase(
             val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
             if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
             lesson.validateScheduleUpdatable()
+            lockScheduleParticipants(lesson)
             validateNoScheduleConflict(lesson, scheduledAt)
 
             lesson.updateSchedule(request.name, scheduledAt)

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/lesson/usecase/LessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/lesson/usecase/LessonScheduleUseCaseTest.kt
@@ -173,10 +173,12 @@ class LessonScheduleUseCaseTest {
             )
         val account = centralGoogleAccount()
 
-        every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
         every { calendarClientProvider.getIfAvailable() } returns calendarClient
         every { centralGoogleAccountAdaptor.findGoogle() } returns account
         every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every { lessonAdaptor.save(lesson) } returns lesson
+        every { centralGoogleAccountAdaptor.save(account) } returns account
         every {
             calendarClient.deleteMeetEventWithRefreshToken(
                 refreshToken = "refresh-token",
@@ -201,6 +203,8 @@ class LessonScheduleUseCaseTest {
                 sendUpdates = true,
             )
         }
+        verify(exactly = 1) { lessonAdaptor.save(lesson) }
+        verify(exactly = 1) { centralGoogleAccountAdaptor.save(account) }
     }
 
     private fun mockSchedulePreparation(
@@ -223,6 +227,8 @@ class LessonScheduleUseCaseTest {
         every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
         every { userAdaptor.findById(teacherUserId) } returns user(teacherUserId, "teacher@example.com")
         every { userAdaptor.findById(studentUserId) } returns user(studentUserId, "student@example.com")
+        every { lessonAdaptor.save(lesson) } returns lesson
+        every { centralGoogleAccountAdaptor.save(account) } returns account
     }
 
     private fun lesson(

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/lesson/usecase/LessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/lesson/usecase/LessonScheduleUseCaseTest.kt
@@ -64,6 +64,7 @@ class LessonScheduleUseCaseTest {
         every { txTemplate.execute(any<TransactionCallback<Any?>>()) } answers {
             firstArg<TransactionCallback<Any?>>().doInTransaction(mockk())
         }
+        every { userAdaptor.lockByIdsForUpdate(any()) } just Runs
         createUseCase =
             CreateLessonScheduleUseCase(
                 lessonAdaptor = lessonAdaptor,

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/lesson/usecase/LessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/lesson/usecase/LessonScheduleUseCaseTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.transaction.support.TransactionCallback
 import org.springframework.transaction.support.TransactionTemplate
@@ -207,12 +208,51 @@ class LessonScheduleUseCaseTest {
         verify(exactly = 1) { centralGoogleAccountAdaptor.save(account) }
     }
 
+    @Test
+    fun `관리자가 수업 스케줄 삭제 중 Calendar event 취소에 실패하면 lesson 일정을 복구한다`() {
+        val scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
+        val googleMeet = LessonGoogleMeet("event-id", "https://meet.google.com/abc-defg-hij", "abc-defg-hij")
+        val lesson =
+            lesson(
+                scheduledAt = scheduledAt,
+                googleMeet = googleMeet,
+            )
+        val account = centralGoogleAccount()
+        val calendarException = RuntimeException("calendar delete failed")
+
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
+        every { calendarClientProvider.getIfAvailable() } returns calendarClient
+        every { centralGoogleAccountAdaptor.findGoogle() } returns account
+        every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every { lessonAdaptor.save(lesson) } returns lesson
+        every {
+            calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "event-id",
+                sendUpdates = true,
+            )
+        } throws calendarException
+
+        val thrown = assertThrows<RuntimeException> { deleteUseCase.execute(1L) }
+
+        assertAll(
+            { assertEquals(calendarException, thrown) },
+            { assertEquals(scheduledAt, lesson.scheduledAt) },
+            { assertEquals("event-id", lesson.googleMeet?.calendarEventId) },
+            { assertEquals("https://meet.google.com/abc-defg-hij", lesson.googleMeet?.joinUrl) },
+            { assertEquals("abc-defg-hij", lesson.googleMeet?.code) },
+        )
+        verify(exactly = 2) { lessonAdaptor.save(lesson) }
+        verify(exactly = 0) { centralGoogleAccountAdaptor.save(account) }
+    }
+
     private fun mockSchedulePreparation(
         lesson: Lesson,
         account: CentralGoogleAccount,
         scheduledAt: LocalDateTime,
     ) {
         every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
         every {
             lessonAdaptor.existsScheduleConflict(
                 studentUserId = studentUserId,

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/lesson/usecase/LessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/lesson/usecase/LessonScheduleUseCaseTest.kt
@@ -89,6 +89,7 @@ class LessonScheduleUseCaseTest {
             DeleteLessonScheduleUseCase(
                 lessonAdaptor = lessonAdaptor,
                 centralGoogleAccountAdaptor = centralGoogleAccountAdaptor,
+                userAdaptor = userAdaptor,
                 aesTokenEncryptor = aesTokenEncryptor,
                 centralGoogleCalendarClientProvider = calendarClientProvider,
                 txTemplate = txTemplate,
@@ -226,6 +227,15 @@ class LessonScheduleUseCaseTest {
         every { centralGoogleAccountAdaptor.findGoogle() } returns account
         every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
         every { lessonAdaptor.save(lesson) } returns lesson
+        every {
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = studentUserId,
+                teacherUserId = teacherUserId,
+                scheduledAt = scheduledAt,
+                requestedDurationMinutes = 60L,
+                excludeLessonId = 1L,
+            )
+        } returns false
         every {
             calendarClient.deleteMeetEventWithRefreshToken(
                 refreshToken = "refresh-token",

--- a/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/lesson/usecase/LessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Backoffice/src/test/kotlin/com/sclass/backoffice/lesson/usecase/LessonScheduleUseCaseTest.kt
@@ -1,0 +1,263 @@
+package com.sclass.backoffice.lesson.usecase
+
+import com.sclass.backoffice.lesson.dto.ScheduleLessonRequest
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonGoogleMeet
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.domain.domains.user.adaptor.UserAdaptor
+import com.sclass.domain.domains.user.domain.AuthProvider
+import com.sclass.domain.domains.user.domain.User
+import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventCreateCommand
+import com.sclass.infrastructure.calendar.dto.GoogleCalendarEventResult
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class LessonScheduleUseCaseTest {
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor
+    private lateinit var userAdaptor: UserAdaptor
+    private lateinit var aesTokenEncryptor: AesTokenEncryptor
+    private lateinit var calendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>
+    private lateinit var calendarClient: CentralGoogleCalendarClient
+    private lateinit var txTemplate: TransactionTemplate
+    private lateinit var createUseCase: CreateLessonScheduleUseCase
+    private lateinit var updateUseCase: UpdateLessonScheduleUseCase
+    private lateinit var deleteUseCase: DeleteLessonScheduleUseCase
+
+    private val studentUserId = "student-user-id-0000000001"
+    private val teacherUserId = "teacher-user-id-0000000001"
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 12, 30)
+    private val zoneId = ZoneId.of("Asia/Seoul")
+    private val clock = Clock.fixed(fixedNow.atZone(zoneId).toInstant(), zoneId)
+
+    @BeforeEach
+    fun setUp() {
+        lessonAdaptor = mockk()
+        centralGoogleAccountAdaptor = mockk()
+        userAdaptor = mockk()
+        aesTokenEncryptor = mockk()
+        calendarClientProvider = mockk()
+        calendarClient = mockk()
+        txTemplate = mockk()
+        every { txTemplate.execute(any<TransactionCallback<Any?>>()) } answers {
+            firstArg<TransactionCallback<Any?>>().doInTransaction(mockk())
+        }
+        createUseCase =
+            CreateLessonScheduleUseCase(
+                lessonAdaptor = lessonAdaptor,
+                centralGoogleAccountAdaptor = centralGoogleAccountAdaptor,
+                userAdaptor = userAdaptor,
+                aesTokenEncryptor = aesTokenEncryptor,
+                centralGoogleCalendarClientProvider = calendarClientProvider,
+                txTemplate = txTemplate,
+                clock = clock,
+            )
+        updateUseCase =
+            UpdateLessonScheduleUseCase(
+                lessonAdaptor = lessonAdaptor,
+                centralGoogleAccountAdaptor = centralGoogleAccountAdaptor,
+                userAdaptor = userAdaptor,
+                aesTokenEncryptor = aesTokenEncryptor,
+                centralGoogleCalendarClientProvider = calendarClientProvider,
+                txTemplate = txTemplate,
+                clock = clock,
+            )
+        deleteUseCase =
+            DeleteLessonScheduleUseCase(
+                lessonAdaptor = lessonAdaptor,
+                centralGoogleAccountAdaptor = centralGoogleAccountAdaptor,
+                aesTokenEncryptor = aesTokenEncryptor,
+                centralGoogleCalendarClientProvider = calendarClientProvider,
+                txTemplate = txTemplate,
+                clock = clock,
+            )
+    }
+
+    @Test
+    fun `관리자가 수업 스케줄을 생성하면 중앙 Google Meet을 생성하고 lesson에 저장한다`() {
+        val lesson = lesson()
+        val account = centralGoogleAccount()
+        val commandSlot = slot<GoogleCalendarEventCreateCommand>()
+        val scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
+
+        mockSchedulePreparation(lesson, account, scheduledAt)
+        every {
+            calendarClient.createMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                command = capture(commandSlot),
+            )
+        } returns GoogleCalendarEventResult("event-id", "https://meet.google.com/abc-defg-hij", "abc-defg-hij")
+
+        val response =
+            createUseCase.execute(
+                lessonId = 1L,
+                request = ScheduleLessonRequest(name = "관리자 예약", scheduledAt = scheduledAt),
+            )
+
+        assertAll(
+            { assertEquals("관리자 예약", lesson.name) },
+            { assertEquals(scheduledAt, lesson.scheduledAt) },
+            { assertEquals("event-id", lesson.googleMeet?.calendarEventId) },
+            { assertEquals("https://meet.google.com/abc-defg-hij", response.googleMeetJoinUrl) },
+            { assertEquals("abc-defg-hij", response.googleMeetCode) },
+            { assertEquals(fixedNow, account.lastUsedAt) },
+            { assertEquals("관리자 예약", commandSlot.captured.summary) },
+            { assertEquals(listOf("teacher@example.com", "student@example.com"), commandSlot.captured.attendeeEmails) },
+        )
+    }
+
+    @Test
+    fun `관리자가 기존 Google Meet 수업 스케줄을 수정하면 중앙 Calendar event를 수정한다`() {
+        val lesson =
+            lesson(
+                scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
+                googleMeet = LessonGoogleMeet("event-id", "https://meet.google.com/old-code", "old-code"),
+            )
+        val account = centralGoogleAccount()
+        val commandSlot = slot<GoogleCalendarEventCreateCommand>()
+        val newScheduledAt = LocalDateTime.of(2026, 5, 2, 21, 0)
+
+        mockSchedulePreparation(lesson, account, newScheduledAt)
+        every {
+            calendarClient.updateMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "event-id",
+                command = capture(commandSlot),
+            )
+        } returns GoogleCalendarEventResult("event-id", "https://meet.google.com/new-code", "new-code")
+
+        val response =
+            updateUseCase.execute(
+                lessonId = 1L,
+                request = ScheduleLessonRequest(name = "관리자 변경", scheduledAt = newScheduledAt),
+            )
+
+        assertAll(
+            { assertEquals("관리자 변경", lesson.name) },
+            { assertEquals(newScheduledAt, lesson.scheduledAt) },
+            { assertEquals("event-id", lesson.googleMeet?.calendarEventId) },
+            { assertEquals("https://meet.google.com/new-code", response.googleMeetJoinUrl) },
+            { assertEquals("new-code", response.googleMeetCode) },
+            { assertEquals(fixedNow, account.lastUsedAt) },
+            { assertEquals(newScheduledAt.atZone(zoneId), commandSlot.captured.startAt) },
+        )
+    }
+
+    @Test
+    fun `관리자가 수업 스케줄을 삭제하면 Calendar event를 취소하고 lesson 일정을 제거한다`() {
+        val lesson =
+            lesson(
+                scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
+                googleMeet = LessonGoogleMeet("event-id", "https://meet.google.com/abc-defg-hij", "abc-defg-hij"),
+            )
+        val account = centralGoogleAccount()
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every { calendarClientProvider.getIfAvailable() } returns calendarClient
+        every { centralGoogleAccountAdaptor.findGoogle() } returns account
+        every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every {
+            calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "event-id",
+                sendUpdates = true,
+            )
+        } just Runs
+
+        val response = deleteUseCase.execute(1L)
+
+        assertAll(
+            { assertNull(lesson.scheduledAt) },
+            { assertNull(lesson.googleMeet) },
+            { assertNull(response.scheduledAt) },
+            { assertNull(response.googleMeetJoinUrl) },
+            { assertEquals(fixedNow, account.lastUsedAt) },
+        )
+        verify {
+            calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "event-id",
+                sendUpdates = true,
+            )
+        }
+    }
+
+    private fun mockSchedulePreparation(
+        lesson: Lesson,
+        account: CentralGoogleAccount,
+        scheduledAt: LocalDateTime,
+    ) {
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every {
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = studentUserId,
+                teacherUserId = teacherUserId,
+                scheduledAt = scheduledAt,
+                requestedDurationMinutes = 60L,
+                excludeLessonId = 1L,
+            )
+        } returns false
+        every { calendarClientProvider.getIfAvailable() } returns calendarClient
+        every { centralGoogleAccountAdaptor.findGoogle() } returns account
+        every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every { userAdaptor.findById(teacherUserId) } returns user(teacherUserId, "teacher@example.com")
+        every { userAdaptor.findById(studentUserId) } returns user(studentUserId, "student@example.com")
+    }
+
+    private fun lesson(
+        scheduledAt: LocalDateTime? = null,
+        googleMeet: LessonGoogleMeet? = null,
+        status: LessonStatus = LessonStatus.SCHEDULED,
+    ) = Lesson(
+        id = 1L,
+        lessonType = LessonType.COURSE,
+        enrollmentId = 1L,
+        studentUserId = studentUserId,
+        assignedTeacherUserId = teacherUserId,
+        lessonNumber = 1,
+        name = "수학 1회차",
+        scheduledAt = scheduledAt,
+        status = status,
+        googleMeet = googleMeet,
+    )
+
+    private fun user(
+        id: String,
+        email: String,
+    ) = User(
+        id = id,
+        email = email,
+        name = "user",
+        authProvider = AuthProvider.EMAIL,
+    )
+
+    private fun centralGoogleAccount() =
+        CentralGoogleAccount(
+            googleEmail = "central@example.com",
+            encryptedRefreshToken = "encrypted-refresh-token",
+            scope = "openid https://www.googleapis.com/auth/calendar.events",
+            connectedByAdminUserId = "admin-user-id-000000000001",
+            connectedAt = fixedNow.minusDays(1),
+        )
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/controller/LessonController.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/controller/LessonController.kt
@@ -18,6 +18,7 @@ import com.sclass.supporters.lesson.dto.UpdateLessonRequest
 import com.sclass.supporters.lesson.usecase.CompleteLessonUseCase
 import com.sclass.supporters.lesson.usecase.CreateLessonInquiryPlanUseCase
 import com.sclass.supporters.lesson.usecase.CreateLessonScheduleUseCase
+import com.sclass.supporters.lesson.usecase.DeleteLessonScheduleUseCase
 import com.sclass.supporters.lesson.usecase.GetLessonDetailUseCase
 import com.sclass.supporters.lesson.usecase.GetLessonReportUseCase
 import com.sclass.supporters.lesson.usecase.GetMySubstituteLessonsUseCase
@@ -28,6 +29,7 @@ import com.sclass.supporters.lesson.usecase.UpdateLessonReportUseCase
 import com.sclass.supporters.lesson.usecase.UpdateLessonScheduleUseCase
 import com.sclass.supporters.lesson.usecase.UpdateLessonUseCase
 import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -53,6 +55,7 @@ class LessonController(
     private val recordLessonUseCase: RecordLessonUseCase,
     private val createLessonScheduleUseCase: CreateLessonScheduleUseCase,
     private val updateLessonScheduleUseCase: UpdateLessonScheduleUseCase,
+    private val deleteLessonScheduleUseCase: DeleteLessonScheduleUseCase,
 ) {
     @GetMapping("/my/substitutes")
     fun mySubstituteLessons(
@@ -148,6 +151,18 @@ class LessonController(
                 userId,
                 lessonId,
                 request,
+            ),
+        )
+
+    @DeleteMapping("/{lessonId}/schedule")
+    fun deleteSchedule(
+        @CurrentUserId userId: String,
+        @PathVariable lessonId: Long,
+    ): ApiResponse<LessonResponse> =
+        ApiResponse.success(
+            deleteLessonScheduleUseCase.execute(
+                userId,
+                lessonId,
             ),
         )
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -107,7 +107,7 @@ class CreateLessonScheduleUseCase(
         result: GoogleCalendarEventResult,
     ): LessonResponse =
         txTemplate.execute {
-            val lesson = lessonAdaptor.findById(lessonId)
+            val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
             if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
             if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
             lesson.validateScheduleUpdatable()
@@ -119,9 +119,11 @@ class CreateLessonScheduleUseCase(
                 meetJoinUrl = result.meetJoinUrl,
                 meetCode = result.meetCode,
             )
+            lessonAdaptor.save(lesson)
 
             val centralAccount = centralGoogleAccountAdaptor.findGoogle()
             centralAccount.markUsed(LocalDateTime.now(clock))
+            centralGoogleAccountAdaptor.save(centralAccount)
             LessonResponse.from(lesson)
         }!!
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -99,6 +99,15 @@ class CreateLessonScheduleUseCase(
         }
     }
 
+    private fun lockScheduleParticipants(lesson: Lesson) {
+        userAdaptor.lockByIdsForUpdate(
+            listOf(
+                lesson.studentUserId,
+                lesson.effectiveTeacherUserId,
+            ),
+        )
+    }
+
     private fun saveSchedule(
         userId: String,
         lessonId: Long,
@@ -111,6 +120,7 @@ class CreateLessonScheduleUseCase(
             if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
             if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
             lesson.validateScheduleUpdatable()
+            lockScheduleParticipants(lesson)
             validateNoScheduleConflict(lesson, scheduledAt)
 
             lesson.updateSchedule(request.name, scheduledAt)

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCase.kt
@@ -47,7 +47,7 @@ class CreateLessonScheduleUseCase(
             )
 
         return try {
-            saveSchedule(userId, lessonId, request, prepared.scheduledAt, result)
+            saveSchedule(userId, lessonId, request, prepared, result)
         } catch (e: RuntimeException) {
             deleteCreatedCalendarEvent(prepared, result.eventId)
             throw e
@@ -79,6 +79,8 @@ class CreateLessonScheduleUseCase(
                 command = lesson.toGoogleCalendarCommand(request.name, scheduledAt),
                 calendarClient = calendarClient,
                 refreshToken = refreshToken,
+                studentUserId = lesson.studentUserId,
+                teacherUserId = lesson.effectiveTeacherUserId,
             )
         }!!
 
@@ -112,7 +114,7 @@ class CreateLessonScheduleUseCase(
         userId: String,
         lessonId: Long,
         request: ScheduleLessonRequest,
-        scheduledAt: LocalDateTime,
+        prepared: PreparedCreateSchedule,
         result: GoogleCalendarEventResult,
     ): LessonResponse =
         txTemplate.execute {
@@ -120,10 +122,11 @@ class CreateLessonScheduleUseCase(
             if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
             if (lesson.scheduledAt != null) throw LessonScheduleAlreadyExistsException()
             lesson.validateScheduleUpdatable()
+            lesson.validateParticipantSnapshot(prepared.studentUserId, prepared.teacherUserId)
             lockScheduleParticipants(lesson)
-            validateNoScheduleConflict(lesson, scheduledAt)
+            validateNoScheduleConflict(lesson, prepared.scheduledAt)
 
-            lesson.updateSchedule(request.name, scheduledAt)
+            lesson.updateSchedule(request.name, prepared.scheduledAt)
             lesson.attachGoogleMeet(
                 eventId = result.eventId,
                 meetJoinUrl = result.meetJoinUrl,
@@ -136,6 +139,15 @@ class CreateLessonScheduleUseCase(
             centralGoogleAccountAdaptor.save(centralAccount)
             LessonResponse.from(lesson)
         }!!
+
+    private fun Lesson.validateParticipantSnapshot(
+        studentUserId: String,
+        teacherUserId: String,
+    ) {
+        if (this.studentUserId != studentUserId || effectiveTeacherUserId != teacherUserId) {
+            throw LessonScheduleConflictException()
+        }
+    }
 
     private fun deleteCreatedCalendarEvent(
         prepared: PreparedCreateSchedule,
@@ -171,6 +183,8 @@ class CreateLessonScheduleUseCase(
         val command: GoogleCalendarEventCreateCommand,
         val calendarClient: CentralGoogleCalendarClient,
         val refreshToken: String,
+        val studentUserId: String,
+        val teacherUserId: String,
     )
 
     private companion object {

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCase.kt
@@ -4,11 +4,13 @@ import com.sclass.common.annotation.UseCase
 import com.sclass.common.exception.GoogleCalendarCentralDisabledException
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.LessonGoogleMeet
 import com.sclass.domain.domains.lesson.exception.LessonScheduleNotFoundException
 import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
 import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
 import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
 import com.sclass.supporters.lesson.dto.LessonResponse
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.Clock
@@ -23,10 +25,21 @@ class DeleteLessonScheduleUseCase(
     private val txTemplate: TransactionTemplate,
     private val clock: Clock = Clock.systemDefaultZone(),
 ) {
+    private val log = LoggerFactory.getLogger(DeleteLessonScheduleUseCase::class.java)
+
     fun execute(
         userId: String,
         lessonId: Long,
-    ): LessonResponse =
+    ): LessonResponse {
+        val deleted = deleteSchedule(userId, lessonId)
+        deleted.calendarEvent?.let { deleteCalendarEvent(lessonId, it) }
+        return deleted.response
+    }
+
+    private fun deleteSchedule(
+        userId: String,
+        lessonId: Long,
+    ): DeletedSchedule =
         txTemplate.execute {
             val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
             if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
@@ -34,7 +47,7 @@ class DeleteLessonScheduleUseCase(
             lesson.validateScheduleUpdatable()
 
             val eventId = lesson.googleMeet?.calendarEventId?.takeIf { it.isNotBlank() }
-            val centralAccount =
+            val calendarEvent =
                 eventId?.let {
                     val calendarClient =
                         centralGoogleCalendarClientProvider.getIfAvailable()
@@ -42,22 +55,85 @@ class DeleteLessonScheduleUseCase(
                     val account = centralGoogleAccountAdaptor.findGoogle()
                     val refreshToken = aesTokenEncryptor.decrypt(account.encryptedRefreshToken)
 
-                    calendarClient.deleteMeetEventWithRefreshToken(
-                        refreshToken = refreshToken,
+                    CalendarEventDelete(
                         eventId = it,
-                        sendUpdates = true,
+                        calendarClient = calendarClient,
+                        refreshToken = refreshToken,
+                        scheduledAt = lesson.scheduledAt!!,
+                        googleMeet = lesson.googleMeet!!,
                     )
-                    account
                 }
 
             lesson.deleteSchedule()
             lessonAdaptor.save(lesson)
 
-            centralAccount?.let {
-                it.markUsed(LocalDateTime.now(clock))
-                centralGoogleAccountAdaptor.save(it)
-            }
-
-            LessonResponse.from(lesson)
+            DeletedSchedule(
+                response = LessonResponse.from(lesson),
+                calendarEvent = calendarEvent,
+            )
         }!!
+
+    private fun deleteCalendarEvent(
+        lessonId: Long,
+        calendarEvent: CalendarEventDelete,
+    ) {
+        try {
+            calendarEvent.calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = calendarEvent.refreshToken,
+                eventId = calendarEvent.eventId,
+                sendUpdates = true,
+            )
+            markCalendarUsed()
+        } catch (e: RuntimeException) {
+            restoreSchedule(lessonId, calendarEvent)
+            throw e
+        }
+    }
+
+    private fun markCalendarUsed() {
+        runCatching {
+            txTemplate.execute {
+                val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+                centralAccount.markUsed(LocalDateTime.now(clock))
+                centralGoogleAccountAdaptor.save(centralAccount)
+            }
+        }.onFailure {
+            log.warn("Failed to mark central Google account as used after lesson schedule delete", it)
+        }
+    }
+
+    private fun restoreSchedule(
+        lessonId: Long,
+        calendarEvent: CalendarEventDelete,
+    ) {
+        runCatching {
+            txTemplate.execute {
+                val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
+                if (lesson.scheduledAt == null && lesson.googleMeet == null) {
+                    lesson.updateSchedule(null, calendarEvent.scheduledAt)
+                    lesson.attachGoogleMeet(
+                        eventId = calendarEvent.googleMeet.calendarEventId,
+                        meetJoinUrl = calendarEvent.googleMeet.joinUrl,
+                        meetCode = calendarEvent.googleMeet.code,
+                    )
+                    lessonAdaptor.save(lesson)
+                }
+            }
+        }.onFailure {
+            log.warn("Failed to restore lesson schedule after Google Calendar event delete failed: lessonId={}", lessonId, it)
+        }
+    }
+
+    private data class DeletedSchedule(
+        val response: LessonResponse,
+        val calendarEvent: CalendarEventDelete? = null,
+    )
+
+    private data class CalendarEventDelete(
+        val eventId: String,
+        val calendarClient: CentralGoogleCalendarClient,
+        val refreshToken: String,
+        val scheduledAt: LocalDateTime,
+        val googleMeet: LessonGoogleMeet,
+    )
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCase.kt
@@ -26,72 +26,38 @@ class DeleteLessonScheduleUseCase(
     fun execute(
         userId: String,
         lessonId: Long,
-    ): LessonResponse {
-        val prepared = prepareScheduleDelete(userId, lessonId)
-
-        prepared.calendarEvent?.let {
-            it.calendarClient.deleteMeetEventWithRefreshToken(
-                refreshToken = it.refreshToken,
-                eventId = it.eventId,
-                sendUpdates = true,
-            )
-        }
-
-        return deleteSchedule(userId, lessonId, prepared.calendarEvent != null)
-    }
-
-    private fun prepareScheduleDelete(
-        userId: String,
-        lessonId: Long,
-    ): PreparedDeleteSchedule =
+    ): LessonResponse =
         txTemplate.execute {
-            val lesson = lessonAdaptor.findById(lessonId)
+            val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
             if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
             if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
             lesson.validateScheduleUpdatable()
 
             val eventId = lesson.googleMeet?.calendarEventId?.takeIf { it.isNotBlank() }
-            if (eventId == null) {
-                PreparedDeleteSchedule()
-            } else {
-                val calendarClient =
-                    centralGoogleCalendarClientProvider.getIfAvailable()
-                        ?: throw GoogleCalendarCentralDisabledException()
-                val centralAccount = centralGoogleAccountAdaptor.findGoogle()
-                val refreshToken = aesTokenEncryptor.decrypt(centralAccount.encryptedRefreshToken)
+            val centralAccount =
+                eventId?.let {
+                    val calendarClient =
+                        centralGoogleCalendarClientProvider.getIfAvailable()
+                            ?: throw GoogleCalendarCentralDisabledException()
+                    val account = centralGoogleAccountAdaptor.findGoogle()
+                    val refreshToken = aesTokenEncryptor.decrypt(account.encryptedRefreshToken)
 
-                PreparedDeleteSchedule(CalendarEventDelete(eventId, calendarClient, refreshToken))
-            }
-        }!!
-
-    private fun deleteSchedule(
-        userId: String,
-        lessonId: Long,
-        calendarEventDeleted: Boolean,
-    ): LessonResponse =
-        txTemplate.execute {
-            val lesson = lessonAdaptor.findById(lessonId)
-            if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
-            if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
-            lesson.validateScheduleUpdatable()
+                    calendarClient.deleteMeetEventWithRefreshToken(
+                        refreshToken = refreshToken,
+                        eventId = it,
+                        sendUpdates = true,
+                    )
+                    account
+                }
 
             lesson.deleteSchedule()
+            lessonAdaptor.save(lesson)
 
-            if (calendarEventDeleted) {
-                val centralAccount = centralGoogleAccountAdaptor.findGoogle()
-                centralAccount.markUsed(LocalDateTime.now(clock))
+            centralAccount?.let {
+                it.markUsed(LocalDateTime.now(clock))
+                centralGoogleAccountAdaptor.save(it)
             }
 
             LessonResponse.from(lesson)
         }!!
-
-    private data class PreparedDeleteSchedule(
-        val calendarEvent: CalendarEventDelete? = null,
-    )
-
-    private data class CalendarEventDelete(
-        val eventId: String,
-        val calendarClient: CentralGoogleCalendarClient,
-        val refreshToken: String,
-    )
 }

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCase.kt
@@ -4,10 +4,13 @@ import com.sclass.common.annotation.UseCase
 import com.sclass.common.exception.GoogleCalendarCentralDisabledException
 import com.sclass.common.jwt.AesTokenEncryptor
 import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.lesson.domain.LessonGoogleMeet
+import com.sclass.domain.domains.lesson.exception.LessonScheduleConflictException
 import com.sclass.domain.domains.lesson.exception.LessonScheduleNotFoundException
 import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
 import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.user.adaptor.UserAdaptor
 import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
 import com.sclass.supporters.lesson.dto.LessonResponse
 import org.slf4j.LoggerFactory
@@ -20,6 +23,7 @@ import java.time.LocalDateTime
 class DeleteLessonScheduleUseCase(
     private val lessonAdaptor: LessonAdaptor,
     private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val userAdaptor: UserAdaptor,
     private val aesTokenEncryptor: AesTokenEncryptor,
     private val centralGoogleCalendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>,
     private val txTemplate: TransactionTemplate,
@@ -110,6 +114,9 @@ class DeleteLessonScheduleUseCase(
             txTemplate.execute {
                 val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
                 if (lesson.scheduledAt == null && lesson.googleMeet == null) {
+                    lockScheduleParticipants(lesson)
+                    validateNoScheduleConflict(lesson, calendarEvent.scheduledAt)
+
                     lesson.updateSchedule(null, calendarEvent.scheduledAt)
                     lesson.attachGoogleMeet(
                         eventId = calendarEvent.googleMeet.calendarEventId,
@@ -121,6 +128,32 @@ class DeleteLessonScheduleUseCase(
             }
         }.onFailure {
             log.warn("Failed to restore lesson schedule after Google Calendar event delete failed: lessonId={}", lessonId, it)
+        }
+    }
+
+    private fun lockScheduleParticipants(lesson: Lesson) {
+        userAdaptor.lockByIdsForUpdate(
+            listOf(
+                lesson.studentUserId,
+                lesson.effectiveTeacherUserId,
+            ),
+        )
+    }
+
+    private fun validateNoScheduleConflict(
+        lesson: Lesson,
+        scheduledAt: LocalDateTime,
+    ) {
+        if (
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = lesson.studentUserId,
+                teacherUserId = lesson.effectiveTeacherUserId,
+                scheduledAt = scheduledAt,
+                requestedDurationMinutes = Lesson.DEFAULT_DURATION_MINUTES,
+                excludeLessonId = lesson.id,
+            )
+        ) {
+            throw LessonScheduleConflictException()
         }
     }
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCase.kt
@@ -1,0 +1,97 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.common.annotation.UseCase
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.exception.LessonScheduleNotFoundException
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
+import com.sclass.supporters.lesson.dto.LessonResponse
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
+import java.time.LocalDateTime
+
+@UseCase
+class DeleteLessonScheduleUseCase(
+    private val lessonAdaptor: LessonAdaptor,
+    private val centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor,
+    private val aesTokenEncryptor: AesTokenEncryptor,
+    private val centralGoogleCalendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>,
+    private val txTemplate: TransactionTemplate,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    fun execute(
+        userId: String,
+        lessonId: Long,
+    ): LessonResponse {
+        val prepared = prepareScheduleDelete(userId, lessonId)
+
+        prepared.calendarEvent?.let {
+            it.calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = it.refreshToken,
+                eventId = it.eventId,
+                sendUpdates = true,
+            )
+        }
+
+        return deleteSchedule(userId, lessonId, prepared.calendarEvent != null)
+    }
+
+    private fun prepareScheduleDelete(
+        userId: String,
+        lessonId: Long,
+    ): PreparedDeleteSchedule =
+        txTemplate.execute {
+            val lesson = lessonAdaptor.findById(lessonId)
+            if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
+            if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
+            lesson.validateScheduleUpdatable()
+
+            val eventId = lesson.googleMeet?.calendarEventId?.takeIf { it.isNotBlank() }
+            if (eventId == null) {
+                PreparedDeleteSchedule()
+            } else {
+                val calendarClient =
+                    centralGoogleCalendarClientProvider.getIfAvailable()
+                        ?: throw GoogleCalendarCentralDisabledException()
+                val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+                val refreshToken = aesTokenEncryptor.decrypt(centralAccount.encryptedRefreshToken)
+
+                PreparedDeleteSchedule(CalendarEventDelete(eventId, calendarClient, refreshToken))
+            }
+        }!!
+
+    private fun deleteSchedule(
+        userId: String,
+        lessonId: Long,
+        calendarEventDeleted: Boolean,
+    ): LessonResponse =
+        txTemplate.execute {
+            val lesson = lessonAdaptor.findById(lessonId)
+            if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
+            if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
+            lesson.validateScheduleUpdatable()
+
+            lesson.deleteSchedule()
+
+            if (calendarEventDeleted) {
+                val centralAccount = centralGoogleAccountAdaptor.findGoogle()
+                centralAccount.markUsed(LocalDateTime.now(clock))
+            }
+
+            LessonResponse.from(lesson)
+        }!!
+
+    private data class PreparedDeleteSchedule(
+        val calendarEvent: CalendarEventDelete? = null,
+    )
+
+    private data class CalendarEventDelete(
+        val eventId: String,
+        val calendarClient: CentralGoogleCalendarClient,
+        val refreshToken: String,
+    )
+}

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -55,7 +55,7 @@ class UpdateLessonScheduleUseCase(
             }
 
         return try {
-            saveSchedule(userId, lessonId, request, prepared.scheduledAt, result)
+            saveSchedule(userId, lessonId, request, prepared, result)
         } catch (e: RuntimeException) {
             rollbackCalendarEvent(prepared, result)
             throw e
@@ -92,6 +92,8 @@ class UpdateLessonScheduleUseCase(
                 calendarClient = calendarClient,
                 refreshToken = refreshToken,
                 eventId = lesson.googleMeet?.calendarEventId,
+                studentUserId = lesson.studentUserId,
+                teacherUserId = lesson.effectiveTeacherUserId,
             )
         }!!
 
@@ -125,7 +127,7 @@ class UpdateLessonScheduleUseCase(
         userId: String,
         lessonId: Long,
         request: ScheduleLessonRequest,
-        scheduledAt: LocalDateTime,
+        prepared: PreparedUpdateSchedule,
         result: GoogleCalendarEventResult,
     ): LessonResponse =
         txTemplate.execute {
@@ -133,10 +135,11 @@ class UpdateLessonScheduleUseCase(
             if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
             if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
             lesson.validateScheduleUpdatable()
+            lesson.validateParticipantSnapshot(prepared.studentUserId, prepared.teacherUserId)
             lockScheduleParticipants(lesson)
-            validateNoScheduleConflict(lesson, scheduledAt)
+            validateNoScheduleConflict(lesson, prepared.scheduledAt)
 
-            lesson.updateSchedule(request.name, scheduledAt)
+            lesson.updateSchedule(request.name, prepared.scheduledAt)
             lesson.attachGoogleMeet(
                 eventId = result.eventId,
                 meetJoinUrl = result.meetJoinUrl,
@@ -149,6 +152,15 @@ class UpdateLessonScheduleUseCase(
             centralGoogleAccountAdaptor.save(centralAccount)
             LessonResponse.from(lesson)
         }!!
+
+    private fun Lesson.validateParticipantSnapshot(
+        studentUserId: String,
+        teacherUserId: String,
+    ) {
+        if (this.studentUserId != studentUserId || effectiveTeacherUserId != teacherUserId) {
+            throw LessonScheduleConflictException()
+        }
+    }
 
     private fun rollbackCalendarEvent(
         prepared: PreparedUpdateSchedule,
@@ -218,6 +230,8 @@ class UpdateLessonScheduleUseCase(
         val calendarClient: CentralGoogleCalendarClient,
         val refreshToken: String,
         val eventId: String?,
+        val studentUserId: String,
+        val teacherUserId: String,
     )
 
     private companion object {

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -120,7 +120,7 @@ class UpdateLessonScheduleUseCase(
         result: GoogleCalendarEventResult,
     ): LessonResponse =
         txTemplate.execute {
-            val lesson = lessonAdaptor.findById(lessonId)
+            val lesson = lessonAdaptor.findByIdForUpdate(lessonId)
             if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
             if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
             lesson.validateScheduleUpdatable()
@@ -132,9 +132,11 @@ class UpdateLessonScheduleUseCase(
                 meetJoinUrl = result.meetJoinUrl,
                 meetCode = result.meetCode,
             )
+            lessonAdaptor.save(lesson)
 
             val centralAccount = centralGoogleAccountAdaptor.findGoogle()
             centralAccount.markUsed(LocalDateTime.now(clock))
+            centralGoogleAccountAdaptor.save(centralAccount)
             LessonResponse.from(lesson)
         }!!
 

--- a/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
+++ b/SClass-Api-Supporters/src/main/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCase.kt
@@ -112,6 +112,15 @@ class UpdateLessonScheduleUseCase(
         }
     }
 
+    private fun lockScheduleParticipants(lesson: Lesson) {
+        userAdaptor.lockByIdsForUpdate(
+            listOf(
+                lesson.studentUserId,
+                lesson.effectiveTeacherUserId,
+            ),
+        )
+    }
+
     private fun saveSchedule(
         userId: String,
         lessonId: Long,
@@ -124,6 +133,7 @@ class UpdateLessonScheduleUseCase(
             if (!lesson.isTeacher(userId)) throw LessonUnauthorizedAccessException()
             if (lesson.scheduledAt == null) throw LessonScheduleNotFoundException()
             lesson.validateScheduleUpdatable()
+            lockScheduleParticipants(lesson)
             validateNoScheduleConflict(lesson, scheduledAt)
 
             lesson.updateSchedule(request.name, scheduledAt)

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
@@ -66,6 +66,7 @@ class CreateLessonScheduleUseCaseTest {
         every { txTemplate.execute(any<TransactionCallback<Any?>>()) } answers {
             firstArg<TransactionCallback<Any?>>().doInTransaction(mockk())
         }
+        every { userAdaptor.lockByIdsForUpdate(any()) } just Runs
         useCase =
             CreateLessonScheduleUseCase(
                 lessonAdaptor = lessonAdaptor,

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/CreateLessonScheduleUseCaseTest.kt
@@ -86,6 +86,7 @@ class CreateLessonScheduleUseCaseTest {
         val scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
 
         every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
         every {
             lessonAdaptor.existsScheduleConflict(
                 studentUserId = studentUserId,
@@ -100,6 +101,8 @@ class CreateLessonScheduleUseCaseTest {
         every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
         every { userAdaptor.findById(teacherUserId) } returns user(teacherUserId, "teacher@example.com")
         every { userAdaptor.findById(studentUserId) } returns user(studentUserId, "student@example.com")
+        every { lessonAdaptor.save(lesson) } returns lesson
+        every { centralGoogleAccountAdaptor.save(account) } returns account
         every {
             calendarClient.createMeetEventWithRefreshToken(
                 refreshToken = "refresh-token",
@@ -152,6 +155,7 @@ class CreateLessonScheduleUseCaseTest {
         val scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
 
         every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
         every {
             lessonAdaptor.existsScheduleConflict(
                 studentUserId = studentUserId,
@@ -181,6 +185,7 @@ class CreateLessonScheduleUseCaseTest {
         val scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
 
         every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
         every {
             lessonAdaptor.existsScheduleConflict(
                 studentUserId = studentUserId,

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCaseTest.kt
@@ -1,0 +1,227 @@
+package com.sclass.supporters.lesson.usecase
+
+import com.sclass.common.exception.GoogleCalendarCentralDisabledException
+import com.sclass.common.jwt.AesTokenEncryptor
+import com.sclass.domain.domains.lesson.adaptor.LessonAdaptor
+import com.sclass.domain.domains.lesson.domain.Lesson
+import com.sclass.domain.domains.lesson.domain.LessonGoogleMeet
+import com.sclass.domain.domains.lesson.domain.LessonStatus
+import com.sclass.domain.domains.lesson.domain.LessonType
+import com.sclass.domain.domains.lesson.exception.LessonInvalidStatusTransitionException
+import com.sclass.domain.domains.lesson.exception.LessonScheduleNotFoundException
+import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
+import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
+import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class DeleteLessonScheduleUseCaseTest {
+    private lateinit var lessonAdaptor: LessonAdaptor
+    private lateinit var centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor
+    private lateinit var aesTokenEncryptor: AesTokenEncryptor
+    private lateinit var calendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>
+    private lateinit var calendarClient: CentralGoogleCalendarClient
+    private lateinit var txTemplate: TransactionTemplate
+    private lateinit var useCase: DeleteLessonScheduleUseCase
+
+    private val studentUserId = "student-user-id-0000000001"
+    private val teacherUserId = "teacher-user-id-0000000001"
+    private val fixedNow = LocalDateTime.of(2026, 4, 26, 12, 30)
+    private val zoneId = ZoneId.of("Asia/Seoul")
+    private val clock = Clock.fixed(fixedNow.atZone(zoneId).toInstant(), zoneId)
+
+    @BeforeEach
+    fun setUp() {
+        lessonAdaptor = mockk()
+        centralGoogleAccountAdaptor = mockk()
+        aesTokenEncryptor = mockk()
+        calendarClientProvider = mockk()
+        calendarClient = mockk()
+        txTemplate = mockk()
+        every { txTemplate.execute(any<TransactionCallback<Any?>>()) } answers {
+            firstArg<TransactionCallback<Any?>>().doInTransaction(mockk())
+        }
+        useCase =
+            DeleteLessonScheduleUseCase(
+                lessonAdaptor = lessonAdaptor,
+                centralGoogleAccountAdaptor = centralGoogleAccountAdaptor,
+                aesTokenEncryptor = aesTokenEncryptor,
+                centralGoogleCalendarClientProvider = calendarClientProvider,
+                txTemplate = txTemplate,
+                clock = clock,
+            )
+    }
+
+    @Test
+    fun `Google Meet 일정이 있는 수업 스케줄을 삭제하면 Calendar event를 취소하고 lesson 일정을 제거한다`() {
+        val scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
+        val lesson =
+            lesson(
+                scheduledAt = scheduledAt,
+                googleMeet = LessonGoogleMeet("event-id", "https://meet.google.com/abc-defg-hij", "abc-defg-hij"),
+            )
+        val account = centralGoogleAccount()
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every { calendarClientProvider.getIfAvailable() } returns calendarClient
+        every { centralGoogleAccountAdaptor.findGoogle() } returns account
+        every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every {
+            calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "event-id",
+                sendUpdates = true,
+            )
+        } just Runs
+
+        val response =
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+            )
+
+        assertAll(
+            { assertNull(lesson.scheduledAt) },
+            { assertNull(lesson.googleMeet) },
+            { assertNull(response.scheduledAt) },
+            { assertNull(response.googleMeetJoinUrl) },
+            { assertNull(response.googleMeetCode) },
+            { assertEquals(fixedNow, account.lastUsedAt) },
+        )
+        verify {
+            calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "event-id",
+                sendUpdates = true,
+            )
+        }
+        verify(exactly = 2) { txTemplate.execute(any<TransactionCallback<Any?>>()) }
+    }
+
+    @Test
+    fun `기존 일정은 있지만 Google Meet이 없으면 Calendar 호출 없이 lesson 일정만 제거한다`() {
+        val lesson = lesson(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0))
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+
+        val response =
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+            )
+
+        assertAll(
+            { assertNull(lesson.scheduledAt) },
+            { assertNull(lesson.googleMeet) },
+            { assertNull(response.scheduledAt) },
+        )
+        verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
+    fun `일정이 없는 수업은 스케줄 삭제 불가`() {
+        every { lessonAdaptor.findById(1L) } returns lesson(scheduledAt = null)
+
+        assertThrows<LessonScheduleNotFoundException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+            )
+        }
+
+        verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
+    fun `예정 상태가 아닌 수업은 Calendar 호출 전에 스케줄 삭제 불가`() {
+        every {
+            lessonAdaptor.findById(1L)
+        } returns lesson(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0), status = LessonStatus.IN_PROGRESS)
+
+        assertThrows<LessonInvalidStatusTransitionException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+            )
+        }
+
+        verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
+    fun `담당 선생님이 아니면 스케줄 삭제 불가`() {
+        every { lessonAdaptor.findById(1L) } returns lesson(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0))
+
+        assertThrows<LessonUnauthorizedAccessException> {
+            useCase.execute(
+                userId = "other-teacher-id-000000001",
+                lessonId = 1L,
+            )
+        }
+
+        verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+    }
+
+    @Test
+    fun `Google Meet 일정이 있는데 중앙 Calendar client가 없으면 예외`() {
+        val lesson =
+            lesson(
+                scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0),
+                googleMeet = LessonGoogleMeet("event-id", "https://meet.google.com/abc-defg-hij", "abc-defg-hij"),
+            )
+
+        every { lessonAdaptor.findById(1L) } returns lesson
+        every { calendarClientProvider.getIfAvailable() } returns null
+
+        assertThrows<GoogleCalendarCentralDisabledException> {
+            useCase.execute(
+                userId = teacherUserId,
+                lessonId = 1L,
+            )
+        }
+
+        assertEquals(LocalDateTime.of(2026, 5, 1, 20, 0), lesson.scheduledAt)
+    }
+
+    private fun lesson(
+        scheduledAt: LocalDateTime?,
+        googleMeet: LessonGoogleMeet? = null,
+        status: LessonStatus = LessonStatus.SCHEDULED,
+    ) = Lesson(
+        id = 1L,
+        lessonType = LessonType.COURSE,
+        enrollmentId = 1L,
+        studentUserId = studentUserId,
+        assignedTeacherUserId = teacherUserId,
+        lessonNumber = 1,
+        name = "수학 1회차",
+        scheduledAt = scheduledAt,
+        status = status,
+        googleMeet = googleMeet,
+    )
+
+    private fun centralGoogleAccount() =
+        CentralGoogleAccount(
+            googleEmail = "central@example.com",
+            encryptedRefreshToken = "encrypted-refresh-token",
+            scope = "openid https://www.googleapis.com/auth/calendar.events",
+            connectedByAdminUserId = "admin-user-id-000000000001",
+            connectedAt = fixedNow.minusDays(1),
+        )
+}

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCaseTest.kt
@@ -115,7 +115,51 @@ class DeleteLessonScheduleUseCaseTest {
         }
         verify(exactly = 1) { lessonAdaptor.save(lesson) }
         verify(exactly = 1) { centralGoogleAccountAdaptor.save(account) }
-        verify(exactly = 1) { txTemplate.execute(any<TransactionCallback<Any?>>()) }
+        verify(exactly = 2) { txTemplate.execute(any<TransactionCallback<Any?>>()) }
+    }
+
+    @Test
+    fun `Google Meet 일정 취소에 실패하면 삭제한 lesson 일정을 복구한다`() {
+        val scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0)
+        val googleMeet = LessonGoogleMeet("event-id", "https://meet.google.com/abc-defg-hij", "abc-defg-hij")
+        val lesson =
+            lesson(
+                scheduledAt = scheduledAt,
+                googleMeet = googleMeet,
+            )
+        val account = centralGoogleAccount()
+        val calendarException = RuntimeException("calendar delete failed")
+
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
+        every { calendarClientProvider.getIfAvailable() } returns calendarClient
+        every { centralGoogleAccountAdaptor.findGoogle() } returns account
+        every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every { lessonAdaptor.save(lesson) } returns lesson
+        every {
+            calendarClient.deleteMeetEventWithRefreshToken(
+                refreshToken = "refresh-token",
+                eventId = "event-id",
+                sendUpdates = true,
+            )
+        } throws calendarException
+
+        val thrown =
+            assertThrows<RuntimeException> {
+                useCase.execute(
+                    userId = teacherUserId,
+                    lessonId = 1L,
+                )
+            }
+
+        assertAll(
+            { assertEquals(calendarException, thrown) },
+            { assertEquals(scheduledAt, lesson.scheduledAt) },
+            { assertEquals("event-id", lesson.googleMeet?.calendarEventId) },
+            { assertEquals("https://meet.google.com/abc-defg-hij", lesson.googleMeet?.joinUrl) },
+            { assertEquals("abc-defg-hij", lesson.googleMeet?.code) },
+        )
+        verify(exactly = 2) { lessonAdaptor.save(lesson) }
+        verify(exactly = 0) { centralGoogleAccountAdaptor.save(account) }
     }
 
     @Test

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCaseTest.kt
@@ -12,6 +12,7 @@ import com.sclass.domain.domains.lesson.exception.LessonScheduleNotFoundExceptio
 import com.sclass.domain.domains.lesson.exception.LessonUnauthorizedAccessException
 import com.sclass.domain.domains.oauth.adaptor.CentralGoogleAccountAdaptor
 import com.sclass.domain.domains.oauth.domain.CentralGoogleAccount
+import com.sclass.domain.domains.user.adaptor.UserAdaptor
 import com.sclass.infrastructure.calendar.CentralGoogleCalendarClient
 import io.mockk.Runs
 import io.mockk.every
@@ -34,6 +35,7 @@ import java.time.ZoneId
 class DeleteLessonScheduleUseCaseTest {
     private lateinit var lessonAdaptor: LessonAdaptor
     private lateinit var centralGoogleAccountAdaptor: CentralGoogleAccountAdaptor
+    private lateinit var userAdaptor: UserAdaptor
     private lateinit var aesTokenEncryptor: AesTokenEncryptor
     private lateinit var calendarClientProvider: ObjectProvider<CentralGoogleCalendarClient>
     private lateinit var calendarClient: CentralGoogleCalendarClient
@@ -50,6 +52,7 @@ class DeleteLessonScheduleUseCaseTest {
     fun setUp() {
         lessonAdaptor = mockk()
         centralGoogleAccountAdaptor = mockk()
+        userAdaptor = mockk()
         aesTokenEncryptor = mockk()
         calendarClientProvider = mockk()
         calendarClient = mockk()
@@ -57,10 +60,12 @@ class DeleteLessonScheduleUseCaseTest {
         every { txTemplate.execute(any<TransactionCallback<Any?>>()) } answers {
             firstArg<TransactionCallback<Any?>>().doInTransaction(mockk())
         }
+        every { userAdaptor.lockByIdsForUpdate(any()) } just Runs
         useCase =
             DeleteLessonScheduleUseCase(
                 lessonAdaptor = lessonAdaptor,
                 centralGoogleAccountAdaptor = centralGoogleAccountAdaptor,
+                userAdaptor = userAdaptor,
                 aesTokenEncryptor = aesTokenEncryptor,
                 centralGoogleCalendarClientProvider = calendarClientProvider,
                 txTemplate = txTemplate,
@@ -135,6 +140,15 @@ class DeleteLessonScheduleUseCaseTest {
         every { centralGoogleAccountAdaptor.findGoogle() } returns account
         every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
         every { lessonAdaptor.save(lesson) } returns lesson
+        every {
+            lessonAdaptor.existsScheduleConflict(
+                studentUserId = studentUserId,
+                teacherUserId = teacherUserId,
+                scheduledAt = scheduledAt,
+                requestedDurationMinutes = 60L,
+                excludeLessonId = 1L,
+            )
+        } returns false
         every {
             calendarClient.deleteMeetEventWithRefreshToken(
                 refreshToken = "refresh-token",

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/DeleteLessonScheduleUseCaseTest.kt
@@ -78,10 +78,12 @@ class DeleteLessonScheduleUseCaseTest {
             )
         val account = centralGoogleAccount()
 
-        every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
         every { calendarClientProvider.getIfAvailable() } returns calendarClient
         every { centralGoogleAccountAdaptor.findGoogle() } returns account
         every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
+        every { lessonAdaptor.save(lesson) } returns lesson
+        every { centralGoogleAccountAdaptor.save(account) } returns account
         every {
             calendarClient.deleteMeetEventWithRefreshToken(
                 refreshToken = "refresh-token",
@@ -111,14 +113,17 @@ class DeleteLessonScheduleUseCaseTest {
                 sendUpdates = true,
             )
         }
-        verify(exactly = 2) { txTemplate.execute(any<TransactionCallback<Any?>>()) }
+        verify(exactly = 1) { lessonAdaptor.save(lesson) }
+        verify(exactly = 1) { centralGoogleAccountAdaptor.save(account) }
+        verify(exactly = 1) { txTemplate.execute(any<TransactionCallback<Any?>>()) }
     }
 
     @Test
     fun `기존 일정은 있지만 Google Meet이 없으면 Calendar 호출 없이 lesson 일정만 제거한다`() {
         val lesson = lesson(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0))
 
-        every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
+        every { lessonAdaptor.save(lesson) } returns lesson
 
         val response =
             useCase.execute(
@@ -132,11 +137,12 @@ class DeleteLessonScheduleUseCaseTest {
             { assertNull(response.scheduledAt) },
         )
         verify(exactly = 0) { calendarClientProvider.getIfAvailable() }
+        verify(exactly = 1) { lessonAdaptor.save(lesson) }
     }
 
     @Test
     fun `일정이 없는 수업은 스케줄 삭제 불가`() {
-        every { lessonAdaptor.findById(1L) } returns lesson(scheduledAt = null)
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson(scheduledAt = null)
 
         assertThrows<LessonScheduleNotFoundException> {
             useCase.execute(
@@ -151,7 +157,7 @@ class DeleteLessonScheduleUseCaseTest {
     @Test
     fun `예정 상태가 아닌 수업은 Calendar 호출 전에 스케줄 삭제 불가`() {
         every {
-            lessonAdaptor.findById(1L)
+            lessonAdaptor.findByIdForUpdate(1L)
         } returns lesson(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0), status = LessonStatus.IN_PROGRESS)
 
         assertThrows<LessonInvalidStatusTransitionException> {
@@ -166,7 +172,7 @@ class DeleteLessonScheduleUseCaseTest {
 
     @Test
     fun `담당 선생님이 아니면 스케줄 삭제 불가`() {
-        every { lessonAdaptor.findById(1L) } returns lesson(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0))
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson(scheduledAt = LocalDateTime.of(2026, 5, 1, 20, 0))
 
         assertThrows<LessonUnauthorizedAccessException> {
             useCase.execute(
@@ -186,7 +192,7 @@ class DeleteLessonScheduleUseCaseTest {
                 googleMeet = LessonGoogleMeet("event-id", "https://meet.google.com/abc-defg-hij", "abc-defg-hij"),
             )
 
-        every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
         every { calendarClientProvider.getIfAvailable() } returns null
 
         assertThrows<GoogleCalendarCentralDisabledException> {

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
@@ -89,6 +89,7 @@ class UpdateLessonScheduleUseCaseTest {
         val newScheduledAt = LocalDateTime.of(2026, 5, 2, 21, 0)
 
         every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
         every {
             lessonAdaptor.existsScheduleConflict(
                 studentUserId = studentUserId,
@@ -103,6 +104,8 @@ class UpdateLessonScheduleUseCaseTest {
         every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
         every { userAdaptor.findById(teacherUserId) } returns user(teacherUserId, "teacher@example.com")
         every { userAdaptor.findById(studentUserId) } returns user(studentUserId, "student@example.com")
+        every { lessonAdaptor.save(lesson) } returns lesson
+        every { centralGoogleAccountAdaptor.save(account) } returns account
         every {
             calendarClient.updateMeetEventWithRefreshToken(
                 refreshToken = "refresh-token",
@@ -141,6 +144,7 @@ class UpdateLessonScheduleUseCaseTest {
         val newScheduledAt = LocalDateTime.of(2026, 5, 2, 21, 0)
 
         every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
         every {
             lessonAdaptor.existsScheduleConflict(
                 studentUserId = studentUserId,
@@ -155,6 +159,8 @@ class UpdateLessonScheduleUseCaseTest {
         every { aesTokenEncryptor.decrypt("encrypted-refresh-token") } returns "refresh-token"
         every { userAdaptor.findById(teacherUserId) } returns user(teacherUserId, "teacher@example.com")
         every { userAdaptor.findById(studentUserId) } returns user(studentUserId, "student@example.com")
+        every { lessonAdaptor.save(lesson) } returns lesson
+        every { centralGoogleAccountAdaptor.save(account) } returns account
         every {
             calendarClient.createMeetEventWithRefreshToken(
                 refreshToken = "refresh-token",
@@ -184,6 +190,7 @@ class UpdateLessonScheduleUseCaseTest {
         val lesson = lesson(scheduledAt = originalScheduledAt)
 
         every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
         every {
             lessonAdaptor.existsScheduleConflict(
                 studentUserId = studentUserId,
@@ -222,6 +229,7 @@ class UpdateLessonScheduleUseCaseTest {
         val commandSlots = mutableListOf<GoogleCalendarEventCreateCommand>()
 
         every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
         every {
             lessonAdaptor.existsScheduleConflict(
                 studentUserId = studentUserId,
@@ -279,6 +287,7 @@ class UpdateLessonScheduleUseCaseTest {
         val account = centralGoogleAccount()
 
         every { lessonAdaptor.findById(1L) } returns lesson
+        every { lessonAdaptor.findByIdForUpdate(1L) } returns lesson
         every {
             lessonAdaptor.existsScheduleConflict(
                 studentUserId = studentUserId,

--- a/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
+++ b/SClass-Api-Supporters/src/test/kotlin/com/sclass/supporters/lesson/usecase/UpdateLessonScheduleUseCaseTest.kt
@@ -65,6 +65,7 @@ class UpdateLessonScheduleUseCaseTest {
         every { txTemplate.execute(any<TransactionCallback<Any?>>()) } answers {
             firstArg<TransactionCallback<Any?>>().doInTransaction(mockk())
         }
+        every { userAdaptor.lockByIdsForUpdate(any()) } just Runs
         useCase =
             UpdateLessonScheduleUseCase(
                 lessonAdaptor = lessonAdaptor,

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/adaptor/LessonAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/adaptor/LessonAdaptor.kt
@@ -18,6 +18,8 @@ class LessonAdaptor(
 
     fun findById(id: Long): Lesson = lessonRepository.findByIdOrNull(id) ?: throw LessonNotFoundException()
 
+    fun findByIdForUpdate(id: Long): Lesson = lessonRepository.findByIdForUpdate(id) ?: throw LessonNotFoundException()
+
     fun findByIdOrNull(id: Long): Lesson? = lessonRepository.findByIdOrNull(id)
 
     fun findAllByIds(ids: Collection<Long>): List<Lesson> = lessonRepository.findAllById(ids)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/domain/Lesson.kt
@@ -151,6 +151,12 @@ class Lesson(
         scheduledAt?.let { this.scheduledAt = it }
     }
 
+    fun deleteSchedule() {
+        validateScheduleUpdatable()
+        this.scheduledAt = null
+        this.googleMeet = null
+    }
+
     fun hasGoogleCalendarEvent(): Boolean = googleMeet?.calendarEventId?.isNotBlank() == true
 
     fun validateScheduleUpdatable() {

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepository.kt
@@ -4,6 +4,8 @@ import com.sclass.domain.domains.lesson.domain.Lesson
 import java.time.LocalDateTime
 
 interface LessonCustomRepository {
+    fun findByIdForUpdate(id: Long): Lesson?
+
     fun findAllByEffectiveTeacher(teacherUserId: String): List<Lesson>
 
     fun existsScheduleConflict(

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/lesson/repository/LessonCustomRepositoryImpl.kt
@@ -5,11 +5,19 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import com.sclass.domain.domains.lesson.domain.Lesson
 import com.sclass.domain.domains.lesson.domain.LessonStatus
 import com.sclass.domain.domains.lesson.domain.QLesson
+import jakarta.persistence.LockModeType
 import java.time.LocalDateTime
 
 class LessonCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : LessonCustomRepository {
+    override fun findByIdForUpdate(id: Long): Lesson? =
+        queryFactory
+            .selectFrom(QLesson.lesson)
+            .where(QLesson.lesson.id.eq(id))
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .fetchOne()
+
     override fun findAllByEffectiveTeacher(teacherUserId: String): List<Lesson> =
         queryFactory
             .selectFrom(QLesson.lesson)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/adaptor/UserAdaptor.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/adaptor/UserAdaptor.kt
@@ -12,6 +12,12 @@ class UserAdaptor(
 ) {
     fun findById(id: String): User = userRepository.findById(id).orElseThrow { UserNotFoundException() }
 
+    fun lockByIdsForUpdate(ids: Collection<String>) {
+        val distinctIds = ids.distinct()
+        val users = userRepository.findAllByIdsForUpdate(distinctIds)
+        if (users.size != distinctIds.size) throw UserNotFoundException()
+    }
+
     fun findByEmail(email: String): User = userRepository.findByEmail(email) ?: throw UserNotFoundException()
 
     fun findByEmailOrNull(email: String): User? = userRepository.findByEmail(email)

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/repository/UserCustomRepository.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/repository/UserCustomRepository.kt
@@ -4,4 +4,6 @@ import com.sclass.domain.domains.user.domain.User
 
 interface UserCustomRepository {
     fun findByEmailWithRoles(email: String): User?
+
+    fun findAllByIdsForUpdate(ids: Collection<String>): List<User>
 }

--- a/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/repository/UserCustomRepositoryImpl.kt
+++ b/SClass-Domain/src/main/kotlin/com/sclass/domain/domains/user/repository/UserCustomRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import com.sclass.domain.domains.user.domain.QUser.user
 import com.sclass.domain.domains.user.domain.QUserRole.userRole
 import com.sclass.domain.domains.user.domain.User
+import jakarta.persistence.LockModeType
 
 class UserCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
@@ -14,4 +15,12 @@ class UserCustomRepositoryImpl(
             .leftJoin(userRole)
             .on(user.id.eq(userRole.userId))
             .fetchOne()
+
+    override fun findAllByIdsForUpdate(ids: Collection<String>): List<User> =
+        queryFactory
+            .selectFrom(user)
+            .where(user.id.`in`(ids.distinct().sorted()))
+            .orderBy(user.id.asc())
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .fetch()
 }

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/CentralGoogleCalendarClient.kt
@@ -54,6 +54,7 @@ class CentralGoogleCalendarClient(
     fun deleteMeetEventWithRefreshToken(
         refreshToken: String,
         eventId: String,
+        sendUpdates: Boolean = false,
     ) {
         val accessToken = authorizationCodeClient.refreshAccessToken(refreshToken)
         try {
@@ -61,6 +62,7 @@ class CentralGoogleCalendarClient(
                 eventId = eventId,
                 accessToken = accessToken,
                 calendarId = properties.calendarId,
+                sendUpdates = sendUpdates,
             )
         } catch (e: WebClientResponseException) {
             if (e.isAuthorizationFailure()) throw GoogleCalendarUnauthorizedException()

--- a/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
+++ b/SClass-Infrastructure/src/main/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClient.kt
@@ -123,11 +123,12 @@ class GoogleCalendarClient(
         eventId: String,
         accessToken: String,
         calendarId: String = PRIMARY_CALENDAR_ID,
+        sendUpdates: Boolean = false,
     ) {
         try {
             webClient
                 .delete()
-                .uri(calendarEventUri(calendarId, eventId, sendUpdates = false))
+                .uri(calendarEventDeleteUri(calendarId, eventId, sendUpdates = sendUpdates))
                 .header("Authorization", "Bearer $accessToken")
                 .retrieve()
                 .toBodilessEntity()
@@ -255,6 +256,25 @@ class GoogleCalendarClient(
             )
         return "https://www.googleapis.com/calendar/v3/calendars/$encodedCalendarId/events/$encodedEventId" +
             "?conferenceDataVersion=1$sendUpdatesQuery"
+    }
+
+    private fun calendarEventDeleteUri(
+        calendarId: String,
+        eventId: String,
+        sendUpdates: Boolean,
+    ): String {
+        val sendUpdatesQuery = if (sendUpdates) "?sendUpdates=all" else ""
+        val encodedCalendarId =
+            URLEncoder.encode(
+                calendarId,
+                StandardCharsets.UTF_8,
+            )
+        val encodedEventId =
+            URLEncoder.encode(
+                eventId,
+                StandardCharsets.UTF_8,
+            )
+        return "https://www.googleapis.com/calendar/v3/calendars/$encodedCalendarId/events/$encodedEventId$sendUpdatesQuery"
     }
 
     private fun String.extractMeetCode(): String? =

--- a/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
+++ b/SClass-Infrastructure/src/test/kotlin/com/sclass/infrastructure/calendar/GoogleCalendarClientTest.kt
@@ -74,7 +74,7 @@ class GoogleCalendarClientTest {
         every { requestHeadersSpec.retrieve() } returns responseSpec
     }
 
-    private fun mockDeleteEventCall(uri: String = CALENDAR_EVENT_URI) {
+    private fun mockDeleteEventCall(uri: String = CALENDAR_EVENT_DELETE_URI) {
         every { webClient.delete() } returns requestHeadersUriSpec
         every { requestHeadersUriSpec.uri(uri) } returns deleteRequestHeadersSpec
         every { deleteRequestHeadersSpec.header(HttpHeaders.AUTHORIZATION, any()) } returns deleteRequestHeadersSpec
@@ -83,7 +83,7 @@ class GoogleCalendarClientTest {
 
     private fun mockUpdateEventCall(
         requestSlot: MutableList<GoogleCalendarEventUpdateRequest> = mutableListOf(),
-        uri: String = CALENDAR_EVENT_URI,
+        uri: String = CALENDAR_EVENT_UPDATE_URI,
     ) {
         every { webClient.patch() } returns requestBodyUriSpec
         every { requestBodyUriSpec.uri(uri) } returns requestBodySpec
@@ -218,7 +218,7 @@ class GoogleCalendarClientTest {
 
     @Test
     fun `event id와 calendar id는 update URL path에 안전하게 인코딩한다`() {
-        mockUpdateEventCall(uri = CALENDAR_EVENT_WITH_ENCODED_IDS_URI)
+        mockUpdateEventCall(uri = CALENDAR_EVENT_UPDATE_WITH_ENCODED_IDS_URI)
         every { responseSpec.bodyToMono(GoogleCalendarEventResponse::class.java) } returns
             Mono.just(calendarResponse(meetUri = "https://meet.google.com/updated-code"))
 
@@ -234,7 +234,7 @@ class GoogleCalendarClientTest {
             calendarId = "central@example.com",
         )
 
-        verify { requestBodyUriSpec.uri(CALENDAR_EVENT_WITH_ENCODED_IDS_URI) }
+        verify { requestBodyUriSpec.uri(CALENDAR_EVENT_UPDATE_WITH_ENCODED_IDS_URI) }
     }
 
     @Test
@@ -247,13 +247,13 @@ class GoogleCalendarClientTest {
             accessToken = "access-token",
         )
 
-        verify { requestHeadersUriSpec.uri(CALENDAR_EVENT_URI) }
+        verify { requestHeadersUriSpec.uri(CALENDAR_EVENT_DELETE_URI) }
         verify { deleteRequestHeadersSpec.header(HttpHeaders.AUTHORIZATION, "Bearer access-token") }
     }
 
     @Test
     fun `event id와 calendar id는 delete URL path에 안전하게 인코딩한다`() {
-        mockDeleteEventCall(uri = CALENDAR_EVENT_WITH_ENCODED_IDS_URI)
+        mockDeleteEventCall(uri = CALENDAR_EVENT_DELETE_WITH_ENCODED_IDS_URI)
         every { responseSpec.toBodilessEntity() } returns Mono.just(ResponseEntity.noContent().build())
 
         client.deleteMeetEventWithAccessToken(
@@ -262,7 +262,21 @@ class GoogleCalendarClientTest {
             calendarId = "central@example.com",
         )
 
-        verify { requestHeadersUriSpec.uri(CALENDAR_EVENT_WITH_ENCODED_IDS_URI) }
+        verify { requestHeadersUriSpec.uri(CALENDAR_EVENT_DELETE_WITH_ENCODED_IDS_URI) }
+    }
+
+    @Test
+    fun `Calendar event 삭제는 sendUpdates가 켜져 있으면 취소 알림을 전송한다`() {
+        mockDeleteEventCall(uri = CALENDAR_EVENT_DELETE_WITH_SEND_UPDATES_URI)
+        every { responseSpec.toBodilessEntity() } returns Mono.just(ResponseEntity.noContent().build())
+
+        client.deleteMeetEventWithAccessToken(
+            eventId = "event-id-1",
+            accessToken = "access-token",
+            sendUpdates = true,
+        )
+
+        verify { requestHeadersUriSpec.uri(CALENDAR_EVENT_DELETE_WITH_SEND_UPDATES_URI) }
     }
 
     @Test
@@ -439,11 +453,17 @@ class GoogleCalendarClientTest {
             "https://www.googleapis.com/calendar/v3/calendars/primary/events?conferenceDataVersion=1&sendUpdates=all"
         const val CALENDAR_EVENTS_WITH_ENCODED_CALENDAR_ID_URI =
             "https://www.googleapis.com/calendar/v3/calendars/central%40example.com/events?conferenceDataVersion=1"
-        const val CALENDAR_EVENT_URI =
+        const val CALENDAR_EVENT_UPDATE_URI =
             "https://www.googleapis.com/calendar/v3/calendars/primary/events/event-id-1?conferenceDataVersion=1"
         const val CALENDAR_EVENT_WITH_SEND_UPDATES_URI =
             "https://www.googleapis.com/calendar/v3/calendars/primary/events/event-id-1?conferenceDataVersion=1&sendUpdates=all"
-        const val CALENDAR_EVENT_WITH_ENCODED_IDS_URI =
+        const val CALENDAR_EVENT_UPDATE_WITH_ENCODED_IDS_URI =
             "https://www.googleapis.com/calendar/v3/calendars/central%40example.com/events/event%2Fid+with+space?conferenceDataVersion=1"
+        const val CALENDAR_EVENT_DELETE_URI =
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events/event-id-1"
+        const val CALENDAR_EVENT_DELETE_WITH_SEND_UPDATES_URI =
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events/event-id-1?sendUpdates=all"
+        const val CALENDAR_EVENT_DELETE_WITH_ENCODED_IDS_URI =
+            "https://www.googleapis.com/calendar/v3/calendars/central%40example.com/events/event%2Fid+with+space"
     }
 }


### PR DESCRIPTION
## 요약
- supporters에 `DELETE /api/v1/lessons/{lessonId}/schedule` API를 추가했습니다.
- backoffice에 관리자가 대신 lesson schedule을 생성/수정/삭제할 수 있는 API를 추가했습니다.
- Google Calendar event 삭제 시 `sendUpdates=all`을 지원해 취소 알림 메일이 나가도록 했습니다.

## API 변경
- Supporters
  - `DELETE /api/v1/lessons/{lessonId}/schedule`
- Backoffice
  - `POST /api/v1/lessons/{lessonId}/schedule`
  - `PUT /api/v1/lessons/{lessonId}/schedule`
  - `DELETE /api/v1/lessons/{lessonId}/schedule`

## 동작
- schedule 생성/수정/삭제는 `SCHEDULED` 상태에서만 가능합니다.
- 생성/수정 시 선생님/학생 attendee에 Google Calendar 초대/변경 알림이 발송됩니다.
- 삭제 시 Calendar event가 있으면 취소 알림이 발송되고, lesson의 `scheduledAt`과 Meet 정보가 제거됩니다.
- Google Meet이 없는 기존 schedule도 삭제할 수 있습니다.

## 검증
- pre-commit hook: ktlintFormat + build 통과
- `:SClass-Api-Backoffice:test --tests com.sclass.backoffice.lesson.usecase.LessonScheduleUseCaseTest`
- `:SClass-Api-Supporters:test --tests com.sclass.supporters.lesson.usecase.CreateLessonScheduleUseCaseTest --tests com.sclass.supporters.lesson.usecase.UpdateLessonScheduleUseCaseTest --tests com.sclass.supporters.lesson.usecase.DeleteLessonScheduleUseCaseTest`
- `:SClass-Infrastructure:test --tests com.sclass.infrastructure.calendar.GoogleCalendarClientTest --tests com.sclass.infrastructure.calendar.CentralGoogleCalendarClientTest`
- 관련 모듈 ktlint check

Related #287